### PR TITLE
fix(commands): hide follow-up tool guidance

### DIFF
--- a/.changeset/hide-follow-up-tools.md
+++ b/.changeset/hide-follow-up-tools.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Hide internal Magi follow-up tool names from user-facing guidance.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { beforeEach, describe, expect, test, vi } from "vitest"
-import { parsePrs, parseRunArguments } from "./index"
+import { MagiPlugin, parsePrs, parseRunArguments } from "./index"
 
 const mockState = vi.hoisted(() => ({ home: "" }))
 
@@ -46,6 +46,31 @@ describe("parsePrs", () => {
       dryRun: true,
       prs: [7581],
     })
+  })
+})
+
+describe("tool descriptions", () => {
+  test("marks follow-up tools as assistant-facing", async () => {
+    const plugin = await MagiPlugin({
+      client: { session: {} },
+      directory: ".",
+    } as never)
+    const tools = plugin.tool as Record<string, { description: string }>
+
+    expect(tools.magi_review.description).toContain(
+      "do not tell users to call follow-up tools by name",
+    )
+    expect(tools.magi_merge.description).toContain(
+      "do not tell users to call follow-up tools by name",
+    )
+    for (const name of ["magi_status", "magi_output"]) {
+      expect(tools[name]?.description).toContain(
+        "Assistant-facing follow-up tool.",
+      )
+      expect(tools[name]?.description).toContain(
+        "do not suggest this tool name to users",
+      )
+    }
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ import { MagiRunManager } from "./orchestrator/run-manager"
 const execAsync = promisify(nodeExec)
 const GLOBAL_CONFIG_PATH = join(homedir(), ".config", "opencode", "magi.json")
 const PROJECT_CONFIG_PATH = join(".opencode", "magi.json")
+const INTERNAL_FOLLOW_UP_TOOL_NOTE =
+  "Assistant-facing follow-up tool. Use it yourself when needed; do not suggest this tool name to users."
 
 type ConfigTarget = "global" | "project"
 
@@ -376,8 +378,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
     },
     tool: {
       magi_merge: tool({
-        description:
+        description: [
           "Start background Magi merge runs for one or more GitHub pull requests with configured Magi agents.",
+          "After starting, monitor progress yourself when useful; do not tell users to call follow-up tools by name.",
+        ].join(" "),
         args: {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
@@ -424,8 +428,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         },
       }),
       magi_review: tool({
-        description:
+        description: [
           "Start background Magi review runs for one or more GitHub pull requests and post the reviews.",
+          "After starting, monitor progress yourself when useful; do not tell users to call follow-up tools by name.",
+        ].join(" "),
         args: {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
@@ -471,8 +477,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         },
       }),
       magi_status: tool({
-        description:
+        description: [
           "Show Magi background run status. Optionally filter by runId or PR and wait for completion.",
+          INTERNAL_FOLLOW_UP_TOOL_NOTE,
+        ].join(" "),
         args: {
           runId: tool.schema.string().optional(),
           pr: tool.schema.string().optional(),
@@ -498,8 +506,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         },
       }),
       magi_output: tool({
-        description:
+        description: [
           "Show artifacts and details for a Magi background run by runId or PR, optionally for a single reviewer.",
+          INTERNAL_FOLLOW_UP_TOOL_NOTE,
+        ].join(" "),
         args: {
           runId: tool.schema.string().optional(),
           pr: tool.schema.string().optional(),


### PR DESCRIPTION
Closes #45

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Hide internal Magi follow-up tool names from assistant-facing guidance after review and merge runs start.

## Current behavior (updates)

After /magi:review or /magi:merge starts a background run, assistant responses can mention internal follow-up tool names such as magi_status or magi_output, which is noisy for users.

## New behavior

The review and merge tool descriptions now instruct the assistant to monitor progress itself when useful and avoid telling users to call follow-up tools by name. The status and output tool descriptions are marked as assistant-facing follow-up tools. Slash command templates remain unchanged.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Tested with:

```bash
pnpm exec vitest run src/index.test.ts
```