### PR TITLE
fix(github): avoid PR branch checkout conflicts

### DIFF
--- a/.changeset/detached-pr-worktrees.md
+++ b/.changeset/detached-pr-worktrees.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Avoid PR branch checkout conflicts when creating temporary worktrees.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { describe, expect, test } from "vitest"
 import {
   createWorktree,
+  fetchPullRequest,
   fetchPullRequestCommits,
   fetchPullRequestReviews,
   fetchPullRequestSafetyMeta,
@@ -84,7 +85,7 @@ describe("GitHub command helpers", () => {
     expect(ghHostOption(enterprise)).toBe(" --hostname 'github.example.com'")
   })
 
-  test("pushes detached HEAD to the PR head branch", async () => {
+  test("pushes detached HEAD to the PR head repository", async () => {
     const commands: string[] = []
 
     await pushHead(
@@ -97,13 +98,41 @@ describe("GitHub command helpers", () => {
       repository,
       "/tmp/worktree",
       "editor-bot",
-      "feature-branch",
+      { owner: "fork-owner", ref: "feature-branch", repo: "fork-repo" },
     )
 
     expect(commands[1]).toContain(
-      "push origin 'HEAD:refs/heads/feature-branch'",
+      "push 'https://github.com/fork-owner/fork-repo.git' 'HEAD:refs/heads/feature-branch'",
     )
     expect(commands[1]).toContain("credential.helper")
+  })
+
+  test("fetches PR head repository metadata", async () => {
+    let command = ""
+    const result = await fetchPullRequest(
+      async (value) => {
+        command = value
+
+        return JSON.stringify({
+          baseRefName: "main",
+          baseRefOid: "base-sha",
+          headRefName: "feature-branch",
+          headRefOid: "head-sha",
+          headRepository: { name: "fork-repo" },
+          headRepositoryOwner: { login: "fork-owner" },
+          isDraft: false,
+          number: 1,
+          title: "PR title",
+          url: "https://github.com/owner/repo/pull/1",
+        })
+      },
+      repository,
+      1,
+    )
+
+    expect(command).toContain("headRepository,headRepositoryOwner")
+    expect(result.headRepository?.name).toBe("fork-repo")
+    expect(result.headRepositoryOwner?.login).toBe("fork-owner")
   })
 
   test("posts close comments as PR review comments", async () => {

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -11,6 +11,7 @@ import {
   fetchUnresolvedThreads,
   ghHostOption,
   postCloseComment,
+  pushHead,
   repoSpecifier,
   shellQuote,
   waitForChecks,
@@ -81,6 +82,28 @@ describe("GitHub command helpers", () => {
     expect(ghHostOption(repository)).toBe("")
     expect(repoSpecifier(enterprise)).toBe("github.example.com/owner/repo")
     expect(ghHostOption(enterprise)).toBe(" --hostname 'github.example.com'")
+  })
+
+  test("pushes detached HEAD to the PR head branch", async () => {
+    const commands: string[] = []
+
+    await pushHead(
+      async (command) => {
+        commands.push(command)
+        if (command.includes("gh auth token")) return "token"
+
+        return ""
+      },
+      repository,
+      "/tmp/worktree",
+      "editor-bot",
+      "feature-branch",
+    )
+
+    expect(commands[1]).toContain(
+      "push origin 'HEAD:refs/heads/feature-branch'",
+    )
+    expect(commands[1]).toContain("credential.helper")
   })
 
   test("posts close comments as PR review comments", async () => {
@@ -359,6 +382,32 @@ describe("GitHub command helpers", () => {
 })
 
 describe("createWorktree", () => {
+  test("checks out pull requests without binding the head branch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "magi-worktrees-"))
+    const commands: string[] = []
+
+    try {
+      const result = await createWorktree(
+        async (command) => {
+          commands.push(command)
+          if (command === "git branch --show-current") return "\n"
+
+          return ""
+        },
+        repository,
+        1,
+        root,
+      )
+
+      expect(result.branch).toBeUndefined()
+      expect(commands).toContain(
+        "gh pr checkout 1 --repo 'owner/repo' --detach",
+      )
+    } finally {
+      await removePath(root, { force: true, recursive: true })
+    }
+  })
+
   test("serializes worktree creation for the same repository root", async () => {
     const root = await mkdtemp(join(tmpdir(), "magi-worktrees-"))
     const commands: string[] = []

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -169,7 +169,7 @@ async function checkoutPullRequestWithRetry(
   for (let attempt = 0; ; attempt += 1) {
     try {
       await exec(
-        `gh pr checkout ${pr} --repo ${shellQuote(repoSpecifier(repository))}`,
+        `gh pr checkout ${pr} --repo ${shellQuote(repoSpecifier(repository))} --detach`,
         {
           cwd: worktreePath,
         },
@@ -719,11 +719,12 @@ export async function pushHead(
   repository: ResolvedRepository,
   worktreePath: string,
   account: string,
+  headRefName: string,
 ): Promise<void> {
   const token = await ghToken(exec, repository, account)
 
   await exec(
-    `git -c credential.helper= -c credential.helper=${shellQuote(`!f() { echo username=x-access-token; echo password=${token}; }; f`)} push origin HEAD`,
+    `git -c credential.helper= -c credential.helper=${shellQuote(`!f() { echo username=x-access-token; echo password=${token}; }; f`)} push origin ${shellQuote(`HEAD:refs/heads/${headRefName}`)}`,
     { cwd: worktreePath },
   )
 }

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -6,6 +6,8 @@ import { dirname, join } from "node:path"
 export interface PullRequestMeta {
   baseRefName: string
   baseRefOid: string
+  headRepository?: { name?: string }
+  headRepositoryOwner?: { login?: string }
   headRefName: string
   headRefOid: string
   isDraft: boolean
@@ -208,6 +210,14 @@ export function repoSpecifier(repository: ResolvedRepository): string {
     : `${host}/${repoSlug(repository)}`
 }
 
+function repositoryGitUrl(
+  repository: ResolvedRepository,
+  owner: string,
+  repo: string,
+): string {
+  return `https://${githubHost(repository)}/${owner}/${repo}.git`
+}
+
 export function ghHostOption(repository: ResolvedRepository): string {
   const host = githubHost(repository)
 
@@ -232,7 +242,7 @@ export async function fetchPullRequest(
   pr: number,
 ): Promise<PullRequestMeta> {
   const json = await exec(
-    `gh pr view ${pr} --repo ${shellQuote(repoSpecifier(repository))} --json number,title,url,isDraft,baseRefOid,headRefOid,baseRefName,headRefName`,
+    `gh pr view ${pr} --repo ${shellQuote(repoSpecifier(repository))} --json number,title,url,isDraft,baseRefOid,headRefOid,baseRefName,headRefName,headRepository,headRepositoryOwner`,
   )
 
   return JSON.parse(json) as PullRequestMeta
@@ -719,12 +729,13 @@ export async function pushHead(
   repository: ResolvedRepository,
   worktreePath: string,
   account: string,
-  headRefName: string,
+  head: { owner: string; ref: string; repo: string },
 ): Promise<void> {
   const token = await ghToken(exec, repository, account)
+  const url = repositoryGitUrl(repository, head.owner, head.repo)
 
   await exec(
-    `git -c credential.helper= -c credential.helper=${shellQuote(`!f() { echo username=x-access-token; echo password=${token}; }; f`)} push origin ${shellQuote(`HEAD:refs/heads/${headRefName}`)}`,
+    `git -c credential.helper= -c credential.helper=${shellQuote(`!f() { echo username=x-access-token; echo password=${token}; }; f`)} push ${shellQuote(url)} ${shellQuote(`HEAD:refs/heads/${head.ref}`)}`,
     { cwd: worktreePath },
   )
 }

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -240,12 +240,19 @@ async function runEditor(
         input.repository,
         input.pr,
       )
+      const headOwner = meta.headRepositoryOwner?.login
+      const headRepo = meta.headRepository?.name
+
+      if (!headOwner || !headRepo) {
+        throw new Error("Pull request head repository is missing")
+      }
+
       await pushHead(
         input.exec,
         input.repository,
         worktreePath,
         editor.account,
-        meta.headRefName,
+        { owner: headOwner, ref: meta.headRefName, repo: headRepo },
       )
     }
   }

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -235,7 +235,18 @@ async function runEditor(
 
   if (!input.dryRun) {
     if (result.value.mode === "EDITED") {
-      await pushHead(input.exec, input.repository, worktreePath, editor.account)
+      const meta = await fetchPullRequest(
+        input.exec,
+        input.repository,
+        input.pr,
+      )
+      await pushHead(
+        input.exec,
+        input.repository,
+        worktreePath,
+        editor.account,
+        meta.headRefName,
+      )
     }
   }
 


### PR DESCRIPTION
Closes #18

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use detached PR checkouts for temporary Magi worktrees so reviews do not fail when the PR head branch is already checked out elsewhere. When the editor pushes changes during `/magi:merge`, push detached HEAD explicitly to the PR head branch.

## Current behavior (updates)

Magi runs `gh pr checkout` in its temporary worktree, which checks out the PR head branch. Git rejects that if the same branch is already checked out in another worktree.

## New behavior

Magi runs `gh pr checkout --detach` for temporary PR worktrees and pushes editor commits with an explicit `HEAD:refs/heads/<headRefName>` refspec.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm test src/github/commands.test.ts`.