### PR TITLE
fix(github): avoid exposing command tokens

### DIFF
--- a/.changeset/redact-command-tokens.md
+++ b/.changeset/redact-command-tokens.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Avoid exposing GitHub tokens in failed command messages and Magi run errors.

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -405,18 +405,18 @@ describe("validateConfig", () => {
   test("checks repository permissions when auth succeeds", async () => {
     const result = await validateConfig(config, {
       checkAuth: true,
-      exec: async (command) => {
+      exec: async (command, options) => {
         if (command.startsWith("gh auth token")) {
           const account = command.match(/--user "([^"]+)"/)?.[1]
           return `${account}-token`
         }
 
         if (command.includes("gh api repos/owner/repo")) {
-          if (command.startsWith('GH_TOKEN="bot-a-token"')) {
+          if (options?.env?.GH_TOKEN === "bot-a-token") {
             return JSON.stringify({ pull: false, push: false })
           }
 
-          if (command.startsWith('GH_TOKEN="bot-c-token"')) {
+          if (options?.env?.GH_TOKEN === "bot-c-token") {
             return JSON.stringify({ pull: true, push: false })
           }
 

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -684,7 +684,8 @@ async function fetchPermissions(
     )
   ).trim()
   const raw = await exec(
-    `GH_TOKEN=${JSON.stringify(token)} gh api${ghHostOption(config)} repos/${config.github?.owner}/${config.github?.repo} --jq .permissions`,
+    `gh api${ghHostOption(config)} repos/${config.github?.owner}/${config.github?.repo} --jq .permissions`,
+    { env: { GH_TOKEN: token } },
   )
 
   return JSON.parse(raw) as { pull?: boolean; push?: boolean }

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -1,4 +1,4 @@
-import type { ResolvedRepository } from "../types"
+import type { Exec, ResolvedRepository } from "../types"
 import { mkdtemp, readFile, rm as removePath } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -11,6 +11,7 @@ import {
   fetchPullRequestSafetyMeta,
   fetchUnresolvedThreads,
   ghHostOption,
+  mergePullRequest,
   postCloseComment,
   pushHead,
   repoSpecifier,
@@ -87,10 +88,12 @@ describe("GitHub command helpers", () => {
 
   test("pushes detached HEAD to the PR head repository", async () => {
     const commands: string[] = []
+    const options: Array<Parameters<Exec>[1]> = []
 
     await pushHead(
-      async (command) => {
+      async (command, option) => {
         commands.push(command)
+        options.push(option)
         if (command.includes("gh auth token")) return "token"
 
         return ""
@@ -104,7 +107,32 @@ describe("GitHub command helpers", () => {
     expect(commands[1]).toContain(
       "push 'https://github.com/fork-owner/fork-repo.git' 'HEAD:refs/heads/feature-branch'",
     )
-    expect(commands[1]).toContain("credential.helper")
+    expect(commands[1]).not.toContain("token")
+    expect(options[1]?.env?.GIT_PASSWORD).toBe("token")
+    expect(options[1]?.env?.GIT_CONFIG_VALUE_1).toContain("$GIT_PASSWORD")
+  })
+
+  test("passes GitHub token through exec env for merges", async () => {
+    const commands: string[] = []
+    const options: Array<Parameters<Exec>[1]> = []
+
+    await mergePullRequest(
+      async (command, option) => {
+        commands.push(command)
+        options.push(option)
+        if (command.includes("gh auth token")) return "token"
+
+        return ""
+      },
+      repository,
+      7557,
+      "bot-a",
+    )
+
+    expect(commands[1]).toContain("gh pr merge 7557")
+    expect(commands[1]).not.toContain("GH_TOKEN")
+    expect(commands[1]).not.toContain("token")
+    expect(options[1]?.env?.GH_TOKEN).toBe("token")
   })
 
   test("fetches PR head repository metadata", async () => {
@@ -137,11 +165,13 @@ describe("GitHub command helpers", () => {
 
   test("posts close comments as PR review comments", async () => {
     const commands: string[] = []
+    const options: Array<Parameters<Exec>[1]> = []
     let payload: unknown
 
     const result = await postCloseComment(
-      async (command) => {
+      async (command, option) => {
         commands.push(command)
+        options.push(option)
         if (command.includes("gh auth token")) return "token"
 
         const input = command.match(/--input '([^']+)'/)?.[1]
@@ -161,6 +191,8 @@ describe("GitHub command helpers", () => {
     )
     expect(commands[1]).toContain("repos/owner/repo/pulls/7557/reviews")
     expect(commands[1]).not.toContain("repos/owner/repo/issues/7557/comments")
+    expect(commands[1]).not.toContain("GH_TOKEN")
+    expect(options[1]?.env?.GH_TOKEN).toBe("token")
     expect(payload).toEqual({
       body: "This PR should be closed.",
       event: "COMMENT",

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -236,6 +236,10 @@ export async function ghToken(
   ).trim()
 }
 
+function ghTokenEnv(token: string): { env: Record<string, string> } {
+  return { env: { GH_TOKEN: token } }
+}
+
 export async function fetchPullRequest(
   exec: Exec,
   repository: ResolvedRepository,
@@ -582,7 +586,8 @@ export async function postApproval(
   const token = await ghToken(exec, repository, account)
 
   return exec(
-    `GH_TOKEN=${shellQuote(token)} gh pr review ${pr} --repo ${shellQuote(repoSpecifier(repository))} --approve`,
+    `gh pr review ${pr} --repo ${shellQuote(repoSpecifier(repository))} --approve`,
+    ghTokenEnv(token),
   )
 }
 
@@ -603,7 +608,8 @@ export async function postCloseComment(
 
   try {
     return await exec(
-      `GH_TOKEN=${shellQuote(token)} gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/pulls/${pr}/reviews --method POST --input ${shellQuote(payloadPath)} --jq .html_url`,
+      `gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/pulls/${pr}/reviews --method POST --input ${shellQuote(payloadPath)} --jq .html_url`,
+      ghTokenEnv(token),
     )
   } finally {
     await rm(payloadPath, { force: true })
@@ -653,7 +659,8 @@ export async function postChangesRequested(
 
   try {
     return await exec(
-      `GH_TOKEN=${shellQuote(token)} gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/pulls/${pr}/reviews --method POST --input ${shellQuote(payloadPath)} --jq .html_url`,
+      `gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/pulls/${pr}/reviews --method POST --input ${shellQuote(payloadPath)} --jq .html_url`,
+      ghTokenEnv(token),
     )
   } finally {
     await rm(payloadPath, { force: true })
@@ -677,7 +684,8 @@ export async function mergePullRequest(
   const deleteFlag = repository.merge.deleteBranch ? " --delete-branch" : ""
 
   return exec(
-    `GH_TOKEN=${shellQuote(token)} gh pr merge ${pr} --repo ${shellQuote(repoSpecifier(repository))} ${methodFlag}${autoFlag}${deleteFlag}`,
+    `gh pr merge ${pr} --repo ${shellQuote(repoSpecifier(repository))} ${methodFlag}${autoFlag}${deleteFlag}`,
+    ghTokenEnv(token),
   )
 }
 
@@ -720,7 +728,8 @@ export async function closePullRequest(
   const token = await ghToken(exec, repository, account)
 
   return exec(
-    `GH_TOKEN=${shellQuote(token)} gh pr close ${pr} --repo ${shellQuote(repoSpecifier(repository))}`,
+    `gh pr close ${pr} --repo ${shellQuote(repoSpecifier(repository))}`,
+    ghTokenEnv(token),
   )
 }
 
@@ -735,8 +744,20 @@ export async function pushHead(
   const url = repositoryGitUrl(repository, head.owner, head.repo)
 
   await exec(
-    `git -c credential.helper= -c credential.helper=${shellQuote(`!f() { echo username=x-access-token; echo password=${token}; }; f`)} push ${shellQuote(url)} ${shellQuote(`HEAD:refs/heads/${head.ref}`)}`,
-    { cwd: worktreePath },
+    `git push ${shellQuote(url)} ${shellQuote(`HEAD:refs/heads/${head.ref}`)}`,
+    {
+      cwd: worktreePath,
+      env: {
+        GIT_CONFIG_COUNT: "2",
+        GIT_CONFIG_KEY_0: "credential.helper",
+        GIT_CONFIG_KEY_1: "credential.helper",
+        GIT_CONFIG_VALUE_0: "",
+        GIT_CONFIG_VALUE_1:
+          "!f() { echo username=x-access-token; echo password=$GIT_PASSWORD; }; f",
+        GIT_PASSWORD: token,
+        GIT_TERMINAL_PROMPT: "0",
+      },
+    },
   )
 }
 
@@ -852,7 +873,8 @@ export async function postReply(
 
   try {
     return await exec(
-      `GH_TOKEN=${shellQuote(token)} gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/pulls/${pr}/comments/${commentId}/replies --method POST --input ${shellQuote(payloadPath)} --jq .html_url`,
+      `gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/pulls/${pr}/comments/${commentId}/replies --method POST --input ${shellQuote(payloadPath)} --jq .html_url`,
+      ghTokenEnv(token),
     )
   } finally {
     await rm(payloadPath, { force: true })
@@ -869,6 +891,7 @@ export async function resolveThread(
   const query = `mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { id } } }`
 
   await exec(
-    `GH_TOKEN=${shellQuote(token)} gh api${ghHostOption(repository)} graphql -f query=${shellQuote(query)} -F threadId=${shellQuote(threadId)}`,
+    `gh api${ghHostOption(repository)} graphql -f query=${shellQuote(query)} -F threadId=${shellQuote(threadId)}`,
+    ghTokenEnv(token),
   )
 }

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -14,7 +14,7 @@ vi.mock("./review", async (importOriginal) => {
   return { ...actual, runReview: runReviewMock }
 })
 
-import { MagiRunManager } from "./run-manager"
+import { MagiRunManager, redactSecrets } from "./run-manager"
 
 describe("MagiRunManager notifications", () => {
   afterEach(() => {
@@ -171,6 +171,15 @@ describe("MagiRunManager notifications", () => {
       await rm(directory, { force: true, recursive: true })
     }
   }
+
+  test("redacts tokens from error text", () => {
+    expect(
+      redactSecrets("Command failed: GH_TOKEN='secret-token' gh pr merge 1"),
+    ).toBe("Command failed: GH_TOKEN=<redacted> gh pr merge 1")
+    expect(redactSecrets("echo password=secret-token; git push")).toBe(
+      "echo password=<redacted>; git push",
+    )
+  })
 
   test("sends synthetic notifications as model-visible replies", async () => {
     let promptInput: unknown

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -150,6 +150,19 @@ function now(): string {
   return new Date().toISOString()
 }
 
+export function redactSecrets(value: string): string {
+  return value
+    .replace(
+      /\b(GH_TOKEN|GITHUB_TOKEN|GH_ENTERPRISE_TOKEN)=('[^']*'|"[^"]*"|\S+)/g,
+      "$1=<redacted>",
+    )
+    .replace(/(password=)([^;'\s]+)/g, "$1<redacted>")
+}
+
+function errorMessage(error: unknown): string {
+  return redactSecrets(error instanceof Error ? error.message : String(error))
+}
+
 function isActiveStatus(status: MagiRunStatus): boolean {
   return (
     status === "blocked" ||
@@ -1381,8 +1394,8 @@ export class MagiRunManager {
 
     if (input.event.type === "session.error") {
       agent.status = "failed"
-      agent.error = JSON.stringify(
-        input.event.properties?.error ?? "session error",
+      agent.error = redactSecrets(
+        JSON.stringify(input.event.properties?.error ?? "session error"),
       )
       markUpdated(true)
       dirty = true
@@ -1793,7 +1806,7 @@ export class MagiRunManager {
     if (progress.type === "ci_classifier_failed") {
       const classifier = state.ciClassifiers?.[progress.reviewer]
       if (classifier) {
-        classifier.error = progress.error
+        classifier.error = redactSecrets(progress.error)
         classifier.status = "failed"
         classifier.lastUpdate = now()
       }
@@ -1850,7 +1863,7 @@ export class MagiRunManager {
       const reviewer = state.reviewers[progress.reviewer]
       if (!reviewer) return
       reviewer.status = "failed"
-      reviewer.error = progress.error
+      reviewer.error = redactSecrets(progress.error)
       reviewer.lastUpdate = now()
     }
 
@@ -1928,7 +1941,7 @@ export class MagiRunManager {
     if (progress.type === "ci_classifier_failed") {
       await this.notify(
         state,
-        `**CI classifier ${progress.reviewer}** failed for ${prMarkdownLink(state)}: ${progress.error}`,
+        `**CI classifier ${progress.reviewer}** failed for ${prMarkdownLink(state)}: ${redactSecrets(progress.error)}`,
       )
     }
 
@@ -1964,7 +1977,7 @@ export class MagiRunManager {
       await this.notify(
         state,
         reviewerFailureText({
-          error: progress.error,
+          error: redactSecrets(progress.error),
           pr: prMarkdownLink(state),
           repairAttempts:
             state.reviewers[progress.reviewer]?.repairAttempts ?? 0,
@@ -2110,7 +2123,7 @@ export class MagiRunManager {
 
     if (progress.type === "editor_failed") {
       editor.status = "failed"
-      editor.error = progress.error
+      editor.error = redactSecrets(progress.error)
       editor.lastUpdate = now()
     }
 
@@ -2158,7 +2171,7 @@ export class MagiRunManager {
       await this.notify(
         state,
         editorFailureText({
-          error: progress.error,
+          error: redactSecrets(progress.error),
           pr: prMarkdownLink(state),
           repairAttempts: state.editor?.repairAttempts ?? 0,
         }),
@@ -2181,7 +2194,7 @@ export class MagiRunManager {
     state.status = "failed"
     state.phase = "failed"
     state.completedAt = now()
-    state.error = error instanceof Error ? error.message : String(error)
+    state.error = errorMessage(error)
     if (
       state.editor?.status === "pending" ||
       state.editor?.status === "running" ||


### PR DESCRIPTION
Closes #39

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Move GitHub tokens out of shell command strings and redact secret-looking values before Magi persists or reports run errors.

## Current behavior (updates)

Commands embed `GH_TOKEN=<token>` or git credential helper passwords directly in the command string. If `child_process.exec` fails, the command can appear in `Error.message` and then in Magi status, output, or notifications.

## New behavior

GitHub CLI calls receive `GH_TOKEN` through `Exec` environment options, git pushes receive the token through environment-backed credential helper configuration, and run-manager error paths redact token assignments and credential passwords before persisting or notifying.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `../../node_modules/.bin/vitest run src/github/commands.test.ts src/config/validate.test.ts src/orchestrator/run-manager.test.ts` from the worktree because the worktree does not contain its own `node_modules`.