### PR TITLE
ci(changesets): use PAT token for release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           setupGitUser: false
         env:
           NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 
       - name: Create @dev release
         if: steps.changesets.outputs.published != 'true'


### PR DESCRIPTION
Closes #23

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use the configured PAT_TOKEN when the Changesets action creates or updates release pull requests.

## Current behavior (updates)

Release pull requests are created with the default GitHub Actions token. GitHub suppresses pull_request workflow runs caused by that token, so release PRs can appear without Quality checks.

## New behavior

Release pull requests are created with PAT_TOKEN through the Changesets action's GITHUB_TOKEN environment variable, allowing the Quality workflow to run on release PR events.

## Is this a breaking change (Yes/No):

No

## Additional Information

Commit hooks ran format during commit. No local tests were run because this is a workflow secret reference change.
