### PR TITLE
test(orchestrator): prevent root state output

### DIFF
--- a/.changeset/clean-run-state-tests.md
+++ b/.changeset/clean-run-state-tests.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Prevent run manager tests from writing state files to the repository root.

--- a/.changeset/clean-run-state-tests.md
+++ b/.changeset/clean-run-state-tests.md
@@ -1,5 +1,0 @@
----
-"opencode-magi": patch
----
-
-Prevent run manager tests from writing state files to the repository root.

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -229,10 +229,11 @@ describe("MagiRunManager notifications", () => {
 
   test("notifies reviewer failures", async () => {
     const { manager, prompts } = managerWithPromptCapture()
+    const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
     const state: MagiRunState = {
       command: "review",
       createdAt: "now",
-      outputDir: ".",
+      outputDir: directory,
       parentSessionId: "parent-session",
       phase: "reviewing",
       pr: 7557,
@@ -256,11 +257,15 @@ describe("MagiRunManager notifications", () => {
     }
 
     privateManager.active.set("run", state)
-    await privateManager.applyReviewProgress("run", {
-      error: "Invalid JSON",
-      reviewer: "security",
-      type: "reviewer_failed",
-    })
+    try {
+      await privateManager.applyReviewProgress("run", {
+        error: "Invalid JSON",
+        reviewer: "security",
+        type: "reviewer_failed",
+      })
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
 
     expect(state.reviewers.security.status).toBe("failed")
     expect(prompts).toMatchObject([
@@ -281,6 +286,7 @@ describe("MagiRunManager notifications", () => {
 
   test("notifies editor failures", async () => {
     const { manager, prompts } = managerWithPromptCapture()
+    const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
     const state: MagiRunState = {
       command: "merge",
       createdAt: "now",
@@ -290,7 +296,7 @@ describe("MagiRunManager notifications", () => {
         status: "repairing",
         toolCalls: 0,
       },
-      outputDir: ".",
+      outputDir: directory,
       parentSessionId: "parent-session",
       phase: "editing cycle 1",
       pr: 7557,
@@ -307,11 +313,15 @@ describe("MagiRunManager notifications", () => {
     }
 
     privateManager.active.set("run", state)
-    await privateManager.applyMergeProgress("run", {
-      cycle: 1,
-      error: "Invalid JSON",
-      type: "editor_failed",
-    })
+    try {
+      await privateManager.applyMergeProgress("run", {
+        cycle: 1,
+        error: "Invalid JSON",
+        type: "editor_failed",
+      })
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
 
     expect(state.editor?.status).toBe("failed")
     expect(prompts).toMatchObject([


### PR DESCRIPTION
Closes #34

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update run manager notification tests so persisted test state is written under temporary directories instead of the repository root.

## Current behavior (updates)

Some tests used outputDir: . while exercising progress handlers that persist state, causing pnpm test to leave state.json in the repository root.

## New behavior

Those tests now use mkdtemp-created output directories and clean them up with rm in finally blocks, so pnpm test no longer creates root-level state.json.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validation:

- pnpm test src/orchestrator/run-manager.test.ts
- pnpm test
- Confirmed no state.json exists in the PR worktree root after the full test run.