### PR TITLE
docs(commands): use descriptive page titles

### DIFF
--- a/docs/commands/clear.md
+++ b/docs/commands/clear.md
@@ -1,4 +1,4 @@
-# /magi:clear
+# Clear
 
 ## Usage
 

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -1,4 +1,4 @@
-# /magi:merge
+# Merge
 
 ## Usage
 

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -1,4 +1,4 @@
-# /magi:review
+# Review
 
 ## Usage
 

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -1,4 +1,4 @@
-# /magi:triage
+# Triage
 
 ## Usage
 

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -1,4 +1,4 @@
-# /magi:validate
+# Validate
 
 ## Usage
 


### PR DESCRIPTION
Closes #54

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update command documentation page headings to use human-readable titles instead of slash command syntax.

## Current behavior (updates)

Command pages under `docs/commands/` use headings such as `# /magi:merge`.

## New behavior

Command pages use descriptive headings such as `# Merge`, while `docs/commands/index.md` remains unchanged.

## Is this a breaking change (Yes/No):

No

## Additional Information

Docs-only change.