### PR TITLE
feat(review): include pull request links in reports

### DIFF
--- a/.changeset/report-pr-links.md
+++ b/.changeset/report-pr-links.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Include pull request links in generated Magi run reports.

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -664,6 +664,7 @@ async function finishMergeRun(
     editorOutputs: reportInput.editorOutputs,
     outputs: reportInput.outputs,
     posted: reportInput.posted,
+    pr: input.pr,
     repository: input.repository,
     status: result.status,
   })
@@ -932,6 +933,7 @@ export async function runMerge(input: MergeRunInput): Promise<MergeRunResult> {
         editorOutputs: [],
         outputs: {},
         posted: {},
+        pr: input.pr,
         repository: input.repository,
         safety,
         status: "safety_blocked",

--- a/src/orchestrator/report.test.ts
+++ b/src/orchestrator/report.test.ts
@@ -11,6 +11,7 @@ const repository = {
       { account: "bot-c", index: 2, key: "gamma", model: "test/model" },
     ],
   },
+  github: { host: "github.test", owner: "o", repo: "r" },
 } as ResolvedRepository
 
 const passingChecks: CheckWaitReport[] = [
@@ -59,9 +60,13 @@ describe("report formatting", () => {
       posted: {
         alpha: "https://github.com/o/r/pull/1#pullrequestreview-1",
       },
+      pr: 29,
       repository,
     })
 
+    expect(report).toContain(
+      "- **Pull Request**: [#29](https://github.test/o/r/pull/29)",
+    )
     expect(report).toContain("- **Check**: Pass")
     expect(report).toContain(
       "- **alpha**: [Changes requested](https://github.com/o/r/pull/1#pullrequestreview-1)",
@@ -111,10 +116,14 @@ describe("report formatting", () => {
         gamma: { findings: [], verdict: "MERGE" },
       },
       posted: {},
+      pr: 29,
       repository,
       status: "ci_unresolved",
     })
 
+    expect(report).toContain(
+      "- **Pull Request**: [#29](https://github.test/o/r/pull/29)",
+    )
     expect(report).toContain("- **Status**: Failed")
     expect(report).toContain("- **Check**: Failure")
     expect(report).toContain("- **TypeScript**: Type error in changed file.")
@@ -146,6 +155,7 @@ describe("report formatting", () => {
         gamma: { findings: [], verdict: "MERGE" },
       },
       posted: {},
+      pr: 29,
       repository,
       status: "changes_unresolved",
     })

--- a/src/orchestrator/report.ts
+++ b/src/orchestrator/report.ts
@@ -27,6 +27,7 @@ export interface ReviewReportInput {
   dryRun?: boolean
   outputs: Record<string, ReviewerOutput>
   posted: Record<string, string>
+  pr: number
   repository: ResolvedRepository
   safety?: SafetyGateResult
 }
@@ -47,6 +48,13 @@ function reportUrl(value: string | undefined): string | undefined {
 
 function linkOrText(text: string, url: string | undefined): string {
   return url ? `[${text}](${url})` : text
+}
+
+function pullRequestLine(input: ReviewReportInput): string {
+  const host = input.repository.github.host || "github.com"
+  const url = `https://${host}/${input.repository.github.owner}/${input.repository.github.repo}/pull/${input.pr}`
+
+  return `- **Pull Request**: [#${input.pr}](${url})`
 }
 
 function formatFinding(finding: Finding): string {
@@ -228,6 +236,7 @@ function editorLines(outputs: EditOutput[] | undefined): string[] {
 
 export function formatReviewReport(input: ReviewReportInput): string {
   return [
+    pullRequestLine(input),
     ...dryRunLines(input.dryRun),
     ...safetyLines(input.safety),
     ...checkLines(input.ciReports),
@@ -237,6 +246,7 @@ export function formatReviewReport(input: ReviewReportInput): string {
 
 export function formatMergeReport(input: MergeReportInput): string {
   return [
+    pullRequestLine(input),
     ...mergeStatusLines(input.status),
     ...dryRunLines(input.dryRun),
     ...safetyLines(input.safety),

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -787,6 +787,7 @@ export async function runReview(
         dryRun: input.dryRun,
         outputs: {},
         posted: {},
+        pr: input.pr,
         repository: input.repository,
         safety,
       })
@@ -1349,6 +1350,7 @@ export async function runReview(
       dryRun: input.dryRun,
       outputs,
       posted,
+      pr: input.pr,
       repository: input.repository,
     })
 


### PR DESCRIPTION
Closes #32

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a pull request Markdown link to generated Magi review and merge reports.

## Current behavior (updates)

Completion notifications include a linked PR reference, but the generated report body starts with status/check/reviewer details and does not identify the PR when read independently.

## New behavior

Generated review and merge reports now begin with a line like:

```md
- **Pull Request**: [#29](https://github.com/owner/repo/pull/29)
```

This applies to normal reports and safety-blocked reports.

## Is this a breaking change (Yes/No):

No

## Additional Information

Targeted tests run:

```sh
pnpm test src/orchestrator/review.test.ts src/orchestrator/merge.test.ts src/orchestrator/report.test.ts
```