### PR TITLE
chore(config): capitalize reviewer ids

### DIFF
--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -8,17 +8,17 @@
   "agents": {
     "reviewers": [
       {
-        "id": "melchior",
+        "id": "Melchior",
         "account": "melchior-magi",
         "model": "openai/gpt-5.5"
       },
       {
-        "id": "balthasar",
+        "id": "Balthasar",
         "account": "balthasar-magi",
         "model": "opencode/deepseek-v4-flash-free"
       },
       {
-        "id": "caspar",
+        "id": "Caspar",
         "account": "caspar-magi",
         "model": "opencode/qwen3.6-plus-free"
       }


### PR DESCRIPTION
Closes #19

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Capitalizes the MAGI reviewer IDs in the project OpenCode configuration.

## Current behavior (updates)

Reviewer IDs are configured as lowercase values: `melchior`, `balthasar`, and `caspar`.

## New behavior

Reviewer IDs use the official capitalized names: `Melchior`, `Balthasar`, and `Caspar`.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tests were not run because this is a configuration-only change.