### PR TITLE
fix(review): pass approval policy to review runs

### DIFF
--- a/.changeset/fix-review-approval-policy.md
+++ b/.changeset/fix-review-approval-policy.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Pass the resolved review approval policy into review automation.

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -820,6 +820,45 @@ describe("MagiRunManager notifications", () => {
     }
   })
 
+  test("passes the resolved approval policy to review runs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const state = sampleReviewState(join(directory, "run"))
+    const repository = sampleRepository()
+    const privateManager = manager as unknown as {
+      active: Map<string, MagiRunState>
+      executeReview(input: Record<string, unknown>): Promise<void>
+    }
+
+    repository.merge.approvalPolicy = "unanimous"
+    state.status = "running"
+    privateManager.active.set("run", state)
+    runReviewMock.mockResolvedValueOnce({
+      outputs: {
+        security: { findings: [], verdict: "MERGE" },
+      },
+      posted: { security: "approved" },
+      report: "Report",
+      sessionIds: {},
+      verdict: "MERGE",
+    })
+
+    try {
+      await privateManager.executeReview({
+        config: { agents: { reviewers: [] } },
+        pr: 7557,
+        repository,
+        runId: "run",
+      })
+
+      expect(runReviewMock).toHaveBeenCalledWith(
+        expect.objectContaining({ approvalPolicy: "unanimous" }),
+      )
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   test("notifies CI classifier progress and reports", async () => {
     await withTrackedSession(async ({ manager, prompts }) => {
       const privateManager = manager as unknown as {

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -1615,6 +1615,7 @@ export class MagiRunManager {
     signal?: AbortSignal
   }): Promise<void> {
     const result = await runReview({
+      approvalPolicy: input.repository.merge.approvalPolicy,
       client: this.input.client,
       config: input.config,
       directory: this.input.directory,


### PR DESCRIPTION
Closes #64

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Pass the resolved review merge approval policy into `runReview` so review automation evaluates merge eligibility with the configured policy.

## Current behavior (updates)

`executeReview` omitted `approvalPolicy`, so `runReview` fell back to `majority` even when the resolved repository config used `unanimous`.

## New behavior

`executeReview` forwards `input.repository.merge.approvalPolicy`, and a regression test covers the unanimous policy path.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm test src/orchestrator/run-manager.test.ts`.