### PR TITLE
fix(config): require unanimous review approval

### DIFF
--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -36,7 +36,8 @@
       }
     ],
     "merge": {
-      "queue": true
+      "queue": true,
+      "approvalPolicy": "unanimous"
     },
     "prompts": {
       "reviewGuidelines": ".agents/references/pr-review-guidelines.md"


### PR DESCRIPTION
Closes #61

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Set the project Magi review merge policy to require unanimous approval.

## Current behavior (updates)

Review merge automation used the default majority approval policy while merge queue automation was enabled.

## New behavior

Review merge automation now explicitly requires `review.merge.approvalPolicy: unanimous`, preventing merge attempts when any reviewer requests changes.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validated `.opencode/magi.json` against the local Magi schema.