### PR TITLE
chore(github): add magi team code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+* @magi-ai/melchior @magi-ai/balthasar @magi-ai/caspar
+
 package.json @hirotomoyamada
 LICENSE @hirotomoyamada
 .github/ @hirotomoyamada


### PR DESCRIPTION
Closes #7

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds the Magi reviewer accounts as default CODEOWNERS for repository files.

## Current behavior (updates)

Repository files only have specific ownership entries for selected paths.

## New behavior

A wildcard CODEOWNERS rule requests `@magi-ai/melchior`, `@magi-ai/balthasar`, and `@magi-ai/caspar` by default.

## Is this a breaking change (Yes/No):

No

## Additional Information

CODEOWNERS-only change; no local tests were run.