### PR TITLE
fix(github): avoid merge queue command flags

### DIFF
--- a/.changeset/merge-queue-command-flags.md
+++ b/.changeset/merge-queue-command-flags.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Avoid unsupported merge flags when queueing pull requests through GitHub merge queue.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -11,6 +11,7 @@ import {
   fetchPullRequestSafetyMeta,
   fetchUnresolvedThreads,
   ghHostOption,
+  mergePullRequest,
   postCloseComment,
   pushHead,
   repoSpecifier,
@@ -105,6 +106,46 @@ describe("GitHub command helpers", () => {
       "push 'https://github.com/fork-owner/fork-repo.git' 'HEAD:refs/heads/feature-branch'",
     )
     expect(commands[1]).toContain("credential.helper")
+  })
+
+  test("merges pull requests with configured flags", async () => {
+    const commands: string[] = []
+
+    await mergePullRequest(
+      async (command) => {
+        commands.push(command)
+        if (command.includes("gh auth token")) return "token"
+
+        return ""
+      },
+      repository,
+      7557,
+      "bot-a",
+    )
+
+    expect(commands[1]).toContain("gh pr merge 7557")
+    expect(commands[1]).toContain("--squash --auto --delete-branch")
+  })
+
+  test("queues pull requests without merge method or delete branch flags", async () => {
+    const commands: string[] = []
+
+    await mergePullRequest(
+      async (command) => {
+        commands.push(command)
+        if (command.includes("gh auth token")) return "token"
+
+        return ""
+      },
+      { ...repository, merge: { ...repository.merge, mergeQueue: true } },
+      7557,
+      "bot-a",
+    )
+
+    expect(commands[1]).toContain("gh pr merge 7557")
+    expect(commands[1]).not.toContain("--squash")
+    expect(commands[1]).not.toContain("--auto")
+    expect(commands[1]).not.toContain("--delete-branch")
   })
 
   test("fetches PR head repository metadata", async () => {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -675,9 +675,12 @@ export async function mergePullRequest(
         : "--squash"
   const autoFlag = repository.merge.auto ? " --auto" : ""
   const deleteFlag = repository.merge.deleteBranch ? " --delete-branch" : ""
+  const mergeFlags = repository.merge.mergeQueue
+    ? ""
+    : ` ${methodFlag}${autoFlag}${deleteFlag}`
 
   return exec(
-    `GH_TOKEN=${shellQuote(token)} gh pr merge ${pr} --repo ${shellQuote(repoSpecifier(repository))} ${methodFlag}${autoFlag}${deleteFlag}`,
+    `GH_TOKEN=${shellQuote(token)} gh pr merge ${pr} --repo ${shellQuote(repoSpecifier(repository))}${mergeFlags}`,
   )
 }
 


### PR DESCRIPTION
Closes #40

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Avoid passing merge strategy, auto-merge, and delete-branch flags when `/magi:merge` queues a pull request through GitHub merge queue.

## Current behavior (updates)

Merge queue mode still builds `gh pr merge` with configured merge flags, including the default `--delete-branch`.

## New behavior

When `review.merge.queue` is enabled, opencode-magi runs `gh pr merge` without merge method, `--auto`, or `--delete-branch` flags and lets GitHub CLI handle merge queue behavior.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `../../node_modules/.bin/vitest run src/github/commands.test.ts` from the worktree because the worktree does not contain its own `node_modules`.