### PR TITLE
ci(changesets): require changesets for README updates

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -39,11 +39,11 @@ jobs:
         run: |
           git fetch --no-tags --prune --depth=1 origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
 
-          changed_files="$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- src schema.json package.json)"
+          changed_files="$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- src schema.json package.json README.md)"
           changeset_files="$(git diff --name-only --diff-filter=A "origin/${{ github.base_ref }}...HEAD" -- ".changeset/*.md")"
 
           if [ -n "$changed_files" ] && [ -z "$changeset_files" ]; then
-            echo "A changeset is required for package code, prompt, schema, or package metadata changes."
+            echo "A changeset is required for package code, prompt, schema, package metadata, or README changes."
             echo "Changed files requiring a changeset:"
             echo "$changed_files"
             exit 1


### PR DESCRIPTION
Closes #5

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Require changesets when README.md changes by including README.md in the quality workflow changeset validation.

## Current behavior (updates)

The changeset validation job checks src, schema.json, and package.json changes, but README.md changes do not require a changeset.

## New behavior

README.md changes are included in the changeset-required path list, and the validation message mentions README changes.

## Is this a breaking change (Yes/No):

No

## Additional Information

Pre-commit format hook ran during commit. No runtime tests were run because this is a workflow-only change.