### PR TITLE
fix(config): update repository URLs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "hirotomoyamada/opencode-magi"
+      "repo": "magi-ai/opencode-magi"
     }
   ],
   "commit": false,

--- a/.changeset/fuzzy-repos-cheer.md
+++ b/.changeset/fuzzy-repos-cheer.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Update repository URLs to match the current GitHub organization.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,8 +10,8 @@ body:
 
         Please search open/closed issues before submitting. Someone might have asked the same thing before 😎!
 
-          - [Issues](https://github.com/hirotomoyamada/opencode-magi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
-          - [Closed Issues](https://github.com/hirotomoyamada/opencode-magi/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed)
+          - [Issues](https://github.com/magi-ai/opencode-magi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
+          - [Closed Issues](https://github.com/magi-ai/opencode-magi/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed)
 
         We're all volunteers here, so please help us help you by taking the time to accurately fill out this template. 💖
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,8 +10,8 @@ body:
 
         Please search open/closed feature requests before submitting. Someone might have asked the same thing before 😎!
 
-          - [Issues](https://github.com/hirotomoyamada/opencode-magi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
-          - [Closed Issues](https://github.com/hirotomoyamada/opencode-magi/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed)
+          - [Issues](https://github.com/magi-ai/opencode-magi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
+          - [Closed Issues](https://github.com/magi-ai/opencode-magi/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed)
   - type: textarea
     id: "description"
     attributes:

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/hirotomoyamada/opencode-magi/main/schema.json",
+  "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
   "language": "en",
   "github": {
     "owner": "magi-ai",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ When it comes to open source, there are different ways you can contribute, all o
 
 The following steps will get you up and running to contribute to OpenCode Magi:
 
-1. Fork the [repository](https://github.com/hirotomoyamada/opencode-magi).
+1. Fork the [repository](https://github.com/magi-ai/opencode-magi).
 
 2. Clone your fork locally.
 
@@ -64,7 +64,7 @@ AI-assisted contributions remain the responsibility of the human submitter. Plea
 
 ## Think you found a bug?
 
-Please use the [bug report template](https://github.com/hirotomoyamada/opencode-magi/issues/new/choose) and provide a clear path to reproduction.
+Please use the [bug report template](https://github.com/magi-ai/opencode-magi/issues/new/choose) and provide a clear path to reproduction.
 
 Useful bug reports usually include:
 
@@ -77,7 +77,7 @@ Useful bug reports usually include:
 
 ## Proposing a new feature or changed behavior?
 
-Please use the [feature request template](https://github.com/hirotomoyamada/opencode-magi/issues/new/choose) and explain the problem you want to solve.
+Please use the [feature request template](https://github.com/magi-ai/opencode-magi/issues/new/choose) and explain the problem you want to solve.
 
 For new or changed APIs, configuration options, commands, prompts, or automation behavior, include thoughtful comments and sample usage. Proposals that are unclear, too broad, or not aligned with the project goals may be closed.
 
@@ -122,7 +122,7 @@ build: update release workflow
 
 ### Steps to PR
 
-1. Fork and clone the [repository](https://github.com/hirotomoyamada/opencode-magi).
+1. Fork and clone the [repository](https://github.com/magi-ai/opencode-magi).
 
 2. Create a new branch out of the `main` branch. Use the format `<type>/<description>`, where `type` is one of the conventional commit types and `description` is a short kebab-case summary.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add the following content to the configuration file.
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/hirotomoyamada/opencode-magi/main/schema.json",
+  "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
   "agents": {
     "reviewers": [
       {
@@ -96,7 +96,7 @@ Add the following content to the configuration file.
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/hirotomoyamada/opencode-magi/main/schema.json",
+  "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
   "github": {
     "owner": "your-owner",
     "repo": "your-repo"

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,7 +24,7 @@ If at least one config exists, Magi validates the merged effective config and re
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/hirotomoyamada/opencode-magi/main/schema.json",
+  "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
   "agents": {
     "reviewers": [
       {
@@ -62,7 +62,7 @@ If at least one config exists, Magi validates the merged effective config and re
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/hirotomoyamada/opencode-magi/main/schema.json",
+  "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
   "github": {
     "host": "github.com",
     "owner": "yamada-ui",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "author": "Hirotomo Yamada <hirotomo.yamada@avap.co.jp>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hirotomoyamada/opencode-magi"
+    "url": "https://github.com/magi-ai/opencode-magi"
   },
   "bugs": {
-    "url": "https://github.com/hirotomoyamada/opencode-magi/issues"
+    "url": "https://github.com/magi-ai/opencode-magi/issues"
   },
   "keywords": [
     "opencode",


### PR DESCRIPTION
Closes #12

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update stale repository references from hirotomoyamada/opencode-magi to magi-ai/opencode-magi.

## Current behavior (updates)

Changesets changelog generation and documentation links still reference the previous repository owner. The release workflow can fail when GitHub cannot resolve that repository.

## New behavior

Changesets, package metadata, issue templates, docs, README examples, and the project Magi config point to magi-ai/opencode-magi.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification:

- `gh repo view magi-ai/opencode-magi --json nameWithOwner,url,visibility`
- `node -e "JSON.parse(require('fs').readFileSync('.changeset/config.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('.opencode/magi.json','utf8'))"`
- `git diff --check`