### PR TITLE
docs(config): document OpenCode restart after setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Add the plugin to `opencode.json`.
 }
 ```
 
+Restart OpenCode. Done.
+
 ### Configure
 
 Configure global defaults in `~/.config/opencode/magi.json` and project overrides in `<project>/.opencode/magi.json`.


### PR DESCRIPTION
Closes #1

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a README note to restart OpenCode after adding the opencode-magi plugin to `opencode.json`.

## Current behavior (updates)

The setup instructions show the plugin configuration and then move directly to configuration details.

## New behavior

The setup instructions explicitly tell users to restart OpenCode after adding the plugin.

## Is this a breaking change (Yes/No):

No

## Additional Information

Docs-only change; no tests were run.