### PR TITLE
feat(config)!: restructure review and merge config

### DIFF
--- a/.changeset/new-config-shape.md
+++ b/.changeset/new-config-shape.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": major
+---
+
+Restructure Magi configuration around review and merge sections.

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -5,8 +5,8 @@
     "owner": "magi-ai",
     "repo": "opencode-magi"
   },
-  "agents": {
-    "reviewers": [
+  "review": {
+    "agents": [
       {
         "id": "Melchior",
         "account": "melchior-magi",
@@ -23,6 +23,14 @@
         "model": "opencode/qwen3.6-plus-free"
       }
     ],
+    "merge": {
+      "queue": true
+    },
+    "prompts": {
+      "reviewGuidelines": ".agents/references/pr-review-guidelines.md"
+    }
+  },
+  "merge": {
     "editor": {
       "account": "hirotomoyamada",
       "model": "openai/gpt-5.5",
@@ -31,11 +39,5 @@
         "email": "hirotomo.yamada@avap.co.jp"
       }
     }
-  },
-  "merge": {
-    "mergeQueue": true
-  },
-  "prompts": {
-    "reviewGuidelines": ".agents/references/pr-review-guidelines.md"
   }
 }

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Add the following content to the configuration file.
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
-  "agents": {
-    "reviewers": [
+  "review": {
+    "agents": [
       {
         "account": "your-account-1",
         "model": "openai/gpt-5.5"
@@ -80,7 +80,7 @@ Add the following content to the configuration file.
 }
 ```
 
-`agents.reviewers[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique.
+`review.agents[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique.
 
 #### Set project config
 
@@ -101,8 +101,8 @@ Add the following content to the configuration file.
     "owner": "your-owner",
     "repo": "your-repo"
   },
-  "agents": {
-    "reviewers": [
+  "review": {
+    "agents": [
       {
         "account": "your-account-1",
         "model": "openai/gpt-5.5"
@@ -115,7 +115,9 @@ Add the following content to the configuration file.
         "account": "your-account-3",
         "model": "opencode/kimi-k2-6"
       }
-    ],
+    ]
+  },
+  "merge": {
     "editor": {
       "account": "your-editor-account",
       "model": "openai/gpt-5.5",
@@ -128,7 +130,7 @@ Add the following content to the configuration file.
 }
 ```
 
-`agents.reviewers[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique.
+`review.agents[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique. `merge.editor.account` is used by `/magi:merge` to push fixes, close PRs, and merge PRs.
 
 #### Validate config
 

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -19,41 +19,41 @@ During a single merge flow, Magi reuses reviewer OpenCode sessions from the init
 
 ## Flow
 
-1. Stop before agent execution when `safety.*` gates block the PR.
+1. Stop before agent execution when `review.safety.*` gates block the PR.
 2. Run the full [`/magi:review`](review.md) flow.
 3. If every configured reviewer already reviewed the current effective head, reuse those existing verdicts instead of aborting.
-4. If the review decision is `CLOSE`, close the PR when `automation.close` is enabled and stop. Dry runs stop before closing.
-5. If the review decision is `MERGE`, merge the PR when `automation.merge` is enabled and stop. Dry runs stop before merging.
+4. If the review decision is `CLOSE`, close the PR when `merge.automation.close` is enabled and stop. Dry runs stop before closing.
+5. If the review decision is `MERGE`, merge the PR when `merge.automation.merge` is enabled and stop. Dry runs stop before merging.
 6. If the review majority is `CHANGES_REQUESTED`, start edit and re-review cycles.
 7. Fetch unresolved review threads, or use synthetic dry-run threads from reviewer findings.
 8. Run the editor agent with the edit prompt.
 9. Parse editor output as the fixed edit JSON schema.
 10. Push the editor commit to the PR branch with the editor account when the editor made code changes, unless `--dry-run` is set.
 11. Post editor replies to the review comments listed in the editor output, unless `--dry-run` is set.
-12. Wait for PR checks again when the editor made code changes and `checks.waitAfterEdit` is enabled. Dry runs skip post-edit CI because changes are not pushed.
+12. Wait for PR checks again when the editor made code changes and `merge.checks.wait` is enabled. Dry runs skip post-edit CI because changes are not pushed.
 13. Classify failed job logs as `SCOPE_IN` or `SCOPE_OUT`; rerun only `SCOPE_OUT` GitHub Actions jobs and pass `SCOPE_IN` failure context to re-reviewers.
 14. Fetch each reviewer's unresolved threads, or use synthetic dry-run threads from reviewer findings.
 15. Run every reviewer agent with the re-review prompt.
 16. Parse each re-review response as the fixed re-review JSON schema.
 17. Resolve threads, post follow-up replies, post new findings, post close comments, or approve according to each reviewer output, unless `--dry-run` is set.
-18. Aggregate re-review verdicts and apply `merge.approvalPolicy`.
-19. If the re-review decision is `MERGE`, merge the PR when `automation.merge` is enabled and stop. Dry runs stop before merging.
-20. If the re-review decision is `CLOSE`, close the PR when `automation.close` is enabled and stop. Dry runs stop before closing.
+18. Aggregate re-review verdicts and apply `review.merge.approvalPolicy`.
+19. If the re-review decision is `MERGE`, merge the PR when `merge.automation.merge` is enabled and stop. Dry runs stop before merging.
+20. If the re-review decision is `CLOSE`, close the PR when `merge.automation.close` is enabled and stop. Dry runs stop before closing.
 21. Repeat while at least one unresolved review thread still has remaining resolution attempts.
 22. If only exhausted unresolved threads remain, return `changes_unresolved` and leave the PR open.
 23. Remove the temporary worktree when the merge flow completes.
 
 Merge outcomes:
 
-| Status               | Meaning                                                                                                              |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `merged`             | The PR reached `MERGE` and `gh pr merge` completed successfully.                                                     |
-| `approved`           | The PR reached `MERGE`, approvals were posted, and `automation.merge` disabled the merge step.                       |
-| `closed`             | A review or re-review majority was `CLOSE` and Magi ran `gh pr close`.                                               |
-| `close_requested`    | A review or re-review decision was `CLOSE`, comments were posted, and `automation.close` disabled the close step.    |
-| `dequeued`           | With `merge.mergeQueue: true`, GitHub removed the PR from auto-merge or the merge queue.                             |
-| `changes_unresolved` | Unresolved review threads reached the per-thread `merge.maxThreadResolutionCycles` limit without a `MERGE` majority. |
-| `ci_unresolved`      | Review and approvals completed, but scope-outside CI remained unresolved so Magi did not merge.                      |
+| Status               | Meaning                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `merged`             | The PR reached `MERGE` and `gh pr merge` completed successfully.                                                        |
+| `approved`           | The PR reached `MERGE`, approvals were posted, and `merge.automation.merge` disabled the merge step.                    |
+| `closed`             | A review or re-review majority was `CLOSE` and Magi ran `gh pr close`.                                                  |
+| `close_requested`    | A review or re-review decision was `CLOSE`, comments were posted, and `merge.automation.close` disabled the close step. |
+| `dequeued`           | With `review.merge.queue: true`, GitHub removed the PR from auto-merge or the merge queue.                              |
+| `changes_unresolved` | Unresolved review threads reached the per-thread `merge.maxThreadResolutionCycles` limit without a `MERGE` majority.    |
+| `ci_unresolved`      | Review and approvals completed, but scope-outside CI remained unresolved so Magi did not merge.                         |
 
 ## Outputs
 
@@ -79,40 +79,40 @@ Important settings for `/magi:merge`:
 
 | Setting                           | Purpose                                                            |
 | --------------------------------- | ------------------------------------------------------------------ |
-| `agents.editor`                   | Editor agent, model, persona, permissions, GitHub account, author. |
-| `agents.reviewers`                | Reviewer agents used for initial review and re-review.             |
-| `automation.close`                | Run `gh pr close` after a close decision.                          |
-| `automation.merge`                | Run `gh pr merge` after approval.                                  |
-| `checks.waitAfterEdit`            | Wait for PR checks after editor changes.                           |
-| `merge.approvalPolicy`            | Decide readiness by `majority` or `unanimous`.                     |
-| `merge.auto`                      | Pass `--auto` to `gh pr merge`.                                    |
-| `merge.deleteBranch`              | Delete the PR branch during merge when configured.                 |
+| `merge.editor`                    | Editor agent, model, persona, permissions, GitHub account, author. |
+| `review.agents`                   | Reviewer agents used for initial review and re-review.             |
+| `merge.automation.close`          | Run `gh pr close` after a close decision.                          |
+| `merge.automation.merge`          | Run `gh pr merge` after approval.                                  |
+| `merge.checks.wait`               | Wait for PR checks after editor changes.                           |
+| `review.merge.approvalPolicy`     | Decide readiness by `majority` or `unanimous`.                     |
+| `review.merge.auto`               | Pass `--auto` to `gh pr merge`.                                    |
+| `review.merge.deleteBranch`       | Delete the PR branch during merge when configured.                 |
 | `merge.maxThreadResolutionCycles` | Maximum fix/reply attempts per unresolved review thread.           |
-| `merge.mergeQueue`                | Poll GitHub merge queue completion after `gh pr merge`.            |
-| `merge.method`                    | Merge method: `merge`, `squash`, or `rebase`.                      |
-| `prompts.edit*`                   | Editor prompt templates and guidelines.                            |
-| `prompts.rereview*`               | Re-review prompt templates and guidelines.                         |
-| `safety.*`                        | Optional gates that block merge before agents run.                 |
+| `review.merge.queue`              | Poll GitHub merge queue completion after `gh pr merge`.            |
+| `review.merge.method`             | Merge method: `merge`, `squash`, or `rebase`.                      |
+| `merge.prompts.edit*`             | Editor prompt templates and guidelines.                            |
+| `review.prompts.rereview`         | Re-review prompt template.                                         |
+| `review.safety.*`                 | Optional gates that block merge before agents run.                 |
 
 See [Config](/docs/config.md) for the complete configuration reference.
 
 ## FAQ
 
-### What happens when `automation.merge` is false?
+### What happens when `merge.automation.merge` is false?
 
 Magi posts approvals and stops with `approved`. It does not run `gh pr merge`.
 
-### What happens when `automation.close` is false?
+### What happens when `merge.automation.close` is false?
 
 Magi posts close comments and stops with `close_requested`. It leaves the PR open.
 
 ### How does merge queue support work?
 
-`merge.auto` controls whether Magi passes `--auto` to `gh pr merge`. `merge.mergeQueue` controls whether Magi polls GitHub after the merge command to wait for merge queue completion. These settings are independent.
+`review.merge.auto` controls whether Magi passes `--auto` to `gh pr merge`. `review.merge.queue` controls whether Magi polls GitHub after the merge command to wait for merge queue completion. These settings are independent.
 
-When `merge.mergeQueue` is `true`, Magi also checks the base branch rules for a `merge_queue` rule. If GitHub reports that merge queue is not enabled, or Magi cannot verify it, the run records a warning.
+When `review.merge.queue` is `true`, Magi also checks the base branch rules for a `merge_queue` rule. If GitHub reports that merge queue is not enabled, or Magi cannot verify it, the run records a warning.
 
-### What does `merge.approvalPolicy: unanimous` change?
+### What does `review.merge.approvalPolicy: unanimous` change?
 
 `MERGE` requires every reviewer to approve. A `CLOSE` majority still closes or requests close. A close minority is sent back to the close reviewer for reconsideration; if any reviewer remains non-approving after reconsideration, Magi continues as `CHANGES_REQUESTED`.
 
@@ -126,7 +126,7 @@ Scope-outside unresolved jobs do not stop review, editing, re-review, or approva
 
 ### Which GitHub account pushes and merges?
 
-The editor account configured at `agents.editor.account` posts fixes, pushes commits, closes PRs, and merges PRs. It must be authenticated with GitHub CLI and able to push to the repository.
+The editor account configured at `merge.editor.account` posts fixes, pushes commits, closes PRs, and merges PRs. It must be authenticated with GitHub CLI and able to push to the repository.
 
 ### Can child agents request permissions?
 

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -21,13 +21,13 @@ It skips reviewer accounts that already reviewed the current effective head. If 
 
 1. Fetch PR metadata with `gh pr view`.
 2. Abort if the PR is a draft.
-3. Stop before agent execution when `safety.*` gates block the PR.
-4. Fetch existing PR reviews for configured `agents.reviewers[].account` values.
+3. Stop before agent execution when `review.safety.*` gates block the PR.
+4. Fetch existing PR reviews for configured `review.agents[].account` values.
 5. Determine review freshness against the latest non-merge PR commit.
 6. Skip current reviewers, use re-review mode for stale reviewers, and use initial review mode for reviewers with no prior review.
-7. Wait for PR checks when `checks.waitBeforeReview` is enabled.
-8. If checks fail, remove checks matching `checks.exclude`, fetch failed job logs, classify each remaining failure as `SCOPE_IN` or `SCOPE_OUT`, rerun only `SCOPE_OUT` GitHub Actions jobs up to `checks.retryFailedJobs`, and pass `SCOPE_IN` failure context to reviewers. Dry runs skip the rerun and report it as a planned action.
-9. Create a detached git worktree under `worktree.dirs.pr` and check out the PR branch.
+7. Wait for PR checks when `review.checks.wait` is enabled.
+8. If checks fail, remove checks matching `review.checks.exclude`, fetch failed job logs, classify each remaining failure as `SCOPE_IN` or `SCOPE_OUT`, rerun only `SCOPE_OUT` GitHub Actions jobs up to `review.checks.retryFailedJobs`, and pass `SCOPE_IN` failure context to reviewers. Dry runs skip the rerun and report it as a planned action.
+9. Create a detached git worktree under `review.worktree` and check out the PR branch.
 10. Run each non-skipped reviewer agent through the reviewer worker pool.
 11. Parse each reviewer response as the fixed review or re-review JSON schema.
 12. Validate each `CHANGES_REQUESTED` finding by asking the other reviewers to vote on it.
@@ -35,15 +35,16 @@ It skips reviewer accounts that already reviewed the current effective head. If 
 14. Reconsider any minority `CLOSE` verdict before posting.
 15. Aggregate active reviewer verdicts plus skipped reviewer verdicts from existing GitHub review state by majority vote.
 16. Post each active reviewer result to GitHub with that reviewer's configured account, unless `--dry-run` is set.
-17. Remove the temporary worktree and recorded worktree branch.
+17. If configured, merge or close the PR according to `review.automation`.
+18. Remove the temporary worktree and recorded worktree branch.
 
 Reviewer verdicts map to GitHub actions:
 
-| Verdict             | GitHub action                                                              |
-| ------------------- | -------------------------------------------------------------------------- |
-| `MERGE`             | Post an approving PR review.                                               |
-| `CHANGES_REQUESTED` | Post a request-changes PR review with inline comments from `findings`.     |
-| `CLOSE`             | Post a PR comment with `reason`. The review command does not close the PR. |
+| Verdict             | GitHub action                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `MERGE`             | Post an approving PR review.                                                                                      |
+| `CHANGES_REQUESTED` | Post a request-changes PR review with inline comments from `findings`.                                            |
+| `CLOSE`             | Post a PR comment with `reason`. The review command closes the PR only when `review.automation.close` is enabled. |
 
 The majority result can be `MERGE`, `CHANGES_REQUESTED`, or `CLOSE`. Reviewer count must be odd and at least 3, so one verdict must reach majority.
 
@@ -68,20 +69,20 @@ Review artifacts are written to the run output directory:
 
 Important settings for `/magi:review`:
 
-| Setting                   | Purpose                                                       |
-| ------------------------- | ------------------------------------------------------------- |
-| `agents.reviewers`        | Reviewer agents, models, personas, permissions, and accounts. |
-| `checks.waitBeforeReview` | Wait for PR checks before review.                             |
-| `checks.exclude`          | Ignore matching failed checks.                                |
-| `checks.retryFailedJobs`  | Retry scope-outside GitHub Actions jobs.                      |
-| `concurrency.reviewers`   | Maximum reviewer agents running at once.                      |
-| `concurrency.runs`        | Maximum PR runs processed at once.                            |
-| `github.apiRetryAttempts` | Retry count for GitHub CLI API rate limit errors.             |
-| `output.dirs.pr`          | PR run output directory.                                      |
-| `output.repairAttempts`   | Model output repair attempts.                                 |
-| `prompts.review*`         | Review prompt templates and guidelines.                       |
-| `safety.*`                | Optional gates that block review before agents run.           |
-| `worktree.dirs.pr`        | Temporary PR worktree base directory.                         |
+| Setting                         | Purpose                                                       |
+| ------------------------------- | ------------------------------------------------------------- |
+| `review.agents`                 | Reviewer agents, models, personas, permissions, and accounts. |
+| `review.checks.wait`            | Wait for PR checks before review.                             |
+| `review.checks.exclude`         | Ignore matching failed checks.                                |
+| `review.checks.retryFailedJobs` | Retry scope-outside GitHub Actions jobs.                      |
+| `review.concurrency.reviewers`  | Maximum reviewer agents running at once.                      |
+| `review.concurrency.runs`       | Maximum PR runs processed at once.                            |
+| `github.apiRetryAttempts`       | Retry count for GitHub CLI API rate limit errors.             |
+| `review.output`                 | PR run output directory.                                      |
+| `output.repairAttempts`         | Model output repair attempts.                                 |
+| `review.prompts.*`              | Review prompt templates and guidelines.                       |
+| `review.safety.*`               | Optional gates that block review before agents run.           |
+| `review.worktree`               | Temporary PR worktree base directory.                         |
 
 See [Config](/docs/config.md) for the complete configuration reference.
 
@@ -109,4 +110,4 @@ Magi currently queries reviews first 100, commits first 100, review threads firs
 
 ### Which GitHub accounts are used?
 
-Each reviewer posts with its configured `agents.reviewers[].account`. Each account must be authenticated with GitHub CLI and able to read the repository and post PR reviews or comments.
+Each reviewer posts with its configured `review.agents[].account`. Each account must be authenticated with GitHub CLI and able to read the repository and post PR reviews or comments. Review automation uses the first configured reviewer account for PR merge or close actions.

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -18,7 +18,7 @@ It is safe to run after creating or updating `~/.config/opencode/magi.json` or `
 2. Read the project config at `<project>/.opencode/magi.json`.
 3. Report whether each config file is found, missing, or invalid JSON.
 4. Merge existing configs, with project config overriding global config.
-5. Validate known keys, value types, reviewer count, reviewer IDs, duplicate accounts, model IDs, prompts, output settings, worktree settings, check settings, merge settings, automation settings, and clear settings.
+5. Validate known keys, value types, reviewer count, reviewer IDs, duplicate accounts, model IDs, prompts, output settings, worktree settings, check settings, review settings, merge settings, automation settings, and clear settings.
 6. Require `github.owner` and `github.repo` when a project config exists.
 7. Verify GitHub CLI authentication for configured reviewer and editor accounts.
 8. Verify repository permissions when GitHub authentication succeeds.
@@ -42,15 +42,16 @@ It does not modify files, create runs, post to GitHub, or start agents.
 
 `/magi:validate` validates the same settings documented in [Config](/docs/config.md). The most important requirements are:
 
-| Setting                      | Requirement                                                 |
-| ---------------------------- | ----------------------------------------------------------- |
-| `agents.reviewers`           | Required for review/merge, at least 3 reviewers, odd count. |
-| `agents.reviewers[].model`   | Required full OpenCode model ID in `provider/model` form.   |
-| `agents.reviewers[].account` | Required GitHub account, unique across reviewers.           |
-| `agents.editor`              | Required by `/magi:merge`, optional for `/magi:review`.     |
-| `github.owner`               | Required for PR review/merge runs.                          |
-| `github.repo`                | Required for PR review/merge runs.                          |
-| `prompts.*`                  | Must point to readable files when configured.               |
+| Setting                   | Requirement                                                 |
+| ------------------------- | ----------------------------------------------------------- |
+| `review.agents`           | Required for review/merge, at least 3 reviewers, odd count. |
+| `review.agents[].model`   | Required full OpenCode model ID in `provider/model` form.   |
+| `review.agents[].account` | Required GitHub account, unique across reviewers.           |
+| `merge.editor`            | Required by `/magi:merge`, optional for `/magi:review`.     |
+| `github.owner`            | Required for PR review/merge runs.                          |
+| `github.repo`             | Required for PR review/merge runs.                          |
+| `review.prompts.*`        | Must point to readable files when configured.               |
+| `merge.prompts.*`         | Must point to readable files when configured.               |
 
 ## FAQ
 
@@ -72,4 +73,4 @@ Yes, after auth succeeds. Reviewer accounts must be able to read the repository.
 
 ### Why can validation pass without an editor?
 
-`agents.editor` is required when running `/magi:merge`, but not when running only `/magi:review`. `/magi:validate` validates general config by default; `/magi:merge` performs a stricter validation before starting.
+`merge.editor` is required when running `/magi:merge`, but not when running only `/magi:review`. `/magi:validate` validates general config by default; `/magi:merge` performs a stricter validation before starting.

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,7 @@ Config files are merged by OpenCode Magi, not by OpenCode. Priority, lowest to h
 1. `~/.config/opencode/magi.json` - global defaults.
 2. `<project>/.opencode/magi.json` - project overrides.
 
-Object values are deep merged. Array values are replaced, so setting `agents.reviewers` in the project config replaces the global reviewer list.
+Object values are deep merged. Array values are replaced, so setting `review.agents` in the project config replaces the global reviewer list.
 
 ## Validate
 
@@ -25,8 +25,8 @@ If at least one config exists, Magi validates the merged effective config and re
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
-  "agents": {
-    "reviewers": [
+  "review": {
+    "agents": [
       {
         "id": "general",
         "model": "openai/gpt-5.5",
@@ -45,15 +45,7 @@ If at least one config exists, Magi validates the merged effective config and re
         "account": "your-account-3",
         "persona": "Focus on backward compatibility."
       }
-    ],
-    "editor": {
-      "model": "openai/gpt-5.5",
-      "account": "your-editor-account",
-      "author": {
-        "name": "your-account",
-        "email": "your-email@example.com"
-      }
-    }
+    ]
   }
 }
 ```
@@ -69,167 +61,98 @@ If at least one config exists, Magi validates the merged effective config and re
     "repo": "yamada-ui"
   },
   "language": "ja",
-  "merge": {
-    "mergeQueue": true
+  "review": {
+    "merge": {
+      "queue": true
+    },
+    "prompts": {
+      "reviewGuidelines": ".agents/references/review-guidelines.md"
+    }
   },
-  "prompts": {
-    "reviewGuidelines": ".agents/references/review-guidelines.md",
-    "editGuidelines": ".agents/references/edit-guidelines.md"
+  "merge": {
+    "editor": {
+      "model": "openai/gpt-5.5",
+      "account": "your-editor-account",
+      "author": {
+        "name": "your-account",
+        "email": "your-email@example.com"
+      }
+    },
+    "prompts": {
+      "editGuidelines": ".agents/references/edit-guidelines.md"
+    }
   }
 }
 ```
 
-## Global Reference
+## Reference
 
-These keys usually belong in `~/.config/opencode/magi.json` because they are reusable defaults across projects.
-
-| Key                                    | Required             | Default                                                        | Description                                                                                                                                  |
-| -------------------------------------- | -------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agents`                               | Yes                  | -                                                              | Agent defaults. Project config can override this object or replace `agents.reviewers`.                                                       |
-| `agents.permissions`                   | No                   | [json](/src/permissions/common.json)                           | Common OpenCode permission rules applied to all Magi child agents before per-agent overrides.                                                |
-| `agents.reviewers`                     | Yes (`review/merge`) | -                                                              | Odd-length array of at least 3 reviewers.                                                                                                    |
-| `agents.reviewers[].id`                | No                   | `reviewer-1`, `reviewer-2`, ...                                | Reviewer key used for run state, output files, and session tracking.                                                                         |
-| `agents.reviewers[].model`             | Yes                  | -                                                              | Full OpenCode model ID used by the reviewer, in `provider/model` form. Use `opencode/gpt-...` and `openai/gpt-...` to distinguish providers. |
-| `agents.reviewers[].account`           | Yes                  | -                                                              | GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>`.                              |
-| `agents.reviewers[].options`           | No                   | -                                                              | OpenCode provider/model options injected for this reviewer, such as `reasoningEffort`, `textVerbosity`, or Anthropic `thinking`.             |
-| `agents.reviewers[].permission`        | No                   | -                                                              | OpenCode permission overrides for this reviewer. Also used by this reviewer's CI classifier sessions.                                        |
-| `agents.reviewers[].persona`           | No                   | -                                                              | Reviewer-specific additional perspective.                                                                                                    |
-| `agents.editor`                        | No                   | -                                                              | Editor used by `/magi:merge`. Required only when running `/magi:merge`.                                                                      |
-| `agents.editor.model`                  | Yes (`/magi:merge`)  | -                                                              | Full OpenCode model ID used by the editor when `agents.editor` is configured.                                                                |
-| `agents.editor.account`                | Yes (`/magi:merge`)  | -                                                              | GitHub account used for editor commits, replies, pushes, and merge operations.                                                               |
-| `agents.editor.author.name`            | Yes (`/magi:merge`)  | -                                                              | Git commit author name configured in the temporary worktree before editor commits.                                                           |
-| `agents.editor.author.email`           | Yes (`/magi:merge`)  | -                                                              | Git commit author email configured in the temporary worktree before editor commits.                                                          |
-| `agents.editor.options`                | No                   | -                                                              | OpenCode provider/model options injected for the editor.                                                                                     |
-| `agents.editor.permission`             | No                   | [json](/src/permissions/editor.json)                           | OpenCode permission overrides for the editor. Defaults allow editing and local commit creation, but not pushing.                             |
-| `agents.editor.persona`                | No                   | -                                                              | Editor-specific additional instructions.                                                                                                     |
-| `automation`                           | No                   | -                                                              | Runtime automation switches. Project config can override global defaults.                                                                    |
-| `automation.merge`                     | No                   | `true`                                                         | Whether `/magi:merge` runs `gh pr merge` after reviewers approve. If false, Magi stops after approvals are posted.                           |
-| `automation.close`                     | No                   | `true`                                                         | Whether `/magi:merge` runs `gh pr close` after a close decision. If false, Magi leaves the PR open after close comments are posted.          |
-| `clear`                                | No                   | -                                                              | Cleanup defaults for `/magi:clear`. Project config can override global defaults.                                                             |
-| `clear.output`                         | No                   | `true`                                                         | Delete inactive run output directories under `output.dirs`.                                                                                  |
-| `clear.worktree`                       | No                   | `true`                                                         | Remove inactive run worktrees with `git worktree remove`, prune worktrees, and delete remaining worktree folders.                            |
-| `clear.session`                        | No                   | `true`                                                         | Delete OpenCode child sessions created for inactive Magi runs.                                                                               |
-| `clear.branch`                         | No                   | `true`                                                         | Delete the branch recorded when Magi created the worktree. Older runs without a recorded branch are skipped.                                 |
-| `checks`                               | No                   | -                                                              | Check handling defaults. Project config can override global defaults.                                                                        |
-| `checks.exclude`                       | No                   | `[]`                                                           | Check names to exclude from failure classification and CI merge blocking. Exact strings and `/regex/` patterns are supported.                |
-| `checks.waitBeforeReview`              | No                   | `true`                                                         | Whether to wait for PR checks before review.                                                                                                 |
-| `checks.waitAfterEdit`                 | No                   | `true`                                                         | Whether to wait for PR checks after the editor pushes a fix commit.                                                                          |
-| `checks.retryFailedJobs`               | No                   | `3`                                                            | Number of times to rerun failed GitHub Actions jobs classified as scope-outside.                                                             |
-| `concurrency`                          | No                   | -                                                              | Worker pool limits. Project config can override global limits.                                                                               |
-| `concurrency.runs`                     | No                   | `3`                                                            | Maximum number of PR runs processed at the same time for `/magi:review` and `/magi:merge`.                                                   |
-| `concurrency.reviewers`                | No                   | `3`                                                            | Maximum number of reviewer agents processed at the same time inside review and re-review phases.                                             |
-| `github`                               | Yes                  | -                                                              | GitHub repository target. Required after global and project config are merged.                                                               |
-| `github.host`                          | No                   | `github.com`                                                   | GitHub host.                                                                                                                                 |
-| `github.owner`                         | Yes                  | -                                                              | GitHub repository owner.                                                                                                                     |
-| `github.repo`                          | Yes                  | -                                                              | GitHub repository name.                                                                                                                      |
-| `github.apiRetryAttempts`              | No                   | `3`                                                            | Number of retry attempts for GitHub CLI API calls that fail with rate limit errors. Set `0` to disable retry.                                |
-| `language`                             | No                   | -                                                              | Default language hint for generated reviews and comments.                                                                                    |
-| `merge`                                | No                   | -                                                              | Merge behavior for `/magi:merge`. Project config can override global defaults.                                                               |
-| `merge.method`                         | No                   | `squash`                                                       | Merge method: `merge`, `squash`, or `rebase`.                                                                                                |
-| `merge.auto`                           | No                   | `true`                                                         | Whether to enable GitHub auto-merge.                                                                                                         |
-| `merge.deleteBranch`                   | No                   | `true`                                                         | Whether to delete the branch after merge.                                                                                                    |
-| `merge.mergeQueue`                     | No                   | `false`                                                        | Whether Magi should use GitHub auto-merge and poll merge queue completion.                                                                   |
-| `merge.maxThreadResolutionCycles`      | No                   | `5`                                                            | Maximum fix/reply attempts per unresolved review thread before stopping that thread. Set `0` for unlimited attempts.                         |
-| `merge.approvalPolicy`                 | No                   | `majority`                                                     | `majority` merges on reviewer majority; `unanimous` requires all reviewers to approve before merging.                                        |
-| `output`                               | No                   | -                                                              | Output handling defaults.                                                                                                                    |
-| `output.dirs.pr`                       | No                   | `.magi/runs/pr`                                                | Directory for PR run artifacts. PR #123 is stored under `pr/123/<runId>`.                                                                    |
-| `output.repairAttempts`                | No                   | `3`                                                            | Number of times to ask a model to repair invalid structured output.                                                                          |
-| `worktree`                             | No                   | -                                                              | Worktree handling defaults.                                                                                                                  |
-| `worktree.dirs.pr`                     | No                   | `.magi/worktrees/pr`                                           | Directory for temporary PR worktrees. PR #123 is stored under `<dir>/pr-123`.                                                                |
-| `prompts`                              | No                   | -                                                              | Project prompts merge over global prompts.                                                                                                   |
-| `prompts.review`                       | No                   | [md](/src/prompts/templates/review.md)                         | Task template override for initial review.                                                                                                   |
-| `prompts.rereview`                     | No                   | [md](/src/prompts/templates/rereview.md)                       | Task template override for re-review after edits.                                                                                            |
-| `prompts.reviewGuidelines`             | No                   | -                                                              | Markdown file appended to reviewer prompts as shared review guidance. Supports absolute paths, project-relative paths, and `~/` paths.       |
-| `prompts.edit`                         | No                   | [md](/src/prompts/templates/edit.md)                           | Task template override for editor fixes, disagreements, and clarification questions.                                                         |
-| `prompts.editGuidelines`               | No                   | -                                                              | Markdown file appended to editor prompts as shared edit guidance. Supports absolute paths, project-relative paths, and `~/` paths.           |
-| `prompts.findingValidation`            | No                   | [md](/src/prompts/templates/finding-validation.md)             | Task template override for voting on review findings.                                                                                        |
-| `prompts.closeReconsideration`         | No                   | [md](/src/prompts/templates/close-reconsideration.md)          | Task template override when a close verdict is in the minority.                                                                              |
-| `prompts.rereviewCloseReconsideration` | No                   | [md](/src/prompts/templates/rereview-close-reconsideration.md) | Task template override when a re-review close verdict is in the minority.                                                                    |
-| `prompts.ciClassification`             | No                   | [md](/src/prompts/templates/ci-classification.md)              | Task template override for classifying failed checks as scope-in or scope-out.                                                               |
-| `prompts.ciClassificationAfterEdit`    | No                   | [md](/src/prompts/templates/ci-classification-after-edit.md)   | Task template override for classifying failed checks after editor changes. Falls back to `prompts.ciClassification` when unset.              |
-| `safety`                               | No                   | -                                                              | Optional gates evaluated before `/magi:review` and `/magi:merge` run agents.                                                                 |
-| `safety.requiredLabels`                | No                   | `[]`                                                           | Labels that must all be present on the PR.                                                                                                   |
-| `safety.blockedPaths`                  | No                   | `[]`                                                           | Glob patterns for changed files that block Magi automation.                                                                                  |
-| `safety.maxChangedFiles`               | No                   | -                                                              | Maximum changed file count allowed before Magi blocks the run.                                                                               |
-| `safety.allowAuthors`                  | No                   | `[]`                                                           | If set, only these PR authors are allowed to run through Magi.                                                                               |
-
-## Project Reference
-
-These keys usually belong in `<project>/.opencode/magi.json` because they describe the current repository or project-specific overrides.
-
-| Key                                    | Required            | Default                                                        | Description                                                                                                                                  |
-| -------------------------------------- | ------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github`                               | Yes                 | -                                                              | GitHub repository target. Required after global and project config are merged.                                                               |
-| `github.host`                          | No                  | `github.com`                                                   | GitHub host.                                                                                                                                 |
-| `github.owner`                         | Yes                 | -                                                              | GitHub repository owner.                                                                                                                     |
-| `github.repo`                          | Yes                 | -                                                              | GitHub repository name.                                                                                                                      |
-| `github.apiRetryAttempts`              | No                  | `3`                                                            | Number of retry attempts for GitHub CLI API calls that fail with rate limit errors. Set `0` to disable retry.                                |
-| `agents`                               | No                  | -                                                              | Project-specific agent overrides.                                                                                                            |
-| `agents.permissions`                   | No                  | [json](/src/permissions/common.json)                           | Project-specific common OpenCode permission overrides applied to all Magi child agents.                                                      |
-| `agents.reviewers`                     | No                  | -                                                              | Project-specific reviewer list. If set, replaces the global reviewer list.                                                                   |
-| `agents.reviewers[].id`                | No                  | `reviewer-1`, `reviewer-2`, ...                                | Reviewer key used for run state, output files, and session tracking.                                                                         |
-| `agents.reviewers[].model`             | Yes                 | -                                                              | Full OpenCode model ID used by the reviewer, in `provider/model` form. Use `opencode/gpt-...` and `openai/gpt-...` to distinguish providers. |
-| `agents.reviewers[].account`           | Yes                 | -                                                              | GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>`.                              |
-| `agents.reviewers[].options`           | No                  | -                                                              | OpenCode provider/model options injected for this reviewer, such as `reasoningEffort`, `textVerbosity`, or Anthropic `thinking`.             |
-| `agents.reviewers[].permission`        | No                  | -                                                              | Project-specific OpenCode permission overrides for this reviewer. Also used by this reviewer's CI classifier sessions.                       |
-| `agents.reviewers[].persona`           | No                  | -                                                              | Reviewer-specific additional perspective.                                                                                                    |
-| `agents.editor`                        | No                  | -                                                              | Project-specific editor for `/magi:merge`.                                                                                                   |
-| `agents.editor.model`                  | Yes (`/magi:merge`) | -                                                              | Full OpenCode model ID used by the editor when `agents.editor` is configured.                                                                |
-| `agents.editor.account`                | Yes (`/magi:merge`) | -                                                              | GitHub account used for editor commits, replies, pushes, and merge operations.                                                               |
-| `agents.editor.author.name`            | Yes (`/magi:merge`) | -                                                              | Git commit author name configured in the temporary worktree before editor commits.                                                           |
-| `agents.editor.author.email`           | Yes (`/magi:merge`) | -                                                              | Git commit author email configured in the temporary worktree before editor commits.                                                          |
-| `agents.editor.options`                | No                  | -                                                              | OpenCode provider/model options injected for the editor.                                                                                     |
-| `agents.editor.permission`             | No                  | [json](/src/permissions/editor.json)                           | Project-specific OpenCode permission overrides for the editor. Defaults allow editing and local commit creation, but not pushing.            |
-| `agents.editor.persona`                | No                  | -                                                              | Editor-specific additional instructions.                                                                                                     |
-| `automation`                           | No                  | -                                                              | Project-specific automation switches.                                                                                                        |
-| `automation.merge`                     | No                  | `true`                                                         | Whether `/magi:merge` runs `gh pr merge` after approvals are posted.                                                                         |
-| `automation.close`                     | No                  | `true`                                                         | Whether `/magi:merge` runs `gh pr close` after close comments are posted.                                                                    |
-| `clear`                                | No                  | -                                                              | Project-specific cleanup defaults for `/magi:clear`.                                                                                         |
-| `clear.output`                         | No                  | `true`                                                         | Delete inactive run output directories under `output.dirs`.                                                                                  |
-| `clear.worktree`                       | No                  | `true`                                                         | Remove inactive run worktrees with `git worktree remove`, prune worktrees, and delete remaining worktree folders.                            |
-| `clear.session`                        | No                  | `true`                                                         | Delete OpenCode child sessions created for inactive Magi runs.                                                                               |
-| `clear.branch`                         | No                  | `true`                                                         | Delete the branch recorded when Magi created the worktree. Older runs without a recorded branch are skipped.                                 |
-| `concurrency`                          | No                  | -                                                              | Project-specific worker pool limits.                                                                                                         |
-| `concurrency.runs`                     | No                  | `3`                                                            | Maximum number of PR runs processed at the same time.                                                                                        |
-| `concurrency.reviewers`                | No                  | `3`                                                            | Maximum number of reviewer agents processed at the same time per PR phase.                                                                   |
-| `language`                             | No                  | -                                                              | Project-specific language hint.                                                                                                              |
-| `merge`                                | No                  | -                                                              | Merge behavior for `/magi:merge`.                                                                                                            |
-| `merge.method`                         | No                  | `squash`                                                       | Merge method: `merge`, `squash`, or `rebase`.                                                                                                |
-| `merge.auto`                           | No                  | `true`                                                         | Whether to enable GitHub auto-merge.                                                                                                         |
-| `merge.deleteBranch`                   | No                  | `true`                                                         | Whether to delete the branch after merge.                                                                                                    |
-| `merge.mergeQueue`                     | No                  | `false`                                                        | Whether Magi should use GitHub auto-merge and poll merge queue completion.                                                                   |
-| `merge.maxThreadResolutionCycles`      | No                  | `5`                                                            | Maximum fix/reply attempts per unresolved review thread before stopping that thread. Set `0` for unlimited attempts.                         |
-| `merge.approvalPolicy`                 | No                  | `majority`                                                     | `majority` merges on reviewer majority; `unanimous` requires all reviewers to approve before merging.                                        |
-| `checks`                               | No                  | -                                                              | Check handling options.                                                                                                                      |
-| `checks.exclude`                       | No                  | `[]`                                                           | Check names to exclude from failure classification and CI merge blocking. Exact strings and `/regex/` patterns are supported.                |
-| `checks.waitBeforeReview`              | No                  | `true`                                                         | Whether to wait for PR checks before review.                                                                                                 |
-| `checks.waitAfterEdit`                 | No                  | `true`                                                         | Whether to wait for PR checks after the editor pushes a fix commit.                                                                          |
-| `checks.retryFailedJobs`               | No                  | `3`                                                            | Number of times to rerun failed GitHub Actions jobs classified as scope-outside.                                                             |
-| `output`                               | No                  | -                                                              | Project-specific output handling overrides.                                                                                                  |
-| `output.dirs.pr`                       | No                  | `.magi/runs/pr`                                                | Directory for PR run artifacts. PR #123 is stored under `pr/123/<runId>`.                                                                    |
-| `output.repairAttempts`                | No                  | `3`                                                            | Number of times to ask a model to repair invalid structured output.                                                                          |
-| `worktree`                             | No                  | -                                                              | Project-specific worktree handling overrides.                                                                                                |
-| `worktree.dirs.pr`                     | No                  | `.magi/worktrees/pr`                                           | Directory for temporary PR worktrees. PR #123 is stored under `<dir>/pr-123`.                                                                |
-| `prompts`                              | No                  | -                                                              | Project-specific prompt additions. These merge over global prompts.                                                                          |
-| `prompts.review`                       | No                  | [md](/src/prompts/templates/review.md)                         | Task template override for initial review.                                                                                                   |
-| `prompts.rereview`                     | No                  | [md](/src/prompts/templates/rereview.md)                       | Task template override for re-review after edits.                                                                                            |
-| `prompts.reviewGuidelines`             | No                  | -                                                              | Markdown file appended to reviewer prompts as shared review guidance. Supports absolute paths, project-relative paths, and `~/` paths.       |
-| `prompts.edit`                         | No                  | [md](/src/prompts/templates/edit.md)                           | Task template override for editor fixes, disagreements, and clarification questions.                                                         |
-| `prompts.editGuidelines`               | No                  | -                                                              | Markdown file appended to editor prompts as shared edit guidance. Supports absolute paths, project-relative paths, and `~/` paths.           |
-| `prompts.findingValidation`            | No                  | [md](/src/prompts/templates/finding-validation.md)             | Task template override for voting on review findings.                                                                                        |
-| `prompts.closeReconsideration`         | No                  | [md](/src/prompts/templates/close-reconsideration.md)          | Task template override when a close verdict is in the minority.                                                                              |
-| `prompts.rereviewCloseReconsideration` | No                  | [md](/src/prompts/templates/rereview-close-reconsideration.md) | Task template override when a re-review close verdict is in the minority.                                                                    |
-| `prompts.ciClassification`             | No                  | [md](/src/prompts/templates/ci-classification.md)              | Task template override for classifying failed checks as scope-in or scope-out.                                                               |
-| `prompts.ciClassificationAfterEdit`    | No                  | [md](/src/prompts/templates/ci-classification-after-edit.md)   | Task template override for classifying failed checks after editor changes. Falls back to `prompts.ciClassification` when unset.              |
-| `safety`                               | No                  | -                                                              | Optional gates evaluated before `/magi:review` and `/magi:merge` run agents.                                                                 |
-| `safety.requiredLabels`                | No                  | `[]`                                                           | Labels that must all be present on the PR.                                                                                                   |
-| `safety.blockedPaths`                  | No                  | `[]`                                                           | Glob patterns for changed files that block Magi automation.                                                                                  |
-| `safety.maxChangedFiles`               | No                  | -                                                              | Maximum changed file count allowed before Magi blocks the run.                                                                               |
-| `safety.allowAuthors`                  | No                  | `[]`                                                           | If set, only these PR authors are allowed to run through Magi.                                                                               |
+| Key                                   | Scope   | Required            | Default                                                      | Description                                                                                                          |
+| ------------------------------------- | ------- | ------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `github`                              | Project | Yes                 | -                                                            | GitHub repository target.                                                                                            |
+| `github.host`                         | Project | No                  | `github.com`                                                 | GitHub host.                                                                                                         |
+| `github.owner`                        | Project | Yes                 | -                                                            | GitHub repository owner.                                                                                             |
+| `github.repo`                         | Project | Yes                 | -                                                            | GitHub repository name.                                                                                              |
+| `github.apiRetryAttempts`             | Project | No                  | `3`                                                          | Number of retry attempts for GitHub CLI API calls that fail with rate limit errors.                                  |
+| `language`                            | Both    | No                  | -                                                            | Default language hint for generated reviews and comments.                                                            |
+| `agents.permissions`                  | Both    | No                  | [json](/src/permissions/common.json)                         | Common OpenCode permission rules applied before per-agent `permissions`.                                             |
+| `output.repairAttempts`               | Both    | No                  | `3`                                                          | Number of times to ask a model to repair invalid structured output.                                                  |
+| `review`                              | Both    | Yes                 | -                                                            | PR review configuration used by `/magi:review` and the review phase of `/magi:merge`.                                |
+| `review.agents`                       | Both    | Yes                 | -                                                            | Odd-length array of at least 3 reviewer agents.                                                                      |
+| `review.agents[].id`                  | Both    | No                  | `reviewer-1`, ...                                            | Reviewer key used for run state, output files, and session tracking.                                                 |
+| `review.agents[].model`               | Both    | Yes                 | -                                                            | Full OpenCode model ID used by the reviewer.                                                                         |
+| `review.agents[].account`             | Both    | Yes                 | -                                                            | GitHub account used to post reviews and approvals.                                                                   |
+| `review.agents[].options`             | Both    | No                  | -                                                            | OpenCode provider/model options injected for this reviewer.                                                          |
+| `review.agents[].permissions`         | Both    | No                  | -                                                            | OpenCode permission overrides for this reviewer and this reviewer's CI classifier sessions.                          |
+| `review.agents[].persona`             | Both    | No                  | -                                                            | Reviewer-specific additional perspective.                                                                            |
+| `review.prompts.review`               | Both    | No                  | [md](/src/prompts/templates/review.md)                       | Task template override for initial review.                                                                           |
+| `review.prompts.rereview`             | Both    | No                  | [md](/src/prompts/templates/rereview.md)                     | Task template override for re-review after edits.                                                                    |
+| `review.prompts.reviewGuidelines`     | Both    | No                  | -                                                            | Markdown file appended to reviewer prompts as shared review guidance.                                                |
+| `review.prompts.ciClassification`     | Both    | No                  | [md](/src/prompts/templates/ci-classification.md)            | Task template override for classifying failed checks before review.                                                  |
+| `review.prompts.findingValidation`    | Both    | No                  | [md](/src/prompts/templates/finding-validation.md)           | Task template override for voting on review findings.                                                                |
+| `review.prompts.closeReconsideration` | Both    | No                  | [md](/src/prompts/templates/close-reconsideration.md)        | Task template override when a close verdict is in the minority. Used for review and re-review.                       |
+| `review.checks.exclude`               | Both    | No                  | `[]`                                                         | Check names to exclude from failure classification. Exact strings and `/regex/` patterns supported.                  |
+| `review.checks.wait`                  | Both    | No                  | `true`                                                       | Whether to wait for PR checks before review.                                                                         |
+| `review.checks.retryFailedJobs`       | Both    | No                  | `3`                                                          | Number of times to rerun failed GitHub Actions jobs classified as scope-outside.                                     |
+| `review.safety.requiredLabels`        | Both    | No                  | `[]`                                                         | Labels that must all be present on the PR.                                                                           |
+| `review.safety.blockedPaths`          | Both    | No                  | `[]`                                                         | Glob patterns for changed files that block Magi automation.                                                          |
+| `review.safety.maxChangedFiles`       | Both    | No                  | -                                                            | Maximum changed file count allowed before Magi blocks the run.                                                       |
+| `review.safety.allowAuthors`          | Both    | No                  | `[]`                                                         | If set, only these PR authors are allowed to run through Magi.                                                       |
+| `review.automation.merge`             | Both    | No                  | `false`                                                      | Whether `/magi:review` runs `gh pr merge` after reviewer majority approves.                                          |
+| `review.automation.close`             | Both    | No                  | `false`                                                      | Whether `/magi:review` runs `gh pr close` after a close majority.                                                    |
+| `review.concurrency.runs`             | Both    | No                  | `3`                                                          | Maximum PR runs processed at the same time.                                                                          |
+| `review.concurrency.reviewers`        | Both    | No                  | `3`                                                          | Maximum reviewer agents running at once per PR phase.                                                                |
+| `review.merge.method`                 | Both    | No                  | `squash`                                                     | Merge method: `merge`, `squash`, or `rebase`.                                                                        |
+| `review.merge.auto`                   | Both    | No                  | `true`                                                       | Whether Magi passes `--auto` to `gh pr merge`.                                                                       |
+| `review.merge.deleteBranch`           | Both    | No                  | `true`                                                       | Whether Magi passes `--delete-branch` to `gh pr merge`.                                                              |
+| `review.merge.queue`                  | Both    | No                  | `false`                                                      | Whether Magi polls merge queue completion after `gh pr merge`.                                                       |
+| `review.merge.approvalPolicy`         | Both    | No                  | `majority`                                                   | `majority` merges on reviewer majority; `unanimous` requires all reviewers to approve.                               |
+| `review.output`                       | Both    | No                  | `.magi/runs/pr`                                              | Directory for PR run artifacts. PR #123 is stored under `<dir>/123/<runId>`.                                         |
+| `review.worktree`                     | Both    | No                  | `.magi/worktrees/pr`                                         | Directory for temporary PR worktrees. PR #123 is stored under `<dir>/pr-123`.                                        |
+| `merge`                               | Both    | No                  | -                                                            | Additional `/magi:merge` configuration.                                                                              |
+| `merge.editor`                        | Both    | Yes (`/magi:merge`) | -                                                            | Editor agent used by `/magi:merge`.                                                                                  |
+| `merge.editor.model`                  | Both    | Yes (`/magi:merge`) | -                                                            | Full OpenCode model ID used by the editor.                                                                           |
+| `merge.editor.account`                | Both    | Yes (`/magi:merge`) | -                                                            | GitHub account used for editor commits, replies, pushes, and merge operations.                                       |
+| `merge.editor.author.name`            | Both    | Yes (`/magi:merge`) | -                                                            | Git commit author name configured in the temporary worktree before editor commits.                                   |
+| `merge.editor.author.email`           | Both    | Yes (`/magi:merge`) | -                                                            | Git commit author email configured in the temporary worktree before editor commits.                                  |
+| `merge.editor.options`                | Both    | No                  | -                                                            | OpenCode provider/model options injected for the editor.                                                             |
+| `merge.editor.permissions`            | Both    | No                  | [json](/src/permissions/editor.json)                         | OpenCode permission overrides for the editor.                                                                        |
+| `merge.editor.persona`                | Both    | No                  | -                                                            | Editor-specific additional instructions.                                                                             |
+| `merge.checks.wait`                   | Both    | No                  | `true`                                                       | Whether to wait for PR checks after the editor pushes a fix commit.                                                  |
+| `merge.prompts.edit`                  | Both    | No                  | [md](/src/prompts/templates/edit.md)                         | Task template override for editor fixes, disagreements, and clarification questions.                                 |
+| `merge.prompts.editGuidelines`        | Both    | No                  | -                                                            | Markdown file appended to editor prompts as shared edit guidance.                                                    |
+| `merge.prompts.ciClassification`      | Both    | No                  | [md](/src/prompts/templates/ci-classification-after-edit.md) | Task template override for classifying failed checks after editor changes.                                           |
+| `merge.automation.merge`              | Both    | No                  | `true`                                                       | Whether `/magi:merge` runs `gh pr merge` after reviewers approve.                                                    |
+| `merge.automation.close`              | Both    | No                  | `false`                                                      | Whether `/magi:merge` runs `gh pr close` after a close decision.                                                     |
+| `merge.maxThreadResolutionCycles`     | Both    | No                  | `5`                                                          | Maximum fix/reply attempts per unresolved review thread before stopping that thread. Set `0` for unlimited attempts. |
+| `clear.output`                        | Both    | No                  | `true`                                                       | Delete inactive run output directories.                                                                              |
+| `clear.worktree`                      | Both    | No                  | `true`                                                       | Remove inactive run worktrees and prune worktree folders.                                                            |
+| `clear.session`                       | Both    | No                  | `true`                                                       | Delete OpenCode child sessions created for inactive Magi runs.                                                       |
+| `clear.branch`                        | Both    | No                  | `true`                                                       | Delete the branch recorded when Magi created the worktree.                                                           |
 
 ## Agent Permissions
 
-Magi passes resolved OpenCode permission rules to every child session. `agents.permissions` is the common base for all Magi agents, and `agents.reviewers[].permission` or `agents.editor.permission` override that base for one agent.
+Magi passes resolved OpenCode permission rules to every child session. `agents.permissions` is the common base for all Magi agents, and `review.agents[].permissions` or `merge.editor.permissions` override that base for one agent.
 
 Permission values follow OpenCode's permission shape:
 
@@ -244,13 +167,15 @@ Permission values follow OpenCode's permission shape:
         "git status*": "allow",
         "git diff*": "allow"
       }
-    },
-    "reviewers": [
+    }
+  },
+  "review": {
+    "agents": [
       {
         "id": "security",
         "model": "anthropic/claude-opus-4-7",
         "account": "your-account-2",
-        "permission": {
+        "permissions": {
           "webfetch": "allow"
         }
       }
@@ -267,7 +192,7 @@ Supported actions are `allow`, `ask`, and `deny`. Pattern objects are order-sens
 - Reviewer keys must be unique. The key is `id` when provided, otherwise `reviewer-1`, `reviewer-2`, and so on.
 - Reviewer `account` values must be unique.
 - Each configured account must be logged in for GitHub CLI: `gh auth token --user <account>`.
-- `agents.editor` is required when running `/magi:merge`, but not when running only `/magi:review`.
+- `merge.editor` is required when running `/magi:merge`, but not when running only `/magi:review`.
 - Permission values must be `allow`, `ask`, `deny`, or an object of pattern-to-action rules.
 
 ## GitHub Permissions

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -4,7 +4,7 @@ Magi keeps built-in task prompts as Markdown templates under [`src/prompts/templ
 
 Custom prompt files replace the built-in task template for that phase. They do not replace the fixed output contract, so prompt customization cannot change the required response schema.
 
-Guideline files are additive. Configure `prompts.reviewGuidelines` or `prompts.editGuidelines` when you want to keep Magi's built-in task prompts and append shared guidance from a Markdown file.
+Guideline files are additive. Configure `review.prompts.reviewGuidelines` or `merge.prompts.editGuidelines` when you want to keep Magi's built-in task prompts and append shared guidance from a Markdown file.
 
 Custom prompt and guideline files are also rendered with the same placeholder values as the built-in template for that phase.
 
@@ -14,12 +14,12 @@ Project prompt paths in `.opencode/magi.json` override the same global prompt ke
 
 For each model call, Magi builds one final prompt from several parts.
 
-The `<task>` block comes from either Magi's built-in Markdown template or your configured `prompts.*` Markdown file. It tells the model what phase it is running, what PR to inspect, what diff range to use, and what inputs Magi has collected for that phase.
+The `<task>` block comes from either Magi's built-in Markdown template or your configured `review.prompts.*` or `merge.prompts.*` Markdown file. It tells the model what phase it is running, what PR to inspect, what diff range to use, and what inputs Magi has collected for that phase.
 
 For example, in a review prompt:
 
-- Without `prompts.review`, Magi uses [`review.md`](/src/prompts/templates/review.md).
-- With `prompts.review`, Magi uses that file instead of [`review.md`](/src/prompts/templates/review.md).
+- Without `review.prompts.review`, Magi uses [`review.md`](/src/prompts/templates/review.md).
+- With `review.prompts.review`, Magi uses that file instead of [`review.md`](/src/prompts/templates/review.md).
 - In both cases, Magi still appends the fixed review output contract.
 
 The custom file replaces the built-in task, but it does not replace the output schema.
@@ -28,7 +28,7 @@ The final prompt has this shape:
 
 ```text
 <task>
-...built-in template or configured prompts.* template, with runtime values filled in...
+...built-in template or configured prompt template, with runtime values filled in...
 </task>
 
 <language>
@@ -40,11 +40,11 @@ The final prompt has this shape:
 </persona>
 
 <review_guidelines>
-    ...optional Markdown loaded from prompts.reviewGuidelines...
+    ...optional Markdown loaded from review.prompts.reviewGuidelines...
 </review_guidelines>
 
 <edit_guidelines>
-    ...optional Markdown loaded from prompts.editGuidelines...
+    ...optional Markdown loaded from merge.prompts.editGuidelines...
 </edit_guidelines>
 
 <output_contract>
@@ -56,12 +56,14 @@ Only the task template and guideline files support placeholder replacement. The 
 
 ## Review Guidelines
 
-Use `prompts.reviewGuidelines` to append repository-specific review standards without replacing Magi's built-in task prompt.
+Use `review.prompts.reviewGuidelines` to append repository-specific review standards without replacing Magi's built-in task prompt.
 
 ```json
 {
-  "prompts": {
-    "reviewGuidelines": ".agents/references/pr-review-guidelines.md"
+  "review": {
+    "prompts": {
+      "reviewGuidelines": ".agents/references/pr-review-guidelines.md"
+    }
   }
 }
 ```
@@ -78,7 +80,7 @@ Placeholders use `{name}` syntax. Unknown placeholders are left unchanged.
 
 Used when a reviewer performs an initial PR review.
 
-Config key: `prompts.review`
+Config key: `review.prompts.review`
 
 Built-in template: [`review.md`](/src/prompts/templates/review.md)
 
@@ -91,14 +93,12 @@ Built-in template: [`review.md`](/src/prompts/templates/review.md)
 | `{jsonEncodedWorktreePath}` | JSON-encoded worktree path for shell snippets.                          |
 | `{ciFailureContext}`        | Scope-in CI failure context, when present.                              |
 | `{ciFailureContextBlock}`   | Full `<ci_failure_context>` block when context exists, otherwise empty. |
-| `{ciFailureLogs}`           | Backward-compatible alias for `{ciFailureContext}`.                     |
-| `{ciFailureLogsBlock}`      | Backward-compatible alias for `{ciFailureContextBlock}`.                |
 
 ### Re-review
 
 Used when a reviewer checks new commits or editor changes against unresolved review threads.
 
-Config key: `prompts.rereview`
+Config key: `review.prompts.rereview`
 
 Built-in template: [`rereview.md`](/src/prompts/templates/rereview.md)
 
@@ -112,8 +112,6 @@ Built-in template: [`rereview.md`](/src/prompts/templates/rereview.md)
 | `{unresolvedThreads}`             | JSON list of unresolved review threads for the reviewer.                              |
 | `{ciFailureContext}`              | Scope-in CI failure context, when present.                                            |
 | `{ciFailureContextBlock}`         | Full `<ci_failure_context>` block when context exists, otherwise empty.               |
-| `{ciFailureLogs}`                 | Backward-compatible alias for `{ciFailureContext}`.                                   |
-| `{ciFailureLogsBlock}`            | Backward-compatible alias for `{ciFailureContextBlock}`.                              |
 | `{previousReview}`                | Previous GitHub review metadata, when available.                                      |
 | `{previousReviewBlock}`           | Full `<previous_review>` block when previous review metadata exists, otherwise empty. |
 
@@ -121,7 +119,7 @@ Built-in template: [`rereview.md`](/src/prompts/templates/rereview.md)
 
 Used when the editor responds to requested changes by fixing code, disagreeing with a clear reason, or asking for clarification.
 
-Config key: `prompts.edit`
+Config key: `merge.prompts.edit`
 
 Built-in template: [`edit.md`](/src/prompts/templates/edit.md)
 
@@ -134,12 +132,14 @@ Built-in template: [`edit.md`](/src/prompts/templates/edit.md)
 
 #### Edit Guidelines
 
-Use `prompts.editGuidelines` to append repository-specific edit standards without replacing Magi's built-in task prompt.
+Use `merge.prompts.editGuidelines` to append repository-specific edit standards without replacing Magi's built-in task prompt.
 
 ```json
 {
-  "prompts": {
-    "editGuidelines": ".agents/references/edit-guidelines.md"
+  "merge": {
+    "prompts": {
+      "editGuidelines": ".agents/references/edit-guidelines.md"
+    }
   }
 }
 ```
@@ -152,7 +152,7 @@ Paths may be absolute, project-relative, or start with `~/`.
 
 Used when reviewers vote on whether another reviewer's findings should remain posted.
 
-Config key: `prompts.findingValidation`
+Config key: `review.prompts.findingValidation`
 
 Built-in template: [`finding-validation.md`](/src/prompts/templates/finding-validation.md)
 
@@ -169,7 +169,7 @@ Built-in template: [`finding-validation.md`](/src/prompts/templates/finding-vali
 
 Used when a reviewer returned `CLOSE`, but `CLOSE` did not reach majority. The reviewer must choose `MERGE` or `CHANGES_REQUESTED` before anything is posted.
 
-Config key: `prompts.closeReconsideration`
+Config key: `review.prompts.closeReconsideration`
 
 Built-in template: [`close-reconsideration.md`](/src/prompts/templates/close-reconsideration.md)
 
@@ -186,7 +186,7 @@ Built-in template: [`close-reconsideration.md`](/src/prompts/templates/close-rec
 
 Used when a reviewer returned `CLOSE` during re-review, but `CLOSE` did not reach majority. The reviewer must choose `MERGE` or `CHANGES_REQUESTED` before anything is posted.
 
-Config key: `prompts.rereviewCloseReconsideration`
+Config key: `review.prompts.closeReconsideration`
 
 Built-in template: [`rereview-close-reconsideration.md`](/src/prompts/templates/rereview-close-reconsideration.md)
 
@@ -200,15 +200,13 @@ Built-in template: [`rereview-close-reconsideration.md`](/src/prompts/templates/
 | `{unresolvedThreads}`             | JSON list of unresolved review threads for the reviewer.                |
 | `{ciFailureContext}`              | Scope-in CI failure context, when present.                              |
 | `{ciFailureContextBlock}`         | Full `<ci_failure_context>` block when context exists, otherwise empty. |
-| `{ciFailureLogs}`                 | Backward-compatible alias for `{ciFailureContext}`.                     |
-| `{ciFailureLogsBlock}`            | Backward-compatible alias for `{ciFailureContextBlock}`.                |
 | `{closeReason}`                   | The original minority close reason.                                     |
 
 ### CI Classification
 
 Used when failed checks need to be classified as caused by the PR (`SCOPE_IN`) or likely flaky, external, or infrastructure-related (`SCOPE_OUT`).
 
-Config key: `prompts.ciClassification`
+Config key: `review.prompts.ciClassification`
 
 Built-in template: [`ci-classification.md`](/src/prompts/templates/ci-classification.md)
 
@@ -220,9 +218,9 @@ Built-in template: [`ci-classification.md`](/src/prompts/templates/ci-classifica
 
 ### CI Classification After Edit
 
-Used when failed checks need to be classified after the editor has pushed fixes. If `prompts.ciClassificationAfterEdit` is not set, Magi falls back to `prompts.ciClassification`. The fixed output contract is the same as [CI Classification](#ci-classification).
+Used when failed checks need to be classified after the editor has pushed fixes.
 
-Config key: `prompts.ciClassificationAfterEdit`
+Config key: `merge.prompts.ciClassification`
 
 Built-in template: [`ci-classification-after-edit.md`](/src/prompts/templates/ci-classification-after-edit.md)
 

--- a/schema.json
+++ b/schema.json
@@ -5,13 +5,11 @@
   "additionalProperties": false,
   "properties": {
     "$schema": { "type": "string" },
-    "agents": { "$ref": "#/$defs/agents" },
-    "automation": {
+    "agents": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "merge": { "type": "boolean", "default": true },
-        "close": { "type": "boolean", "default": true }
+        "permissions": { "$ref": "#/$defs/permissions" }
       }
     },
     "clear": {
@@ -22,24 +20,6 @@
         "worktree": { "type": "boolean", "default": true },
         "session": { "type": "boolean", "default": true },
         "branch": { "type": "boolean", "default": true }
-      }
-    },
-    "checks": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "exclude": { "type": "array", "items": { "type": "string" } },
-        "waitAfterEdit": { "type": "boolean" },
-        "waitBeforeReview": { "type": "boolean" },
-        "retryFailedJobs": { "type": "integer", "minimum": 0, "default": 3 }
-      }
-    },
-    "concurrency": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "runs": { "type": "integer", "minimum": 1, "default": 3 },
-        "reviewers": { "type": "integer", "minimum": 1, "default": 3 }
       }
     },
     "github": {
@@ -59,64 +39,15 @@
       }
     },
     "language": { "type": "string" },
-    "merge": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "approvalPolicy": {
-          "enum": ["majority", "unanimous"],
-          "default": "majority"
-        },
-        "method": { "enum": ["merge", "squash", "rebase"] },
-        "auto": { "type": "boolean" },
-        "deleteBranch": { "type": "boolean" },
-        "mergeQueue": { "type": "boolean", "default": false },
-        "maxThreadResolutionCycles": {
-          "type": "integer",
-          "minimum": 0,
-          "default": 5,
-          "description": "Maximum resolution attempts per unresolved review thread. Set 0 for unlimited attempts."
-        }
-      }
-    },
+    "merge": { "$ref": "#/$defs/merge" },
     "output": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "dirs": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "pr": { "type": "string" }
-          }
-        },
         "repairAttempts": { "type": "integer", "minimum": 0, "default": 3 }
       }
     },
-    "prompts": { "$ref": "#/$defs/prompts" },
-    "safety": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "allowAuthors": { "type": "array", "items": { "type": "string" } },
-        "blockedPaths": { "type": "array", "items": { "type": "string" } },
-        "maxChangedFiles": { "type": "integer", "minimum": 0 },
-        "requiredLabels": { "type": "array", "items": { "type": "string" } }
-      }
-    },
-    "worktree": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "dirs": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "pr": { "type": "string" }
-          }
-        }
-      }
-    }
+    "review": { "$ref": "#/$defs/review" }
   },
   "$defs": {
     "reviewer": {
@@ -128,7 +59,7 @@
         "model": { "type": "string", "minLength": 1 },
         "options": { "type": "object", "additionalProperties": true },
         "account": { "type": "string", "minLength": 1 },
-        "permission": { "$ref": "#/$defs/permission" },
+        "permissions": { "$ref": "#/$defs/permissions" },
         "persona": { "type": "string" }
       }
     },
@@ -149,21 +80,120 @@
             "email": { "type": "string", "minLength": 1 }
           }
         },
-        "permission": { "$ref": "#/$defs/permission" },
+        "permissions": { "$ref": "#/$defs/permissions" },
         "persona": { "type": "string" }
       }
     },
-    "agents": {
+    "automation": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "permissions": { "$ref": "#/$defs/permission" },
-        "reviewers": {
+        "merge": { "type": "boolean" },
+        "close": { "type": "boolean" }
+      }
+    },
+    "reviewChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "exclude": { "type": "array", "items": { "type": "string" } },
+        "wait": { "type": "boolean", "default": true },
+        "retryFailedJobs": { "type": "integer", "minimum": 0, "default": 3 }
+      }
+    },
+    "mergeChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "wait": { "type": "boolean", "default": true }
+      }
+    },
+    "concurrency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runs": { "type": "integer", "minimum": 1, "default": 3 },
+        "reviewers": { "type": "integer", "minimum": 1, "default": 3 }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowAuthors": { "type": "array", "items": { "type": "string" } },
+        "blockedPaths": { "type": "array", "items": { "type": "string" } },
+        "maxChangedFiles": { "type": "integer", "minimum": 0 },
+        "requiredLabels": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "reviewPrompts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "review": { "type": "string" },
+        "rereview": { "type": "string" },
+        "reviewGuidelines": { "type": "string" },
+        "ciClassification": { "type": "string" },
+        "findingValidation": { "type": "string" },
+        "closeReconsideration": { "type": "string" }
+      }
+    },
+    "mergePrompts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "edit": { "type": "string" },
+        "editGuidelines": { "type": "string" },
+        "ciClassification": { "type": "string" }
+      }
+    },
+    "reviewMerge": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approvalPolicy": {
+          "enum": ["majority", "unanimous"],
+          "default": "majority"
+        },
+        "method": { "enum": ["merge", "squash", "rebase"] },
+        "auto": { "type": "boolean" },
+        "deleteBranch": { "type": "boolean" },
+        "queue": { "type": "boolean", "default": false }
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "agents": {
           "type": "array",
           "minItems": 3,
           "items": { "$ref": "#/$defs/reviewer" }
         },
-        "editor": { "$ref": "#/$defs/editor" }
+        "prompts": { "$ref": "#/$defs/reviewPrompts" },
+        "checks": { "$ref": "#/$defs/reviewChecks" },
+        "safety": { "$ref": "#/$defs/safety" },
+        "automation": { "$ref": "#/$defs/automation" },
+        "concurrency": { "$ref": "#/$defs/concurrency" },
+        "merge": { "$ref": "#/$defs/reviewMerge" },
+        "output": { "type": "string" },
+        "worktree": { "type": "string" }
+      }
+    },
+    "merge": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "editor": { "$ref": "#/$defs/editor" },
+        "checks": { "$ref": "#/$defs/mergeChecks" },
+        "prompts": { "$ref": "#/$defs/mergePrompts" },
+        "automation": { "$ref": "#/$defs/automation" },
+        "maxThreadResolutionCycles": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 5,
+          "description": "Maximum resolution attempts per unresolved review thread. Set 0 for unlimited attempts."
+        }
       }
     },
     "permissionAction": { "enum": ["allow", "ask", "deny"] },
@@ -176,7 +206,7 @@
         }
       ]
     },
-    "permission": {
+    "permissions": {
       "oneOf": [
         { "$ref": "#/$defs/permissionAction" },
         {
@@ -184,23 +214,6 @@
           "additionalProperties": { "$ref": "#/$defs/permissionRule" }
         }
       ]
-    },
-    "prompts": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "review": { "type": "string" },
-        "rereview": { "type": "string" },
-        "edit": { "type": "string" },
-        "editGuidelines": { "type": "string" },
-        "findingValidation": { "type": "string" },
-        "closeReconsideration": { "type": "string" },
-        "rereviewCloseReconsideration": { "type": "string" },
-        "ciClassification": { "type": "string" },
-        "ciClassificationAfterEdit": { "type": "string" },
-        "report": { "type": "string" },
-        "reviewGuidelines": { "type": "string" }
-      }
     }
   }
 }

--- a/src/config/load.test.ts
+++ b/src/config/load.test.ts
@@ -4,8 +4,11 @@ import { mergeMagiConfig } from "./load"
 import { resolveRepository } from "./resolve"
 
 const config: MagiConfig = {
-  agents: {
-    reviewers: [
+  agents: {},
+  github: { owner: "owner", repo: "repo" },
+  language: "en",
+  review: {
+    agents: [
       {
         model: "anthropic/claude",
         account: "bot-a",
@@ -14,15 +17,15 @@ const config: MagiConfig = {
       { id: "security", model: "anthropic/claude", account: "bot-b" },
       { id: "compat", model: "openai/gpt", account: "bot-c" },
     ],
+    prompts: { review: "global-review.md" },
+  },
+  merge: {
     editor: {
       model: "openai/gpt",
       account: "bot-c",
       author: { email: "bot-c@example.com", name: "Bot C" },
     },
   },
-  github: { owner: "owner", repo: "repo" },
-  language: "en",
-  prompts: { review: "global-review.md" },
 }
 
 describe("mergeMagiConfig", () => {
@@ -31,9 +34,14 @@ describe("mergeMagiConfig", () => {
       config as unknown as Record<string, unknown>,
       {
         language: "ja",
-        automation: { merge: false },
-        merge: { approvalPolicy: "unanimous", mergeQueue: true },
-        prompts: { edit: "project-edit.md", review: "project-review.md" },
+        merge: {
+          automation: { merge: false },
+          prompts: { edit: "project-edit.md" },
+        },
+        review: {
+          merge: { approvalPolicy: "unanimous", queue: true },
+          prompts: { review: "project-review.md" },
+        },
       },
     ) as unknown as MagiConfig
     const repo = resolveRepository(merged)
@@ -44,8 +52,16 @@ describe("mergeMagiConfig", () => {
     expect(repo.merge.mergeQueue).toBe(true)
     expect(repo.automation.merge).toBe(false)
     expect(repo.prompts).toEqual({
+      ciClassification: undefined,
+      ciClassificationAfterEdit: undefined,
+      closeReconsideration: undefined,
       edit: "project-edit.md",
+      editGuidelines: undefined,
+      findingValidation: undefined,
+      rereview: undefined,
+      rereviewCloseReconsideration: undefined,
       review: "project-review.md",
+      reviewGuidelines: undefined,
     })
   })
 
@@ -53,8 +69,8 @@ describe("mergeMagiConfig", () => {
     const merged = mergeMagiConfig(
       config as unknown as Record<string, unknown>,
       {
-        agents: {
-          reviewers: [
+        review: {
+          agents: [
             { id: "a", model: "openai/gpt", account: "bot-1" },
             { id: "b", model: "openai/gpt", account: "bot-2" },
             { id: "c", model: "openai/gpt", account: "bot-3" },
@@ -63,9 +79,11 @@ describe("mergeMagiConfig", () => {
       },
     ) as unknown as MagiConfig
 
-    expect(
-      merged.agents.reviewers!.map((reviewer) => reviewer.account),
-    ).toEqual(["bot-1", "bot-2", "bot-3"])
-    expect(merged.agents.editor).toEqual(config.agents.editor)
+    expect(merged.review?.agents!.map((reviewer) => reviewer.account)).toEqual([
+      "bot-1",
+      "bot-2",
+      "bot-3",
+    ])
+    expect(merged.merge?.editor).toEqual(config.merge?.editor)
   })
 })

--- a/src/config/output.ts
+++ b/src/config/output.ts
@@ -18,7 +18,7 @@ export function outputBaseDir(
 ): string {
   return resolvePath(
     directory,
-    config.output?.dirs?.[kind] ?? DEFAULT_OUTPUT_DIRS[kind],
+    config.review?.output ?? DEFAULT_OUTPUT_DIRS[kind],
   )
 }
 

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, test } from "vitest"
 import { resolveRepository, reviewerKey } from "./resolve"
 
 const config: MagiConfig = {
-  agents: {
-    reviewers: [
+  agents: {},
+  github: { owner: "owner", repo: "repo" },
+  language: "en",
+  review: {
+    agents: [
       {
         model: "anthropic/claude",
         account: "bot-a",
@@ -13,17 +16,17 @@ const config: MagiConfig = {
       { id: "security", model: "anthropic/claude", account: "bot-b" },
       { id: "compat", model: "openai/gpt", account: "bot-c" },
     ],
+    prompts: { review: "global-review.md" },
+  },
+  merge: {
     editor: {
       model: "openai/gpt",
       account: "bot-c",
       author: { email: "bot-c@example.com", name: "Bot C" },
     },
   },
-  github: { owner: "owner", repo: "repo" },
-  language: "en",
-  prompts: { review: "global-review.md" },
 }
-const reviewers = config.agents.reviewers ?? []
+const reviewers = config.review?.agents ?? []
 
 describe("resolveRepository", () => {
   test("uses index reviewer keys unless id is configured", () => {
@@ -46,7 +49,8 @@ describe("resolveRepository", () => {
     expect(repo.merge.approvalPolicy).toBe("majority")
     expect(repo.merge.mergeQueue).toBe(false)
     expect(repo.merge.maxThreadResolutionCycles).toBe(5)
-    expect(repo.automation).toEqual({ close: true, merge: true })
+    expect(repo.automation).toEqual({ close: false, merge: true })
+    expect(repo.reviewAutomation).toEqual({ close: false, merge: false })
     expect(repo.concurrency).toEqual({ runs: 3, reviewers: 3 })
     expect(repo.checks.exclude).toEqual([])
     expect(repo.checks.waitAfterEdit).toBe(true)
@@ -95,10 +99,13 @@ describe("resolveRepository", () => {
           bash: { "gh pr view*": "allow" },
           webfetch: "allow",
         },
-        reviewers: [
+      },
+      review: {
+        ...config.review,
+        agents: [
           {
             ...(reviewers[0] as NonNullable<(typeof reviewers)[number]>),
-            permission: { bash: { "git push*": "deny" }, webfetch: "deny" },
+            permissions: { bash: { "git push*": "deny" }, webfetch: "deny" },
           },
           ...reviewers.slice(1),
         ],

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -78,33 +78,36 @@ export function mergePermissions(
 
 export function resolveReviewerPermission(
   agents: AgentsConfig,
-  reviewer: { permission?: PermissionConfig },
+  reviewer: { permissions?: PermissionConfig },
 ): PermissionConfig {
   return mergePermissions(
     mergePermissions(DEFAULT_REVIEWER_PERMISSION, agents.permissions),
-    reviewer.permission,
+    reviewer.permissions,
   )
 }
 
 export function resolveEditorPermission(
   agents: AgentsConfig,
-  editor: { permission?: PermissionConfig },
+  editor: { permissions?: PermissionConfig },
 ): PermissionConfig {
   return mergePermissions(
     mergePermissions(DEFAULT_EDITOR_PERMISSION, agents.permissions),
-    editor.permission,
+    editor.permissions,
   )
 }
 
-export function resolveAgents(agents: AgentsConfig): ResolvedAgents {
+export function resolveAgents(config: MagiConfig): ResolvedAgents {
+  const agents = config.agents ?? {}
+  const editor = config.merge?.editor
+
   return {
-    editor: agents.editor
+    editor: editor
       ? {
-          ...agents.editor,
-          permission: resolveEditorPermission(agents, agents.editor),
+          ...editor,
+          permission: resolveEditorPermission(agents, editor),
         }
       : undefined,
-    reviewers: (agents.reviewers ?? []).map<ResolvedReviewer>(
+    reviewers: (config.review?.agents ?? []).map<ResolvedReviewer>(
       (reviewer, index) => ({
         ...reviewer,
         key: reviewerKey(reviewer, index),
@@ -121,20 +124,21 @@ export function resolveRepository(config: MagiConfig): ResolvedRepository {
 
   return {
     alias: config.github.repo,
-    agents: resolveAgents(config.agents),
+    agents: resolveAgents(config),
     automation: {
-      close: config.automation?.close ?? true,
-      merge: config.automation?.merge ?? true,
+      close: config.merge?.automation?.close ?? false,
+      merge: config.merge?.automation?.merge ?? true,
     },
     checks: {
-      exclude: config.checks?.exclude ?? [],
-      waitAfterEdit: config.checks?.waitAfterEdit ?? true,
-      waitBeforeReview: config.checks?.waitBeforeReview ?? true,
-      retryFailedJobs: config.checks?.retryFailedJobs ?? 3,
+      exclude: config.review?.checks?.exclude ?? [],
+      retryFailedJobs: config.review?.checks?.retryFailedJobs ?? 3,
+      wait: config.review?.checks?.wait ?? true,
+      waitAfterEdit: config.merge?.checks?.wait ?? true,
+      waitBeforeReview: config.review?.checks?.wait ?? true,
     },
     concurrency: {
-      runs: config.concurrency?.runs ?? 3,
-      reviewers: config.concurrency?.reviewers ?? 3,
+      runs: config.review?.concurrency?.runs ?? 3,
+      reviewers: config.review?.concurrency?.reviewers ?? 3,
     },
     github: {
       apiRetryAttempts: config.github.apiRetryAttempts ?? 3,
@@ -144,19 +148,36 @@ export function resolveRepository(config: MagiConfig): ResolvedRepository {
     },
     language: config.language,
     merge: {
-      approvalPolicy: config.merge?.approvalPolicy ?? "majority",
-      method: config.merge?.method ?? "squash",
-      auto: config.merge?.auto ?? true,
-      deleteBranch: config.merge?.deleteBranch ?? true,
-      mergeQueue: config.merge?.mergeQueue ?? false,
+      approvalPolicy: config.review?.merge?.approvalPolicy ?? "majority",
+      method: config.review?.merge?.method ?? "squash",
+      auto: config.review?.merge?.auto ?? true,
+      deleteBranch: config.review?.merge?.deleteBranch ?? true,
+      queue: config.review?.merge?.queue ?? false,
+      mergeQueue: config.review?.merge?.queue ?? false,
       maxThreadResolutionCycles: config.merge?.maxThreadResolutionCycles ?? 5,
     },
-    prompts: config.prompts ?? {},
+    prompts: {
+      ciClassification: config.review?.prompts?.ciClassification,
+      ciClassificationAfterEdit: config.merge?.prompts?.ciClassification,
+      closeReconsideration: config.review?.prompts?.closeReconsideration,
+      edit: config.merge?.prompts?.edit,
+      editGuidelines: config.merge?.prompts?.editGuidelines,
+      findingValidation: config.review?.prompts?.findingValidation,
+      rereview: config.review?.prompts?.rereview,
+      rereviewCloseReconsideration:
+        config.review?.prompts?.closeReconsideration,
+      review: config.review?.prompts?.review,
+      reviewGuidelines: config.review?.prompts?.reviewGuidelines,
+    },
+    reviewAutomation: {
+      close: config.review?.automation?.close ?? false,
+      merge: config.review?.automation?.merge ?? false,
+    },
     safety: {
-      allowAuthors: config.safety?.allowAuthors ?? [],
-      blockedPaths: config.safety?.blockedPaths ?? [],
-      maxChangedFiles: config.safety?.maxChangedFiles,
-      requiredLabels: config.safety?.requiredLabels ?? [],
+      allowAuthors: config.review?.safety?.allowAuthors ?? [],
+      blockedPaths: config.review?.safety?.blockedPaths ?? [],
+      maxChangedFiles: config.review?.safety?.maxChangedFiles,
+      requiredLabels: config.review?.safety?.requiredLabels ?? [],
     },
   }
 }

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -1,4 +1,4 @@
-import type { MagiConfig } from "../types"
+import type { MagiConfig, PermissionConfig } from "../types"
 import { mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -7,7 +7,12 @@ import { validateConfig } from "./validate"
 
 const config: MagiConfig = {
   agents: {
-    reviewers: [
+    permissions: { bash: { "git status*": "allow" } },
+  },
+  github: { owner: "owner", repo: "repo" },
+  language: "en",
+  review: {
+    agents: [
       {
         model: "anthropic/claude",
         account: "bot-a",
@@ -16,17 +21,17 @@ const config: MagiConfig = {
       { id: "security", model: "anthropic/claude", account: "bot-b" },
       { id: "compat", model: "openai/gpt", account: "bot-c" },
     ],
+    prompts: { review: "global-review.md" },
+  },
+  merge: {
     editor: {
       model: "openai/gpt",
       account: "bot-c",
       author: { email: "bot-c@example.com", name: "Bot C" },
     },
   },
-  github: { owner: "owner", repo: "repo" },
-  language: "en",
-  prompts: { review: "global-review.md" },
 }
-const reviewers = config.agents.reviewers ?? []
+const reviewers = config.review?.agents ?? []
 
 describe("validateConfig", () => {
   test("accepts valid odd reviewer config", async () => {
@@ -39,7 +44,7 @@ describe("validateConfig", () => {
   test("allows missing editor unless merge validation requires it", async () => {
     const withoutEditor: MagiConfig = {
       ...config,
-      agents: { reviewers },
+      merge: undefined,
     }
 
     await expect(validateConfig(withoutEditor)).resolves.toMatchObject({
@@ -48,7 +53,7 @@ describe("validateConfig", () => {
     await expect(
       validateConfig(withoutEditor, { requireEditor: true }),
     ).resolves.toMatchObject({
-      errors: ["agents.editor is required"],
+      errors: ["merge.editor is required"],
       ok: false,
     })
   })
@@ -56,23 +61,23 @@ describe("validateConfig", () => {
   test("requires editor author when editor is configured", async () => {
     const result = await validateConfig({
       ...config,
-      agents: {
-        ...config.agents,
+      merge: {
+        ...config.merge,
         editor: {
           model: "openai/gpt",
           account: "bot-c",
-        } as MagiConfig["agents"]["editor"],
+        } as NonNullable<MagiConfig["merge"]>["editor"],
       },
     })
 
     expect(result.ok).toBe(false)
-    expect(result.errors).toContain("agents.editor.author.name is required")
-    expect(result.errors).toContain("agents.editor.author.email is required")
+    expect(result.errors).toContain("merge.editor.author.name is required")
+    expect(result.errors).toContain("merge.editor.author.email is required")
   })
 
   test("allows global config without github", async () => {
     const globalConfig: MagiConfig = {
-      agents: { reviewers },
+      review: { agents: reviewers },
     }
 
     await expect(
@@ -83,55 +88,58 @@ describe("validateConfig", () => {
   test("rejects even reviewer config", async () => {
     const result = await validateConfig({
       ...config,
-      agents: {
-        ...config.agents,
-        reviewers: [...reviewers, { account: "bot-d", model: "google/gemini" }],
+      review: {
+        ...config.review,
+        agents: [...reviewers, { account: "bot-d", model: "google/gemini" }],
       },
     })
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "agents.reviewers must contain an odd number of reviewers",
+      "review.agents must contain an odd number of reviewers",
     )
   })
 
   test("rejects invalid concurrency config", async () => {
     const result = await validateConfig({
       ...config,
-      concurrency: { runs: 0, reviewers: -1 },
+      review: { ...config.review, concurrency: { runs: 0, reviewers: -1 } },
     })
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "concurrency.runs must be a positive integer",
+      "review.concurrency.runs must be a positive integer",
     )
     expect(result.errors).toContain(
-      "concurrency.reviewers must be a positive integer",
+      "review.concurrency.reviewers must be a positive integer",
     )
   })
 
   test("rejects invalid automation and approval policy config", async () => {
     const result = await validateConfig({
       ...config,
-      automation: {
-        close: "yes",
-        merge: "no",
-      } as unknown as MagiConfig["automation"],
-      merge: { approvalPolicy: "all" as "majority" },
+      review: {
+        ...config.review,
+        automation: {
+          close: "yes",
+          merge: "no",
+        } as unknown as NonNullable<MagiConfig["review"]>["automation"],
+        merge: { approvalPolicy: "all" as "majority" },
+      },
     })
 
     expect(result.ok).toBe(false)
-    expect(result.errors).toContain("automation.close must be a boolean")
-    expect(result.errors).toContain("automation.merge must be a boolean")
+    expect(result.errors).toContain("review.automation.close must be a boolean")
+    expect(result.errors).toContain("review.automation.merge must be a boolean")
     expect(result.errors).toContain(
-      "merge.approvalPolicy must be majority or unanimous",
+      "review.merge.approvalPolicy must be majority or unanimous",
     )
   })
 
   test("rejects invalid thread resolution cycle config", async () => {
     const result = await validateConfig({
       ...config,
-      merge: { maxThreadResolutionCycles: -1 },
+      merge: { ...config.merge, maxThreadResolutionCycles: -1 },
     })
 
     expect(result.ok).toBe(false)
@@ -153,12 +161,12 @@ describe("validateConfig", () => {
   test("rejects invalid checks retry config", async () => {
     const result = await validateConfig({
       ...config,
-      checks: { retryFailedJobs: -1 },
+      review: { ...config.review, checks: { retryFailedJobs: -1 } },
     })
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "checks.retryFailedJobs must be a non-negative integer",
+      "review.checks.retryFailedJobs must be a non-negative integer",
     )
   })
 
@@ -167,27 +175,26 @@ describe("validateConfig", () => {
       ...config,
       extra: true,
       github: { ...config.github, unknown: true },
-      merge: { ...config.merge, queue: true },
+      review: { ...config.review, unknown: true },
     } as unknown as MagiConfig)
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain("config.extra is not supported")
     expect(result.errors).toContain("github.unknown is not supported")
-    expect(result.errors).toContain("merge.queue is not supported")
+    expect(result.errors).toContain("review.unknown is not supported")
   })
 
   test("rejects invalid worktree dirs config", async () => {
     const result = await validateConfig({
       ...config,
-      worktree: {
-        dir: ".magi/worktrees",
-        dirs: { pr: 1 },
-      } as unknown as MagiConfig["worktree"],
+      review: {
+        ...config.review,
+        worktree: 1,
+      } as unknown as MagiConfig["review"],
     })
 
     expect(result.ok).toBe(false)
-    expect(result.errors).toContain("worktree.dir is not supported")
-    expect(result.errors).toContain("worktree.dirs.pr must be a string")
+    expect(result.errors).toContain("review.worktree must be a string")
   })
 
   test("checks prompt file paths when directory is provided", async () => {
@@ -197,9 +204,12 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         ...config,
-        prompts: {
-          editGuidelines: "missing.txt",
-          reviewGuidelines: "review.txt",
+        review: {
+          ...config.review,
+          prompts: {
+            review: "missing.txt",
+            reviewGuidelines: "review.txt",
+          },
         },
       },
       { directory: dir },
@@ -207,10 +217,10 @@ describe("validateConfig", () => {
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "prompts.editGuidelines file is not readable: missing.txt",
+      "review.prompts.review file is not readable: missing.txt",
     )
     expect(result.errors).not.toContain(
-      "prompts.reviewGuidelines file is not readable: review.txt",
+      "review.prompts.reviewGuidelines file is not readable: review.txt",
     )
   })
 
@@ -229,47 +239,55 @@ describe("validateConfig", () => {
   test("rejects invalid checks exclude config", async () => {
     const result = await validateConfig({
       ...config,
-      checks: { exclude: ["Test", 1] as string[] },
+      review: {
+        ...config.review,
+        checks: { exclude: ["Test", 1] as string[] },
+      },
     })
 
     expect(result.ok).toBe(false)
-    expect(result.errors).toContain("checks.exclude[1] must be a string")
+    expect(result.errors).toContain("review.checks.exclude[1] must be a string")
   })
 
   test("rejects invalid safety config", async () => {
     const result = await validateConfig({
       ...config,
-      safety: {
-        allowAuthors: ["bot-a", 1],
-        blockedPaths: [".github/**"],
-        maxChangedFiles: -1,
-        requiredLabels: ["magi-ok"],
-      } as unknown as MagiConfig["safety"],
+      review: {
+        ...config.review,
+        safety: {
+          allowAuthors: ["bot-a", 1],
+          blockedPaths: [".github/**"],
+          maxChangedFiles: -1,
+          requiredLabels: ["magi-ok"],
+        } as unknown as NonNullable<MagiConfig["review"]>["safety"],
+      },
     })
 
     expect(result.ok).toBe(false)
-    expect(result.errors).toContain("safety.allowAuthors[1] must be a string")
     expect(result.errors).toContain(
-      "safety.maxChangedFiles must be a non-negative integer",
+      "review.safety.allowAuthors[1] must be a string",
+    )
+    expect(result.errors).toContain(
+      "review.safety.maxChangedFiles must be a non-negative integer",
     )
   })
 
   test("rejects non-object model options", async () => {
     const result = await validateConfig({
       ...config,
-      agents: {
-        ...config.agents,
-        reviewers: [
+      review: {
+        ...config.review,
+        agents: [
           { account: "bot-a", model: "openai/gpt", options: "high" },
           { account: "bot-b", model: "openai/gpt" },
           { account: "bot-c", model: "openai/gpt" },
-        ] as MagiConfig["agents"]["reviewers"],
+        ] as NonNullable<MagiConfig["review"]>["agents"],
       },
     })
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "agents.reviewers[0].options must be an object",
+      "review.agents[0].options must be an object",
     )
   })
 
@@ -279,15 +297,21 @@ describe("validateConfig", () => {
       agents: {
         ...config.agents,
         permissions: { bash: { "*": "deny", "git status*": "allow" } },
-        reviewers: [
+      },
+      review: {
+        ...config.review,
+        agents: [
           {
             ...(reviewers[0] as NonNullable<(typeof reviewers)[number]>),
-            permission: { webfetch: "allow" },
+            permissions: { webfetch: "allow" },
           },
           ...reviewers.slice(1),
         ],
-        editor: config.agents.editor
-          ? { ...config.agents.editor, permission: { edit: "allow" } }
+      },
+      merge: {
+        ...config.merge,
+        editor: config.merge?.editor
+          ? { ...config.merge.editor, permissions: { edit: "allow" } }
           : undefined,
       },
     })
@@ -301,15 +325,20 @@ describe("validateConfig", () => {
       ...config,
       agents: {
         ...config.agents,
-        permissions: { bash: { "git status*": "yes" } },
-        reviewers: [
+        permissions: {
+          bash: { "git status*": "yes" },
+        } as unknown as PermissionConfig,
+      },
+      review: {
+        ...config.review,
+        agents: [
           {
             ...(reviewers[0] as NonNullable<(typeof reviewers)[number]>),
-            permission: { webfetch: "maybe" },
+            permissions: { webfetch: "maybe" },
           },
           ...reviewers.slice(1),
         ],
-      } as unknown as MagiConfig["agents"],
+      } as unknown as MagiConfig["review"],
     })
 
     expect(result.ok).toBe(false)
@@ -317,16 +346,16 @@ describe("validateConfig", () => {
       "agents.permissions.bash.git status* must be allow, ask, or deny",
     )
     expect(result.errors).toContain(
-      "agents.reviewers[0].permission.webfetch must be allow, ask, deny, or an object",
+      "review.agents[0].permissions.webfetch must be allow, ask, deny, or an object",
     )
   })
 
   test("rejects model IDs without provider", async () => {
     const result = await validateConfig({
       ...config,
-      agents: {
-        ...config.agents,
-        reviewers: [
+      review: {
+        ...config.review,
+        agents: [
           { account: "bot-a", model: "gpt" },
           { account: "bot-b", model: "openai/gpt" },
           { account: "bot-c", model: "openai/gpt" },
@@ -336,7 +365,7 @@ describe("validateConfig", () => {
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "agents.reviewers[0].model must be a full OpenCode model ID in provider/model form",
+      "review.agents[0].model must be a full OpenCode model ID in provider/model form",
     )
   })
 
@@ -350,10 +379,10 @@ describe("validateConfig", () => {
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "agents.reviewers[2].model uses unknown OpenCode model: openai/gpt",
+      "review.agents[2].model uses unknown OpenCode model: openai/gpt",
     )
     expect(result.errors).toContain(
-      "agents.editor.model uses unknown OpenCode model: openai/gpt",
+      "merge.editor.model uses unknown OpenCode model: openai/gpt",
     )
   })
 

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -1,4 +1,5 @@
 import type {
+  EditorConfig,
   Exec,
   MagiConfig,
   PermissionConfig,
@@ -36,25 +37,20 @@ const validateSchema = AJV.compile(schema)
 const CONFIG_KEYS = new Set([
   "$schema",
   "agents",
-  "automation",
   "clear",
-  "checks",
-  "concurrency",
   "github",
   "language",
   "merge",
   "output",
-  "prompts",
-  "safety",
-  "worktree",
+  "review",
 ])
-const AGENTS_KEYS = new Set(["editor", "permissions", "reviewers"])
+const AGENTS_KEYS = new Set(["permissions"])
 const REVIEWER_KEYS = new Set([
   "account",
   "id",
   "model",
   "options",
-  "permission",
+  "permissions",
   "persona",
 ])
 const EDITOR_KEYS = new Set([
@@ -62,50 +58,60 @@ const EDITOR_KEYS = new Set([
   "author",
   "model",
   "options",
-  "permission",
+  "permissions",
   "persona",
 ])
 const AUTHOR_KEYS = new Set(["email", "name"])
 const GITHUB_KEYS = new Set(["apiRetryAttempts", "host", "owner", "repo"])
+const REVIEW_KEYS = new Set([
+  "agents",
+  "automation",
+  "checks",
+  "concurrency",
+  "merge",
+  "output",
+  "prompts",
+  "safety",
+  "worktree",
+])
 const MERGE_KEYS = new Set([
+  "automation",
+  "checks",
+  "editor",
+  "maxThreadResolutionCycles",
+  "prompts",
+])
+const REVIEW_MERGE_KEYS = new Set([
   "approvalPolicy",
   "auto",
   "deleteBranch",
-  "maxThreadResolutionCycles",
-  "mergeQueue",
   "method",
+  "queue",
 ])
-const CHECKS_KEYS = new Set([
-  "exclude",
-  "retryFailedJobs",
-  "waitAfterEdit",
-  "waitBeforeReview",
-])
+const REVIEW_CHECKS_KEYS = new Set(["exclude", "retryFailedJobs", "wait"])
+const MERGE_CHECKS_KEYS = new Set(["wait"])
 const AUTOMATION_KEYS = new Set(["close", "merge"])
 const CLEAR_KEYS = new Set(["branch", "output", "session", "worktree"])
 const CONCURRENCY_KEYS = new Set(["reviewers", "runs"])
-const OUTPUT_KEYS = new Set(["dirs", "repairAttempts"])
-const OUTPUT_DIR_KEYS = new Set(["pr"])
-const WORKTREE_KEYS = new Set(["dirs"])
-const WORKTREE_DIR_KEYS = new Set(["pr"])
+const OUTPUT_KEYS = new Set(["repairAttempts"])
 const SAFETY_KEYS = new Set([
   "allowAuthors",
   "blockedPaths",
   "maxChangedFiles",
   "requiredLabels",
 ])
-const PROMPT_KEYS = new Set([
+const REVIEW_PROMPT_KEYS = new Set([
   "ciClassification",
-  "ciClassificationAfterEdit",
   "closeReconsideration",
-  "edit",
-  "editGuidelines",
   "findingValidation",
-  "report",
   "rereview",
-  "rereviewCloseReconsideration",
   "review",
   "reviewGuidelines",
+])
+const MERGE_PROMPT_KEYS = new Set([
+  "ciClassification",
+  "edit",
+  "editGuidelines",
 ])
 
 function githubHost(config: MagiConfig): string {
@@ -279,8 +285,8 @@ function validateReviewerList(
     if (reviewer.options != null && !isPlainObject(reviewer.options))
       errors.push(`${path}[${index}].options must be an object`)
     validatePermissionConfig(
-      reviewer.permission,
-      `${path}[${index}].permission`,
+      reviewer.permissions,
+      `${path}[${index}].permissions`,
       errors,
     )
 
@@ -317,11 +323,57 @@ function validateResolvedReviewers(
   }
 }
 
+function validateEditor(
+  editor: EditorConfig | undefined,
+  path: string,
+  errors: string[],
+  catalog?: ModelCatalog,
+): void {
+  if (!editor) return
+  if (!isPlainObject(editor)) {
+    errors.push(`${path} must be an object`)
+    return
+  }
+
+  if (!editor.model) errors.push(`${path}.model is required`)
+  validateKnownKeys(editor, path, EDITOR_KEYS, errors)
+  validateString(editor.model, `${path}.model`, errors)
+  validateString(editor.account, `${path}.account`, errors)
+  validateString(editor.persona, `${path}.persona`, errors)
+  validateModel(editor.model, `${path}.model`, errors, catalog)
+  if (!editor.account) errors.push(`${path}.account is required`)
+  if (editor.options != null && !isPlainObject(editor.options)) {
+    errors.push(`${path}.options must be an object`)
+  }
+  validatePermissionConfig(editor.permissions, `${path}.permissions`, errors)
+  const author = editor.author
+  if (!author || !isPlainObject(author)) {
+    if (author != null) errors.push(`${path}.author must be an object`)
+    errors.push(`${path}.author.name is required`)
+    errors.push(`${path}.author.email is required`)
+  } else {
+    validateKnownKeys(author, `${path}.author`, AUTHOR_KEYS, errors)
+    if (!author.name) {
+      errors.push(`${path}.author.name is required`)
+    } else if (typeof author.name !== "string") {
+      errors.push(`${path}.author.name must be a string`)
+    }
+
+    if (!author.email) {
+      errors.push(`${path}.author.email is required`)
+    } else if (typeof author.email !== "string") {
+      errors.push(`${path}.author.email must be a string`)
+    }
+  }
+}
+
 function validateMerge(
   config: MagiConfig,
   errors: string[],
   options: ValidationOptions,
 ): void {
+  const merge = config.merge
+
   if (options.requireGithub ?? true) {
     if (!config.github?.owner) errors.push("github.owner is required")
     if (!config.github?.repo) errors.push("github.repo is required")
@@ -336,15 +388,6 @@ function validateMerge(
     errors.push("github must be an object")
   }
 
-  if (config.merge != null && !isPlainObject(config.merge)) {
-    errors.push("merge must be an object")
-  }
-
-  validateKnownKeys(config.merge, "merge", MERGE_KEYS, errors)
-  validateBoolean(config.merge?.auto, "merge.auto", errors)
-  validateBoolean(config.merge?.deleteBranch, "merge.deleteBranch", errors)
-  validateBoolean(config.merge?.mergeQueue, "merge.mergeQueue", errors)
-
   if (
     config.github?.apiRetryAttempts != null &&
     (typeof config.github.apiRetryAttempts !== "number" ||
@@ -354,82 +397,106 @@ function validateMerge(
     errors.push("github.apiRetryAttempts must be a non-negative integer")
   }
 
-  if (
-    config.merge?.method != null &&
-    (typeof config.merge.method !== "string" ||
-      !["merge", "rebase", "squash"].includes(config.merge.method))
-  ) {
-    errors.push("merge.method must be merge, squash, or rebase")
+  if (merge != null && !isPlainObject(merge)) {
+    errors.push("merge must be an object")
   }
 
-  if (
-    config.merge?.approvalPolicy != null &&
-    (typeof config.merge.approvalPolicy !== "string" ||
-      !["majority", "unanimous"].includes(config.merge.approvalPolicy))
-  ) {
-    errors.push("merge.approvalPolicy must be majority or unanimous")
-  }
+  validateKnownKeys(merge, "merge", MERGE_KEYS, errors)
+  validateBooleanObject(
+    merge?.automation,
+    "merge.automation",
+    AUTOMATION_KEYS,
+    errors,
+  )
+  const checks = merge?.checks as { wait?: unknown } | undefined
+  validateKnownKeys(checks, "merge.checks", MERGE_CHECKS_KEYS, errors)
+  validateBoolean(checks?.wait, "merge.checks.wait", errors)
+  validateEditor(
+    merge?.editor as EditorConfig | undefined,
+    "merge.editor",
+    errors,
+    options.modelCatalog,
+  )
 
   if (
-    config.merge?.maxThreadResolutionCycles != null &&
-    (typeof config.merge.maxThreadResolutionCycles !== "number" ||
-      !Number.isInteger(config.merge.maxThreadResolutionCycles) ||
-      config.merge.maxThreadResolutionCycles < 0)
+    merge?.maxThreadResolutionCycles != null &&
+    (typeof merge.maxThreadResolutionCycles !== "number" ||
+      !Number.isInteger(merge.maxThreadResolutionCycles) ||
+      merge.maxThreadResolutionCycles < 0)
   ) {
     errors.push(
       "merge.maxThreadResolutionCycles must be a non-negative integer",
     )
   }
+
+  if (options.requireEditor && !merge?.editor)
+    errors.push("merge.editor is required")
+}
+
+function validateReviewMerge(config: MagiConfig, errors: string[]): void {
+  const merge = config.review?.merge
+  if (merge != null && !isPlainObject(merge)) {
+    errors.push("review.merge must be an object")
+  }
+
+  validateKnownKeys(merge, "review.merge", REVIEW_MERGE_KEYS, errors)
+  validateBoolean(merge?.auto, "review.merge.auto", errors)
+  validateBoolean(merge?.deleteBranch, "review.merge.deleteBranch", errors)
+  validateBoolean(merge?.queue, "review.merge.queue", errors)
+
+  if (
+    merge?.method != null &&
+    (typeof merge.method !== "string" ||
+      !["merge", "rebase", "squash"].includes(merge.method))
+  ) {
+    errors.push("review.merge.method must be merge, squash, or rebase")
+  }
+
+  if (
+    merge?.approvalPolicy != null &&
+    (typeof merge.approvalPolicy !== "string" ||
+      !["majority", "unanimous"].includes(merge.approvalPolicy))
+  ) {
+    errors.push("review.merge.approvalPolicy must be majority or unanimous")
+  }
 }
 
 function validateConcurrency(config: MagiConfig, errors: string[]): void {
-  if (config.concurrency != null && !isPlainObject(config.concurrency)) {
-    errors.push("concurrency must be an object")
+  const concurrency = config.review?.concurrency
+  if (concurrency != null && !isPlainObject(concurrency)) {
+    errors.push("review.concurrency must be an object")
   }
 
-  validateKnownKeys(config.concurrency, "concurrency", CONCURRENCY_KEYS, errors)
+  validateKnownKeys(concurrency, "review.concurrency", CONCURRENCY_KEYS, errors)
 
-  if (config.concurrency?.runs != null) {
+  if (concurrency?.runs != null) {
     if (
-      typeof config.concurrency.runs !== "number" ||
-      !Number.isInteger(config.concurrency.runs) ||
-      config.concurrency.runs < 1
+      typeof concurrency.runs !== "number" ||
+      !Number.isInteger(concurrency.runs) ||
+      concurrency.runs < 1
     ) {
-      errors.push("concurrency.runs must be a positive integer")
+      errors.push("review.concurrency.runs must be a positive integer")
     }
   }
 
-  if (config.concurrency?.reviewers != null) {
+  if (concurrency?.reviewers != null) {
     if (
-      typeof config.concurrency.reviewers !== "number" ||
-      !Number.isInteger(config.concurrency.reviewers) ||
-      config.concurrency.reviewers < 1
+      typeof concurrency.reviewers !== "number" ||
+      !Number.isInteger(concurrency.reviewers) ||
+      concurrency.reviewers < 1
     ) {
-      errors.push("concurrency.reviewers must be a positive integer")
+      errors.push("review.concurrency.reviewers must be a positive integer")
     }
   }
 }
 
 function validateAutomation(config: MagiConfig, errors: string[]): void {
-  if (config.automation != null && !isPlainObject(config.automation)) {
-    errors.push("automation must be an object")
-  }
-
-  validateKnownKeys(config.automation, "automation", AUTOMATION_KEYS, errors)
-
-  if (
-    config.automation?.merge != null &&
-    typeof config.automation.merge !== "boolean"
-  ) {
-    errors.push("automation.merge must be a boolean")
-  }
-
-  if (
-    config.automation?.close != null &&
-    typeof config.automation.close !== "boolean"
-  ) {
-    errors.push("automation.close must be a boolean")
-  }
+  validateBooleanObject(
+    config.review?.automation,
+    "review.automation",
+    AUTOMATION_KEYS,
+    errors,
+  )
 }
 
 function validateClear(config: MagiConfig, errors: string[]): void {
@@ -437,44 +504,35 @@ function validateClear(config: MagiConfig, errors: string[]): void {
 }
 
 function validateChecks(config: MagiConfig, errors: string[]): void {
-  if (config.checks != null && !isPlainObject(config.checks)) {
-    errors.push("checks must be an object")
+  const checks = config.review?.checks
+  if (checks != null && !isPlainObject(checks)) {
+    errors.push("review.checks must be an object")
   }
 
-  validateKnownKeys(config.checks, "checks", CHECKS_KEYS, errors)
+  validateKnownKeys(checks, "review.checks", REVIEW_CHECKS_KEYS, errors)
 
-  if (config.checks?.exclude != null) {
-    if (!Array.isArray(config.checks.exclude)) {
-      errors.push("checks.exclude must be an array")
+  if (checks?.exclude != null) {
+    if (!Array.isArray(checks.exclude)) {
+      errors.push("review.checks.exclude must be an array")
     } else {
-      config.checks.exclude.forEach((item, index) => {
+      checks.exclude.forEach((item, index) => {
         if (typeof item !== "string")
-          errors.push(`checks.exclude[${index}] must be a string`)
+          errors.push(`review.checks.exclude[${index}] must be a string`)
       })
     }
   }
 
-  if (
-    config.checks?.waitBeforeReview != null &&
-    typeof config.checks.waitBeforeReview !== "boolean"
-  ) {
-    errors.push("checks.waitBeforeReview must be a boolean")
+  if (checks?.wait != null && typeof checks.wait !== "boolean") {
+    errors.push("review.checks.wait must be a boolean")
   }
 
   if (
-    config.checks?.waitAfterEdit != null &&
-    typeof config.checks.waitAfterEdit !== "boolean"
+    checks?.retryFailedJobs != null &&
+    (typeof checks.retryFailedJobs !== "number" ||
+      !Number.isInteger(checks.retryFailedJobs) ||
+      checks.retryFailedJobs < 0)
   ) {
-    errors.push("checks.waitAfterEdit must be a boolean")
-  }
-
-  if (
-    config.checks?.retryFailedJobs != null &&
-    (typeof config.checks.retryFailedJobs !== "number" ||
-      !Number.isInteger(config.checks.retryFailedJobs) ||
-      config.checks.retryFailedJobs < 0)
-  ) {
-    errors.push("checks.retryFailedJobs must be a non-negative integer")
+    errors.push("review.checks.retryFailedJobs must be a non-negative integer")
   }
 }
 
@@ -496,34 +554,54 @@ function validateStringArray(
 }
 
 function validateSafety(config: MagiConfig, errors: string[]): void {
-  if (config.safety != null && !isPlainObject(config.safety)) {
-    errors.push("safety must be an object")
+  const safety = config.review?.safety
+  if (safety != null && !isPlainObject(safety)) {
+    errors.push("review.safety must be an object")
   }
 
-  validateKnownKeys(config.safety, "safety", SAFETY_KEYS, errors)
+  validateKnownKeys(safety, "review.safety", SAFETY_KEYS, errors)
   validateStringArray(
-    config.safety?.allowAuthors,
-    "safety.allowAuthors",
+    safety?.allowAuthors,
+    "review.safety.allowAuthors",
     errors,
   )
   validateStringArray(
-    config.safety?.blockedPaths,
-    "safety.blockedPaths",
+    safety?.blockedPaths,
+    "review.safety.blockedPaths",
     errors,
   )
   validateStringArray(
-    config.safety?.requiredLabels,
-    "safety.requiredLabels",
+    safety?.requiredLabels,
+    "review.safety.requiredLabels",
     errors,
   )
 
   if (
-    config.safety?.maxChangedFiles != null &&
-    (typeof config.safety.maxChangedFiles !== "number" ||
-      !Number.isInteger(config.safety.maxChangedFiles) ||
-      config.safety.maxChangedFiles < 0)
+    safety?.maxChangedFiles != null &&
+    (typeof safety.maxChangedFiles !== "number" ||
+      !Number.isInteger(safety.maxChangedFiles) ||
+      safety.maxChangedFiles < 0)
   ) {
-    errors.push("safety.maxChangedFiles must be a non-negative integer")
+    errors.push("review.safety.maxChangedFiles must be a non-negative integer")
+  }
+}
+
+function validatePromptObject(
+  prompts: unknown,
+  path: string,
+  keys: Set<string>,
+  errors: string[],
+): void {
+  if (prompts == null) return
+  if (!isPlainObject(prompts)) {
+    errors.push(`${path} must be an object`)
+    return
+  }
+
+  validateKnownKeys(prompts, path, keys, errors)
+  for (const [key, value] of Object.entries(prompts)) {
+    if (typeof value !== "string")
+      errors.push(`${path}.${key} must be a string`)
   }
 }
 
@@ -532,20 +610,31 @@ async function validatePrompts(
   errors: string[],
   directory?: string,
 ): Promise<void> {
-  if (config.prompts == null) return
-  if (!isPlainObject(config.prompts)) {
-    errors.push("prompts must be an object")
-    return
-  }
+  validatePromptObject(
+    config.review?.prompts,
+    "review.prompts",
+    REVIEW_PROMPT_KEYS,
+    errors,
+  )
+  validatePromptObject(
+    config.merge?.prompts,
+    "merge.prompts",
+    MERGE_PROMPT_KEYS,
+    errors,
+  )
 
-  validateKnownKeys(config.prompts, "prompts", PROMPT_KEYS, errors)
+  const promptEntries = [
+    ...Object.entries(config.review?.prompts ?? {}).map(
+      ([key, value]) => [`review.prompts.${key}`, value] as const,
+    ),
+    ...Object.entries(config.merge?.prompts ?? {}).map(
+      ([key, value]) => [`merge.prompts.${key}`, value] as const,
+    ),
+  ]
 
   await Promise.all(
-    Object.entries(config.prompts).map(async ([key, value]) => {
-      if (typeof value !== "string") {
-        errors.push(`prompts.${key} must be a string`)
-        return
-      }
+    promptEntries.map(async ([path, value]) => {
+      if (typeof value !== "string") return
 
       if (!directory) return
 
@@ -554,7 +643,7 @@ async function validatePrompts(
       try {
         await access(fullPath, constants.R_OK)
       } catch {
-        errors.push(`prompts.${key} file is not readable: ${value}`)
+        errors.push(`${path} file is not readable: ${value}`)
       }
     }),
   )
@@ -566,7 +655,7 @@ async function validateAuth(
   errors: string[],
 ): Promise<void> {
   const accounts = new Set<string>()
-  const agents = resolveAgents(config.agents)
+  const agents = resolveAgents(config)
 
   for (const reviewer of agents.reviewers) accounts.add(reviewer.account)
   if (agents.editor) accounts.add(agents.editor.account)
@@ -609,7 +698,7 @@ async function validateRepositoryPermissions(
 ): Promise<void> {
   if (!config.github?.owner || !config.github.repo) return
 
-  const agents = resolveAgents(config.agents)
+  const agents = resolveAgents(config)
 
   await Promise.all(
     agents.reviewers.map(async (reviewer) => {
@@ -670,98 +759,43 @@ export async function validateConfig(
   validateString(config.$schema, "$schema", errors)
   validateString(config.language, "language", errors)
 
-  if (!config.agents) {
-    errors.push("agents is required")
+  if (config.agents != null && !isPlainObject(config.agents)) {
+    errors.push("agents must be an object")
   } else {
-    if (!isPlainObject(config.agents)) {
-      errors.push("agents must be an object")
-    } else {
-      validateKnownKeys(config.agents, "agents", AGENTS_KEYS, errors)
-    }
+    validateKnownKeys(config.agents, "agents", AGENTS_KEYS, errors)
     validatePermissionConfig(
-      config.agents.permissions,
+      config.agents?.permissions as PermissionConfig | undefined,
       "agents.permissions",
       errors,
     )
-    if (!config.agents.reviewers) errors.push("agents.reviewers is required")
+  }
+
+  if (!config.review) {
+    errors.push("review is required")
+  } else {
+    if (!isPlainObject(config.review)) {
+      errors.push("review must be an object")
+    } else {
+      validateKnownKeys(config.review, "review", REVIEW_KEYS, errors)
+    }
+    if (!config.review.agents) errors.push("review.agents is required")
     validateReviewerList(
-      config.agents.reviewers,
-      "agents.reviewers",
+      config.review.agents as ReviewerConfig[] | undefined,
+      "review.agents",
       errors,
       options.modelCatalog,
     )
-    if (options.requireEditor && !config.agents.editor)
-      errors.push("agents.editor is required")
-    if (config.agents.editor) {
-      if (!config.agents.editor.model)
-        errors.push("agents.editor.model is required")
-      validateKnownKeys(
-        config.agents.editor,
-        "agents.editor",
-        EDITOR_KEYS,
-        errors,
-      )
-      validateString(config.agents.editor.model, "agents.editor.model", errors)
-      validateString(
-        config.agents.editor.account,
-        "agents.editor.account",
-        errors,
-      )
-      validateString(
-        config.agents.editor.persona,
-        "agents.editor.persona",
-        errors,
-      )
-      validateModel(
-        config.agents.editor.model,
-        "agents.editor.model",
-        errors,
-        options.modelCatalog,
-      )
-      if (!config.agents.editor.account)
-        errors.push("agents.editor.account is required")
-      if (
-        config.agents.editor.options != null &&
-        !isPlainObject(config.agents.editor.options)
-      ) {
-        errors.push("agents.editor.options must be an object")
-      }
-      validatePermissionConfig(
-        config.agents.editor.permission,
-        "agents.editor.permission",
-        errors,
-      )
-      const author = config.agents.editor.author
-      if (!author || !isPlainObject(author)) {
-        if (author != null)
-          errors.push("agents.editor.author must be an object")
-        errors.push("agents.editor.author.name is required")
-        errors.push("agents.editor.author.email is required")
-      } else {
-        validateKnownKeys(author, "agents.editor.author", AUTHOR_KEYS, errors)
-        if (!author.name) {
-          errors.push("agents.editor.author.name is required")
-        } else if (typeof author.name !== "string") {
-          errors.push("agents.editor.author.name must be a string")
-        }
-
-        if (!author.email) {
-          errors.push("agents.editor.author.email is required")
-        } else if (typeof author.email !== "string") {
-          errors.push("agents.editor.author.email must be a string")
-        }
-      }
-    }
-    if (Array.isArray(config.agents.reviewers)) {
+    if (Array.isArray(config.review.agents)) {
       validateResolvedReviewers(
-        resolveAgents(config.agents).reviewers,
-        "agents.resolvedReviewers",
+        resolveAgents(config).reviewers,
+        "review.resolvedAgents",
         errors,
       )
     }
   }
 
   validateMerge(config, errors, options)
+  validateReviewMerge(config, errors)
   validateAutomation(config, errors)
   validateClear(config, errors)
   validateChecks(config, errors)
@@ -785,51 +819,8 @@ export async function validateConfig(
     }
   }
 
-  if (config.output?.dirs != null) {
-    if (!isPlainObject(config.output.dirs)) {
-      errors.push("output.dirs must be an object")
-    } else {
-      validateKnownKeys(
-        config.output.dirs,
-        "output.dirs",
-        OUTPUT_DIR_KEYS,
-        errors,
-      )
-      const dirs = config.output.dirs as Record<string, unknown>
-      for (const key of OUTPUT_DIR_KEYS) {
-        const value = dirs[key]
-        if (value != null && typeof value !== "string") {
-          errors.push(`output.dirs.${key} must be a string`)
-        }
-      }
-    }
-  }
-
-  if (config.worktree != null && !isPlainObject(config.worktree)) {
-    errors.push("worktree must be an object")
-  }
-
-  validateKnownKeys(config.worktree, "worktree", WORKTREE_KEYS, errors)
-
-  if (config.worktree?.dirs != null) {
-    if (!isPlainObject(config.worktree.dirs)) {
-      errors.push("worktree.dirs must be an object")
-    } else {
-      validateKnownKeys(
-        config.worktree.dirs,
-        "worktree.dirs",
-        WORKTREE_DIR_KEYS,
-        errors,
-      )
-      const dirs = config.worktree.dirs as Record<string, unknown>
-      for (const key of WORKTREE_DIR_KEYS) {
-        const value = dirs[key]
-        if (value != null && typeof value !== "string") {
-          errors.push(`worktree.dirs.${key} must be a string`)
-        }
-      }
-    }
-  }
+  validateString(config.review?.output, "review.output", errors)
+  validateString(config.review?.worktree, "review.worktree", errors)
 
   if (options.checkAuth && !errors.length) {
     if (!options.exec) {

--- a/src/config/worktree.ts
+++ b/src/config/worktree.ts
@@ -1,4 +1,4 @@
-import type { WorktreeConfig } from "../types"
+import type { MagiConfig } from "../types"
 import { isAbsolute, join } from "node:path"
 
 export type WorktreeKind = "pr"
@@ -13,18 +13,18 @@ function resolvePath(directory: string, path: string): string {
 
 export function worktreeBaseDir(
   directory: string,
-  config: { worktree?: WorktreeConfig },
+  config: MagiConfig,
   kind: WorktreeKind,
 ): string {
   return resolvePath(
     directory,
-    config.worktree?.dirs?.[kind] ?? DEFAULT_WORKTREE_DIRS[kind],
+    config.review?.worktree ?? DEFAULT_WORKTREE_DIRS[kind],
   )
 }
 
 export function worktreeBaseDirs(
   directory: string,
-  config: { worktree?: WorktreeConfig } = {},
+  config: MagiConfig = {},
 ): string[] {
   return [worktreeBaseDir(directory, config, "pr")]
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -87,8 +87,8 @@ describe("magi_validate", () => {
     const validateMagiConfigFiles = await loadValidateMagiConfigFiles()
 
     await writeConfig(globalPath, {
-      agents: {
-        reviewers: [
+      review: {
+        agents: [
           { account: "bot-a", model: "openai/gpt" },
           { account: "bot-b", model: "openai/gpt" },
           { account: "bot-c", model: "openai/gpt" },
@@ -121,8 +121,8 @@ describe("magi_validate", () => {
     const validateMagiConfigFiles = await loadValidateMagiConfigFiles()
 
     await writeConfig(globalPath, {
-      agents: {
-        reviewers: [
+      review: {
+        agents: [
           { account: "bot-a", model: "openai/gpt" },
           { account: "bot-b", model: "openai/gpt" },
           { account: "bot-c", model: "openai/gpt" },
@@ -171,8 +171,8 @@ describe("magi_validate", () => {
     const validateMagiConfigFiles = await loadValidateMagiConfigFiles()
 
     await writeConfig(globalPath, {
-      agents: {
-        reviewers: [
+      review: {
+        agents: [
           { account: "bot-a", model: "openai/gpt" },
           { account: "bot-b", model: "openai/gpt" },
         ],
@@ -184,7 +184,7 @@ describe("magi_validate", () => {
     })
 
     expect(result).toContain(
-      "agents.reviewers must contain an odd number of reviewers",
+      "review.agents must contain an odd number of reviewers",
     )
     expect(result).not.toContain("github.owner is required")
     expect(result).not.toContain("github.repo is required")

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,8 +288,7 @@ export async function validateMagiConfigFiles(
           )
         : undefined,
       modelCatalog: options.modelCatalog,
-      requireGithub:
-        hasProjectConfig && Boolean(mergedConfig.agents?.reviewers),
+      requireGithub: hasProjectConfig && Boolean(mergedConfig.review?.agents),
     })
 
     loadedFrom = existing.map((status) => status.path).join(", ")

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -970,6 +970,7 @@ export async function runMerge(input: MergeRunInput): Promise<MergeRunResult> {
     ...abortableInput,
     allowAlreadyReviewed: true,
     approvalPolicy: input.repository.merge.approvalPolicy,
+    enableReviewAutomation: false,
     onProgress: (progress) => input.onProgress?.(progress),
     runId: input.runId,
     dryRun: input.dryRun,

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -67,6 +67,7 @@ export interface ReviewRunInput {
   config: MagiConfig
   directory: string
   dryRun?: boolean
+  enableReviewAutomation?: boolean
   exec: Exec
   onProgress?: (progress: ReviewRunProgress) => void | Promise<void>
   pr: number
@@ -1283,7 +1284,12 @@ export async function runReview(
     }
 
     const automationAccount = input.repository.agents.reviewers[0]?.account
-    if (verdict === "MERGE" && input.repository.reviewAutomation?.merge) {
+    const enableReviewAutomation = input.enableReviewAutomation ?? true
+    if (
+      enableReviewAutomation &&
+      verdict === "MERGE" &&
+      input.repository.reviewAutomation?.merge
+    ) {
       await input.onProgress?.({ phase: "merging PR", type: "phase" })
       posted.automation = hasBlockingCiReports(ciReports)
         ? "skipped: unresolved CI"
@@ -1298,7 +1304,11 @@ export async function runReview(
               )
             : "skipped: no review automation account"
     }
-    if (verdict === "CLOSE" && input.repository.reviewAutomation?.close) {
+    if (
+      enableReviewAutomation &&
+      verdict === "CLOSE" &&
+      input.repository.reviewAutomation?.close
+    ) {
       await input.onProgress?.({ phase: "closing PR", type: "phase" })
       posted.automation = input.dryRun
         ? "dry-run:would-close"

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -15,6 +15,8 @@ import {
   fetchPullRequestCommits,
   fetchPullRequestReviews,
   fetchUnresolvedThreads,
+  closePullRequest,
+  mergePullRequest,
   postApproval,
   postChangesRequested,
   postCloseComment,
@@ -321,6 +323,13 @@ function reviewStateToVerdict(
   if (state === "CHANGES_REQUESTED") return "CHANGES_REQUESTED"
 
   return "CLOSE"
+}
+
+function hasBlockingCiReports(reports: CheckWaitReport[]): boolean {
+  return reports.some(
+    (report) =>
+      report.scopeInside.length || report.scopeOutsideUnresolved.length,
+  )
 }
 
 function previousReviewText(review: PullRequestReview): string {
@@ -1271,6 +1280,36 @@ export async function runReview(
           ]),
         ),
       ),
+    }
+
+    const automationAccount = input.repository.agents.reviewers[0]?.account
+    if (verdict === "MERGE" && input.repository.reviewAutomation?.merge) {
+      await input.onProgress?.({ phase: "merging PR", type: "phase" })
+      posted.automation = hasBlockingCiReports(ciReports)
+        ? "skipped: unresolved CI"
+        : input.dryRun
+          ? "dry-run:would-merge"
+          : automationAccount
+            ? await mergePullRequest(
+                input.exec,
+                input.repository,
+                input.pr,
+                automationAccount,
+              )
+            : "skipped: no review automation account"
+    }
+    if (verdict === "CLOSE" && input.repository.reviewAutomation?.close) {
+      await input.onProgress?.({ phase: "closing PR", type: "phase" })
+      posted.automation = input.dryRun
+        ? "dry-run:would-close"
+        : automationAccount
+          ? await closePullRequest(
+              input.exec,
+              input.repository,
+              input.pr,
+              automationAccount,
+            )
+          : "skipped: no review automation account"
     }
 
     await writeFile(

--- a/src/prompts/compose.ts
+++ b/src/prompts/compose.ts
@@ -16,7 +16,6 @@ import {
 export interface ReviewPromptInput {
   baseSha: string
   ciFailureContext?: string
-  ciFailureLogs?: string
   directory: string
   headSha: string
   pr: number
@@ -26,7 +25,6 @@ export interface ReviewPromptInput {
 }
 
 export interface RereviewPromptInput extends ReviewPromptInput {
-  ciFailureLogs?: string
   includeReviewGuidelines?: boolean
   includeSessionContext?: boolean
   previousReview?: string
@@ -141,18 +139,13 @@ function repositoryValues(
 }
 
 function reviewValues(input: ReviewPromptInput): Record<string, string> {
-  const ciFailureContext =
-    input.ciFailureContext?.trim() ?? input.ciFailureLogs?.trim() ?? ""
+  const ciFailureContext = input.ciFailureContext?.trim() ?? ""
 
   return {
     ...repositoryValues(input.repository),
     baseSha: input.baseSha,
     ciFailureContext,
     ciFailureContextBlock: ciFailureContext
-      ? `<ci_failure_context>\n${ciFailureContext}\n</ci_failure_context>`
-      : "",
-    ciFailureLogs: ciFailureContext,
-    ciFailureLogsBlock: ciFailureContext
       ? `<ci_failure_context>\n${ciFailureContext}\n</ci_failure_context>`
       : "",
     headSha: input.headSha,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface ReviewerConfig {
   id?: string
   model: string
   options?: ModelOptions
-  permission?: PermissionConfig
+  permissions?: PermissionConfig
   persona?: string
 }
 
@@ -35,14 +35,12 @@ export interface EditorConfig {
   }
   model: string
   options?: ModelOptions
-  permission?: PermissionConfig
+  permissions?: PermissionConfig
   persona?: string
 }
 
 export interface AgentsConfig {
-  editor?: EditorConfig
   permissions?: PermissionConfig
-  reviewers?: ReviewerConfig[]
 }
 
 export interface GitHubRepoConfig {
@@ -52,20 +50,22 @@ export interface GitHubRepoConfig {
   repo: string
 }
 
-export interface MergeConfig {
+export interface PullRequestMergeConfig {
   approvalPolicy?: "majority" | "unanimous"
   auto?: boolean
   deleteBranch?: boolean
-  maxThreadResolutionCycles?: number
-  mergeQueue?: boolean
   method?: "merge" | "squash" | "rebase"
+  queue?: boolean
 }
 
-export interface ChecksConfig {
+export interface ReviewChecksConfig {
   exclude?: string[]
   retryFailedJobs?: number
-  waitAfterEdit?: boolean
-  waitBeforeReview?: boolean
+  wait?: boolean
+}
+
+export interface MergeChecksConfig {
+  wait?: boolean
 }
 
 export interface AutomationConfig {
@@ -99,54 +99,75 @@ export interface PromptConfig {
   edit?: string
   editGuidelines?: string
   findingValidation?: string
-  report?: string
   rereview?: string
   rereviewCloseReconsideration?: string
   review?: string
   reviewGuidelines?: string
 }
 
-export interface WorktreeConfig {
-  dirs?: Partial<Record<"pr", string>>
+export interface ReviewPromptConfig {
+  ciClassification?: string
+  closeReconsideration?: string
+  findingValidation?: string
+  rereview?: string
+  review?: string
+  reviewGuidelines?: string
+}
+
+export interface MergePromptConfig {
+  ciClassification?: string
+  edit?: string
+  editGuidelines?: string
 }
 
 export interface RepositoryConfig {
   alias: string
-  checks?: ChecksConfig
   github: GitHubRepoConfig
   language?: string
-  merge?: MergeConfig
-  prompts?: PromptConfig
 }
 
 export interface OutputConfig {
-  dirs?: Partial<Record<"pr", string>>
   repairAttempts?: number
+}
+
+export interface ReviewConfig {
+  agents?: ReviewerConfig[]
+  automation?: AutomationConfig
+  checks?: ReviewChecksConfig
+  concurrency?: ConcurrencyConfig
+  merge?: PullRequestMergeConfig
+  output?: string
+  prompts?: ReviewPromptConfig
+  safety?: SafetyConfig
+  worktree?: string
+}
+
+export interface MergeConfig {
+  automation?: AutomationConfig
+  checks?: MergeChecksConfig
+  editor?: EditorConfig
+  maxThreadResolutionCycles?: number
+  prompts?: MergePromptConfig
 }
 
 export interface MagiConfig {
   $schema?: string
-  agents: AgentsConfig
-  automation?: AutomationConfig
+  agents?: AgentsConfig
   clear?: ClearConfig
-  checks?: ChecksConfig
-  concurrency?: ConcurrencyConfig
   github?: GitHubRepoConfig
   language?: string
   merge?: MergeConfig
   output?: OutputConfig
-  prompts?: PromptConfig
-  safety?: SafetyConfig
-  worktree?: WorktreeConfig
+  review?: ReviewConfig
 }
 
-export interface ResolvedReviewer extends ReviewerConfig {
+export interface ResolvedReviewer extends Omit<ReviewerConfig, "permissions"> {
   index: number
   key: string
   permission: PermissionConfig
 }
 
-export interface ResolvedEditor extends EditorConfig {
+export interface ResolvedEditor extends Omit<EditorConfig, "permissions"> {
   permission: PermissionConfig
 }
 
@@ -158,12 +179,23 @@ export interface ResolvedAgents {
 export interface ResolvedRepository extends RepositoryConfig {
   agents: ResolvedAgents
   automation: Required<AutomationConfig>
-  checks: Required<ChecksConfig>
+  checks: {
+    exclude: string[]
+    retryFailedJobs: number
+    wait?: boolean
+    waitAfterEdit: boolean
+    waitBeforeReview: boolean
+  }
   concurrency: Required<ConcurrencyConfig>
   github: Required<GitHubRepoConfig>
   language?: string
-  merge: Required<MergeConfig>
+  merge: Required<Omit<PullRequestMergeConfig, "queue">> & {
+    maxThreadResolutionCycles: number
+    mergeQueue: boolean
+    queue?: boolean
+  }
   prompts: PromptConfig
+  reviewAutomation?: Required<AutomationConfig>
   safety: Required<Omit<SafetyConfig, "maxChangedFiles">> & {
     maxChangedFiles?: number
   }


### PR DESCRIPTION
Closes #25

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Restructures Magi configuration around review and merge sections, updates schema, docs, tests, and project config, and adds review-command merge and close automation handling.

## Current behavior (updates)

Configuration used legacy top-level sections for agents, prompts, checks, automation, safety, output, and worktree settings, with merge-specific behavior split across older keys.

## New behavior

Configuration is organized under review and merge, uses permissions consistently, removes prompts.report, keeps review and merge automation independent, and documents Global, Project, and Both scopes.

## Is this a breaking change (Yes/No):

Yes. Existing config files must migrate to the new review and merge structure.

## Additional Information

Tests: pnpm test
