### PR TITLE
ci(changesets): ignore test-only changes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           git fetch --no-tags --prune --depth=1 origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
 
-          changed_files="$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- src schema.json package.json README.md)"
+          changed_files="$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- src schema.json package.json README.md ":(exclude)src/**/*.test.ts")"
           changeset_files="$(git diff --name-only --diff-filter=A "origin/${{ github.base_ref }}...HEAD" -- ".changeset/*.md")"
 
           if [ -n "$changed_files" ] && [ -z "$changeset_files" ]; then


### PR DESCRIPTION
Closes #37

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update the Quality workflow Changeset job so test-only changes under src/**/*.test.ts do not require a changeset.

## Current behavior (updates)

The Changeset job diffs all files under src and fails PRs that only modify test files, even though repository changeset rules exclude src/**/*.test.ts.

## New behavior

The Changeset job excludes src/**/*.test.ts from changed_files before deciding whether a changeset is required.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validation:

- Ran the updated git diff pathspec locally against PR #36 branch and confirmed src/orchestrator/run-manager.test.ts is excluded.