### PR TITLE
chore(config): tune magi model options

### DIFF
--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -10,17 +10,29 @@
       {
         "id": "Melchior",
         "account": "melchior-magi",
-        "model": "openai/gpt-5.5"
+        "model": "openai/gpt-5.5",
+        "options": {
+          "reasoningEffort": "high"
+        }
       },
       {
         "id": "Balthasar",
         "account": "balthasar-magi",
-        "model": "opencode/deepseek-v4-flash-free"
+        "model": "opencode/deepseek-v4-flash-free",
+        "options": {
+          "reasoningEffort": "high"
+        }
       },
       {
         "id": "Caspar",
         "account": "caspar-magi",
-        "model": "opencode/qwen3.6-plus-free"
+        "model": "opencode/qwen3.6-plus-free",
+        "options": {
+          "thinking": {
+            "type": "enabled",
+            "budgetTokens": 16000
+          }
+        }
       }
     ],
     "merge": {
@@ -34,6 +46,9 @@
     "editor": {
       "account": "hirotomoyamada",
       "model": "openai/gpt-5.5",
+      "options": {
+        "reasoningEffort": "high"
+      },
       "author": {
         "name": "hirotomoyamada",
         "email": "hirotomo.yamada@avap.co.jp"


### PR DESCRIPTION
Closes #50

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Configures provider-specific model options in the local Magi config to request higher reasoning/thinking behavior.

## Current behavior (updates)

The review agents and merge editor rely on provider defaults without explicit high reasoning options.

## New behavior

Melchior, Balthasar, and the merge editor use `reasoningEffort: high`; Caspar enables thinking with a 16000 token budget.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validated `.opencode/magi.json` parses as JSON.
