### PR TITLE
fix(triage): complete issue triage runtime

### DIFF
--- a/.changeset/triage-config-mismatch.md
+++ b/.changeset/triage-config-mismatch.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Wire triage prompt overrides and mention-based reconsideration settings into the triage runtime.

--- a/.changeset/triage-config-mismatch.md
+++ b/.changeset/triage-config-mismatch.md
@@ -1,5 +1,0 @@
----
-"opencode-magi": patch
----
-
-Wire triage prompt overrides and mention-based reconsideration settings into the triage runtime.

--- a/docs/prompts/index.md
+++ b/docs/prompts/index.md
@@ -34,7 +34,12 @@ Triage prompts:
 - [Kind](triage/kind.md) - Decide whether an issue is a bug, feature request, or needs more information.
 - [Bug](triage/bug.md) - Decide whether a bug report is reproduced or otherwise valid.
 - [Feature](triage/feature.md) - Decide whether a feature request should be implemented.
+- [Action](triage/action.md) - Record the next planned triage action.
+- [Comment](triage/comment.md) - Compose final decision comments.
+- [Question](triage/question.md) - Compose author questions for `ASK` results.
 - [Comment Classification](triage/comment-classification.md) - Classify mention replies for reconsideration.
+- [Reconsider](triage/reconsider.md) - Vote on mention-triggered reconsideration.
+- [Create PR](triage/create-pr.md) - Instruct the creator agent for implementation PRs.
 
 ## Final Prompt Shape
 
@@ -48,7 +53,7 @@ For example, in a review prompt:
 - With `review.prompts.review`, Magi uses that file instead of the built-in template.
 - In both cases, Magi still appends the fixed review output contract.
 
-In a triage vote prompt, `triage.prompts.existingPr`, `triage.prompts.duplicate`, `triage.prompts.kind`, `triage.prompts.bug`, `triage.prompts.feature`, and `triage.prompts.commentClassification` replace their matching built-in triage task templates. Magi still appends the fixed output contract for that phase.
+In a triage prompt, `triage.prompts.existingPr`, `triage.prompts.duplicate`, `triage.prompts.kind`, `triage.prompts.bug`, `triage.prompts.feature`, `triage.prompts.action`, `triage.prompts.comment`, `triage.prompts.question`, `triage.prompts.commentClassification`, `triage.prompts.reconsider`, and `triage.prompts.createPr` replace their matching built-in triage task templates. Magi still appends the fixed output contract for structured phases.
 
 The custom file replaces the built-in task, but it does not replace the output schema.
 

--- a/docs/prompts/triage/action.md
+++ b/docs/prompts/triage/action.md
@@ -1,0 +1,13 @@
+# Action
+
+Used when Magi records the deterministic action plan for a triage result.
+
+Config key: `triage.prompts.action`
+
+Built-in template: [`triage/action.md`](/src/prompts/templates/triage/action.md)
+
+| Placeholder          | Meaning                                                                       |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `{issue}`            | Issue number.                                                                 |
+| `{owner}` / `{repo}` | GitHub repository owner and name.                                             |
+| `{context}`          | JSON context with the triage result, allowed actions, and deterministic plan. |

--- a/docs/prompts/triage/comment.md
+++ b/docs/prompts/triage/comment.md
@@ -1,0 +1,14 @@
+# Comment
+
+Used when Magi composes a final visible issue comment for non-`ASK` triage results.
+
+Config key: `triage.prompts.comment`
+
+Built-in template: [`triage/comment.md`](/src/prompts/templates/triage/comment.md)
+
+| Placeholder          | Meaning                                                                    |
+| -------------------- | -------------------------------------------------------------------------- |
+| `{issue}`            | Issue number.                                                              |
+| `{owner}` / `{repo}` | GitHub repository owner and name.                                          |
+| `{author}`           | Issue author login that must be mentioned.                                 |
+| `{context}`          | JSON context with issue metadata, decision, action, and relationship data. |

--- a/docs/prompts/triage/create-pr.md
+++ b/docs/prompts/triage/create-pr.md
@@ -1,0 +1,14 @@
+# Create PR
+
+Used when the triage creator agent implements an accepted issue and opens an implementation PR.
+
+Config key: `triage.prompts.createPr`
+
+Built-in template: [`triage/create-pr.md`](/src/prompts/templates/triage/create-pr.md)
+
+| Placeholder          | Meaning                                                 |
+| -------------------- | ------------------------------------------------------- |
+| `{issue}`            | Issue number.                                           |
+| `{owner}` / `{repo}` | GitHub repository owner and name.                       |
+| `{worktreePath}`     | Temporary worktree path checked out for implementation. |
+| `{context}`          | JSON context with issue metadata and triage decision.   |

--- a/docs/prompts/triage/question.md
+++ b/docs/prompts/triage/question.md
@@ -1,0 +1,14 @@
+# Question
+
+Used when Magi composes concrete author questions for an `ASK` triage result.
+
+Config key: `triage.prompts.question`
+
+Built-in template: [`triage/question.md`](/src/prompts/templates/triage/question.md)
+
+| Placeholder          | Meaning                                                 |
+| -------------------- | ------------------------------------------------------- |
+| `{issue}`            | Issue number.                                           |
+| `{owner}` / `{repo}` | GitHub repository owner and name.                       |
+| `{author}`           | Issue author login that must be mentioned.              |
+| `{context}`          | JSON context with missing information and vote context. |

--- a/docs/prompts/triage/reconsider.md
+++ b/docs/prompts/triage/reconsider.md
@@ -1,0 +1,13 @@
+# Reconsider
+
+Used when allowed mention replies trigger reconsideration of a previous Magi triage result.
+
+Config key: `triage.prompts.reconsider`
+
+Built-in template: [`triage/reconsider.md`](/src/prompts/templates/triage/reconsider.md)
+
+| Placeholder          | Meaning                                                                        |
+| -------------------- | ------------------------------------------------------------------------------ |
+| `{issue}`            | Issue number.                                                                  |
+| `{owner}` / `{repo}` | GitHub repository owner and name.                                              |
+| `{context}`          | JSON context with previous marker, classified mention replies, and issue data. |

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,6 +3,12 @@ export const MAGI_COMMANDS = {
     description: "Clear inactive Magi runs, sessions, worktrees, and outputs",
     template: "Call the `magi_clear` tool.",
   },
+  "magi:cancel": {
+    description: "Cancel a Magi background run",
+    template: [`Call the \`magi_cancel\` tool.`, "Selector: $ARGUMENTS"].join(
+      "\n",
+    ),
+  },
   "magi:merge": {
     description: "Review and merge pull requests with Magi",
     template: [`Call the \`magi_merge\` tool.`, "PR: $ARGUMENTS"].join("\n"),
@@ -16,6 +22,18 @@ export const MAGI_COMMANDS = {
   "magi:review": {
     description: "Review pull requests with Magi",
     template: [`Call the \`magi_review\` tool.`, "PR: $ARGUMENTS"].join("\n"),
+  },
+  "magi:output": {
+    description: "Show Magi run output artifacts",
+    template: [`Call the \`magi_output\` tool.`, "Selector: $ARGUMENTS"].join(
+      "\n",
+    ),
+  },
+  "magi:status": {
+    description: "Show Magi background run status",
+    template: [`Call the \`magi_status\` tool.`, "Selector: $ARGUMENTS"].join(
+      "\n",
+    ),
   },
   "magi:validate": {
     description: "Validate Magi config",

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "vitest"
 import {
   createWorktree,
   fetchIssue,
+  fetchRelatedPullRequests,
   fetchPullRequest,
   fetchPullRequestCommits,
   fetchPullRequestReviews,
@@ -195,6 +196,59 @@ describe("GitHub command helpers", () => {
     )
 
     expect(result.map((item) => item.number)).toEqual([43])
+  })
+
+  test("normalizes searched related pull request states", async () => {
+    const result = await fetchRelatedPullRequests(
+      async (command) => {
+        if (command.includes("graphql")) {
+          return JSON.stringify({
+            data: {
+              repository: {
+                issue: { timelineItems: { nodes: [] } },
+              },
+            },
+          })
+        }
+
+        expect(command).toContain("gh search prs")
+
+        return JSON.stringify([
+          {
+            author: { login: "bot" },
+            body: "Fixes #58",
+            number: 10,
+            state: "MERGED",
+            title: "Fix issue",
+            url: "https://github.com/owner/repo/pull/10",
+          },
+          {
+            author: { login: "bot" },
+            body: "Closes #58",
+            number: 11,
+            state: "closed",
+            title: "Closed attempt",
+            url: "https://github.com/owner/repo/pull/11",
+          },
+          {
+            author: { login: "bot" },
+            body: "Resolves #58",
+            number: 12,
+            state: "open",
+            title: "Open attempt",
+            url: "https://github.com/owner/repo/pull/12",
+          },
+        ])
+      },
+      repository,
+      58,
+    )
+
+    expect(result.map((pr) => [pr.number, pr.state])).toEqual([
+      [10, "MERGED"],
+      [11, "CLOSED"],
+      [12, "OPEN"],
+    ])
   })
 
   test("pushes detached HEAD to the PR head repository", async () => {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -89,6 +89,11 @@ export interface IssueComment {
   url: string
 }
 
+export interface PostedIssueComment {
+  id: number
+  url: string
+}
+
 export interface IssueMeta {
   author: string
   body: string
@@ -112,6 +117,7 @@ export interface RelatedPullRequest {
 
 export interface DuplicateIssueCandidate {
   body?: string
+  createdAt?: string
   number: number
   state: string
   title: string
@@ -487,7 +493,68 @@ export async function fetchRelatedPullRequests(
     })
   }
 
+  const searchQuery = `repo:${repoSlug(repository)} is:pr ${issue}`
+  const searchRaw = await exec(
+    `gh search prs ${shellQuote(searchQuery)} --json number,title,url,state,body,author --limit 10`,
+  ).catch(() => "[]")
+  const searchData = JSON.parse(searchRaw) as {
+    author?: { login?: string }
+    body?: string
+    number: number
+    state: string
+    title: string
+    url: string
+  }[]
+  const closingReference = new RegExp(
+    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issue}\\b`,
+    "i",
+  )
+
+  for (const item of searchData) {
+    if (!closingReference.test(item.body ?? "")) continue
+
+    prs.set(item.number, {
+      author: item.author?.login ?? "",
+      body: item.body,
+      number: item.number,
+      state: item.state === "CLOSED" ? "CLOSED" : "OPEN",
+      title: item.title,
+      url: item.url,
+    })
+  }
+
   return [...prs.values()]
+}
+
+function duplicateReferences(text: string): number[] {
+  const refs = new Set<number>()
+  const pattern = /duplicate(?:s)?\s+(?:of\s+)?#(\d+)/gi
+
+  for (const match of text.matchAll(pattern)) refs.add(Number(match[1]))
+
+  return [...refs]
+}
+
+async function fetchIssueCandidate(
+  exec: Exec,
+  repository: ResolvedRepository,
+  number: number,
+  whyCandidate: string,
+): Promise<DuplicateIssueCandidate | undefined> {
+  const raw = await exec(
+    `gh issue view ${number} --repo ${shellQuote(repoSpecifier(repository))} --json number,title,url,state,body,createdAt`,
+  ).catch(() => undefined)
+  if (!raw) return undefined
+  const data = JSON.parse(raw) as {
+    body?: string
+    createdAt?: string
+    number: number
+    state: string
+    title: string
+    url: string
+  }
+
+  return { ...data, whyCandidate }
 }
 
 export async function searchDuplicateIssues(
@@ -497,6 +564,18 @@ export async function searchDuplicateIssues(
   limit = 5,
 ): Promise<DuplicateIssueCandidate[]> {
   const query = `${issue.title} repo:${repoSlug(repository)} is:issue -${issue.number}`
+  const explicitCandidates = await Promise.all(
+    duplicateReferences(issue.body)
+      .filter((number) => number !== issue.number)
+      .map((number) =>
+        fetchIssueCandidate(
+          exec,
+          repository,
+          number,
+          "Issue body explicitly references a duplicate target.",
+        ),
+      ),
+  )
   const raw = await exec(
     `gh search issues ${shellQuote(query)} --json number,title,url,state,body --limit ${limit}`,
   )
@@ -508,12 +587,20 @@ export async function searchDuplicateIssues(
     url: string
   }[]
 
-  return data
+  const candidates = new Map<number, DuplicateIssueCandidate>()
+  for (const candidate of explicitCandidates) {
+    if (candidate) candidates.set(candidate.number, candidate)
+  }
+  for (const item of data
     .filter((item) => item.number !== issue.number)
     .map((item) => ({
       ...item,
       whyCandidate: "GitHub issue search matched the title.",
-    }))
+    }))) {
+    if (!candidates.has(item.number)) candidates.set(item.number, item)
+  }
+
+  return [...candidates.values()].slice(0, limit)
 }
 
 export async function postIssueComment(
@@ -522,7 +609,7 @@ export async function postIssueComment(
   issue: number,
   account: string,
   body: string,
-): Promise<string> {
+): Promise<PostedIssueComment> {
   const token = await ghToken(exec, repository, account)
   const payloadPath = join(
     tmpdir(),
@@ -532,10 +619,51 @@ export async function postIssueComment(
   await writeFile(payloadPath, JSON.stringify({ body }))
 
   try {
-    return await exec(
-      `gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/issues/${issue}/comments --method POST --input ${shellQuote(payloadPath)} --jq .html_url`,
+    const raw = await exec(
+      `gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/issues/${issue}/comments --method POST --input ${shellQuote(payloadPath)} --jq '{id: .id, url: .html_url}'`,
       ghTokenEnv(token),
     )
+    const data = JSON.parse(raw) as { id?: number; url?: string }
+
+    if (!data.id || !data.url)
+      throw new Error(
+        "GitHub issue comment response did not include id and url",
+      )
+
+    return { id: data.id, url: data.url }
+  } finally {
+    await rm(payloadPath, { force: true })
+  }
+}
+
+export async function updateIssueComment(
+  exec: Exec,
+  repository: ResolvedRepository,
+  commentId: number,
+  account: string,
+  body: string,
+): Promise<PostedIssueComment> {
+  const token = await ghToken(exec, repository, account)
+  const payloadPath = join(
+    tmpdir(),
+    `magi-issue-comment-${process.pid}-${Date.now()}.json`,
+  )
+
+  await writeFile(payloadPath, JSON.stringify({ body }))
+
+  try {
+    const raw = await exec(
+      `gh api${ghHostOption(repository)} repos/${repository.github.owner}/${repository.github.repo}/issues/comments/${commentId} --method PATCH --input ${shellQuote(payloadPath)} --jq '{id: .id, url: .html_url}'`,
+      ghTokenEnv(token),
+    )
+    const data = JSON.parse(raw) as { id?: number; url?: string }
+
+    if (!data.id || !data.url)
+      throw new Error(
+        "GitHub issue comment response did not include id and url",
+      )
+
+    return { id: data.id, url: data.url }
   } finally {
     await rm(payloadPath, { force: true })
   }

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -115,6 +115,17 @@ export interface RelatedPullRequest {
   url: string
 }
 
+function normalizeRelatedPullRequestState(
+  state?: string,
+): RelatedPullRequest["state"] {
+  const normalized = state?.toUpperCase()
+
+  if (normalized === "MERGED") return "MERGED"
+  if (normalized === "CLOSED") return "CLOSED"
+
+  return "OPEN"
+}
+
 export interface DuplicateIssueCandidate {
   body?: string
   createdAt?: string
@@ -479,9 +490,7 @@ export async function fetchRelatedPullRequests(
     if (!source?.number || !source.url) continue
     const state = source.mergedAt
       ? "MERGED"
-      : source.state === "CLOSED"
-        ? "CLOSED"
-        : "OPEN"
+      : normalizeRelatedPullRequestState(source.state)
     prs.set(source.number, {
       author: source.author?.login ?? "",
       body: source.body,
@@ -517,7 +526,7 @@ export async function fetchRelatedPullRequests(
       author: item.author?.login ?? "",
       body: item.body,
       number: item.number,
-      state: item.state === "CLOSED" ? "CLOSED" : "OPEN",
+      state: normalizeRelatedPullRequestState(item.state),
       title: item.title,
       url: item.url,
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import { type ModelCatalog, validateConfig } from "./config/validate"
 import { withGitHubApiRetry } from "./github/retry"
 import { mapPool } from "./orchestrator/pool"
 import { MagiRunManager } from "./orchestrator/run-manager"
-import { runTriage } from "./orchestrator/triage"
 
 const execAsync = promisify(nodeExec)
 const GLOBAL_CONFIG_PATH = join(homedir(), ".config", "opencode", "magi.json")
@@ -190,6 +189,12 @@ function parseOptionalPr(value: string | undefined): number | undefined {
   return parsePrToken(value)
 }
 
+function parseOptionalIssue(value: string | undefined): number | undefined {
+  if (!value?.trim()) return undefined
+
+  return parseIssueToken(value)
+}
+
 function clearFlag(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined
 }
@@ -247,6 +252,16 @@ function prMarkdownLink(repository: ResolvedRepository, pr: number): string {
   const url = `https://${host}/${repository.github.owner}/${repository.github.repo}/pull/${pr}`
 
   return `[#${pr}](${url})`
+}
+
+function issueMarkdownLink(
+  repository: ResolvedRepository,
+  issue: number,
+): string {
+  const host = repository.github.host || "github.com"
+  const url = `https://${host}/${repository.github.owner}/${repository.github.repo}/issues/${issue}`
+
+  return `[#${issue}](${url})`
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -557,34 +572,38 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
               null,
               2,
             )
-          const results = await mapPool(
+          const states = await mapPool(
             parsed.issues,
             repository.triage.concurrency.runs,
             (issue) =>
-              runTriage({
-                client: modelClient,
+              runManager.startTriage({
                 config: loaded.config,
-                directory,
                 dryRun: parsed.dryRun,
-                exec: retryingExec,
                 issue,
+                parentSessionId: context.sessionID,
                 repository,
                 signal: context.abort,
               }),
             { signal: context.abort },
           )
 
-          return results.map((result) => result.report).join("\n\n")
+          return states
+            .map(
+              (state) =>
+                `Started triaging ${issueMarkdownLink(repository, state.issue as number)}.`,
+            )
+            .join("\n")
         },
       }),
       magi_status: tool({
         description: [
-          "Show Magi background run status. Optionally filter by runId or PR and wait for completion.",
+          "Show Magi background run status. Optionally filter by runId, PR, or issue and wait for completion.",
           INTERNAL_FOLLOW_UP_TOOL_NOTE,
         ].join(" "),
         args: {
           runId: tool.schema.string().optional(),
           pr: tool.schema.string().optional(),
+          issue: tool.schema.string().optional(),
           block: tool.schema.boolean().optional(),
           timeoutSeconds: tool.schema.number().optional(),
           verbose: tool.schema.boolean().optional(),
@@ -592,6 +611,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         async execute(args) {
           const states = await runManager.status({
             block: args.block,
+            issue: parseOptionalIssue(args.issue),
             outputDir: await configuredOutputDir(),
             pr: parseOptionalPr(args.pr),
             runId: args.runId,
@@ -608,21 +628,24 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
       }),
       magi_output: tool({
         description: [
-          "Show artifacts and details for a Magi background run by runId or PR, optionally for a single reviewer.",
+          "Show artifacts and details for a Magi background run by runId, PR, or issue, optionally for a single reviewer.",
           INTERNAL_FOLLOW_UP_TOOL_NOTE,
         ].join(" "),
         args: {
           runId: tool.schema.string().optional(),
           pr: tool.schema.string().optional(),
+          issue: tool.schema.string().optional(),
           reviewer: tool.schema.string().optional(),
         },
         async execute(args) {
-          if (!args.runId && !args.pr) return "Specify runId or pr."
+          if (!args.runId && !args.pr && !args.issue)
+            return "Specify runId, pr, or issue."
 
           const outputDir = await configuredOutputDir()
           if (outputDir) await runManager.status({ outputDir })
           return runManager.output({
             outputDir,
+            issue: parseOptionalIssue(args.issue),
             pr: parseOptionalPr(args.pr),
             reviewer: args.reviewer,
             runId: args.runId,
@@ -630,18 +653,22 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         },
       }),
       magi_cancel: tool({
-        description: "Cancel a Magi background run by runId or PR.",
+        description: "Cancel a Magi background run by runId, PR, or issue.",
         args: {
           runId: tool.schema.string().optional(),
           pr: tool.schema.string().optional(),
+          issue: tool.schema.string().optional(),
         },
         async execute(args) {
-          if (!args.runId && !args.pr) return "Specify runId or pr."
+          if (!args.runId && !args.pr && !args.issue)
+            return "Specify runId, pr, or issue."
 
           const outputDir = await configuredOutputDir()
           if (outputDir) await runManager.status({ outputDir })
           const pr = parseOptionalPr(args.pr)
+          const issue = parseOptionalIssue(args.issue)
           const state = await runManager.cancel({
+            issue,
             outputDir,
             pr,
             runId: args.runId,
@@ -650,7 +677,9 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           if (!state) {
             return args.runId
               ? `Magi run not found: ${args.runId}`
-              : `Magi run not found for PR #${pr}`
+              : issue
+                ? `Magi run not found for issue #${issue}`
+                : `Magi run not found for PR #${pr}`
           }
 
           return runManager.formatStates([state])
@@ -662,6 +691,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         args: {
           runId: tool.schema.string().optional(),
           pr: tool.schema.string().optional(),
+          issue: tool.schema.string().optional(),
           branch: tool.schema.enum(["true", "false"]).optional(),
           output: tool.schema.enum(["true", "false"]).optional(),
           session: tool.schema.enum(["true", "false"]).optional(),
@@ -692,6 +722,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
 
           return runManager.clear({
             options,
+            issue: parseOptionalIssue(args.issue),
             outputDir: loaded
               ? outputBaseDirs(directory, loaded.config)
               : undefined,

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -15,7 +15,11 @@ import {
   writeFile,
 } from "node:fs/promises"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
-import { outputBaseDirs, prRunOutputDir } from "../config/output"
+import {
+  issueRunOutputDir,
+  outputBaseDirs,
+  prRunOutputDir,
+} from "../config/output"
 import { worktreeBaseDirs } from "../config/worktree"
 import {
   removeBranch,
@@ -30,6 +34,7 @@ import {
 } from "./merge"
 import type { ModelClient } from "./model"
 import { runReview, type ReviewRunProgress } from "./review"
+import { runTriage } from "./triage"
 
 export type MagiAgentStatus =
   | "blocked"
@@ -77,7 +82,7 @@ export interface MagiRunAgentState {
 }
 
 export interface MagiRunState {
-  command: "merge" | "review"
+  command: "merge" | "review" | "triage"
   ciReports?: CheckWaitReport[]
   ciClassifiers?: Record<
     string,
@@ -99,6 +104,8 @@ export interface MagiRunState {
   posted?: Record<string, string>
   pr?: number
   prUrl?: string
+  issue?: number
+  issueUrl?: string
   reportPath?: string
   repository: string
   reviewers: Record<string, MagiRunAgentState>
@@ -226,13 +233,29 @@ function prUrl(repository: ResolvedRepository, pr: number): string {
   return `https://${host}/${repository.github.owner}/${repository.github.repo}/pull/${pr}`
 }
 
+function issueUrl(repository: ResolvedRepository, issue: number): string {
+  const host = repository.github.host || "github.com"
+
+  return `https://${host}/${repository.github.owner}/${repository.github.repo}/issues/${issue}`
+}
+
 function prMarkdownLink(state: MagiRunState): string {
   if (state.pr == null) return state.runId
   return state.prUrl ? `[#${state.pr}](${state.prUrl})` : `#${state.pr}`
 }
 
+function issueMarkdownLink(state: MagiRunState): string {
+  if (state.issue == null) return state.runId
+  return state.issueUrl
+    ? `[#${state.issue}](${state.issueUrl})`
+    : `#${state.issue}`
+}
+
 function runLabel(state: MagiRunState): string {
-  return state.pr == null ? state.runId : prMarkdownLink(state)
+  if (state.pr != null) return prMarkdownLink(state)
+  if (state.issue != null) return issueMarkdownLink(state)
+
+  return state.runId
 }
 
 function reviewerCompletionText(input: {
@@ -772,9 +795,76 @@ export class MagiRunManager {
     return state
   }
 
+  async startTriage(input: {
+    config: MagiConfig
+    dryRun?: boolean
+    issue: number
+    parentSessionId?: string
+    repository: ResolvedRepository
+    signal?: AbortSignal
+  }): Promise<MagiRunState> {
+    const runId = createRunId()
+    const outputDir = issueRunOutputDir({
+      config: input.config,
+      directory: this.input.directory,
+      issue: input.issue,
+      runId,
+    })
+    const createdAt = now()
+    const state: MagiRunState = {
+      command: "triage",
+      createdAt,
+      dryRun: input.dryRun,
+      issue: input.issue,
+      issueUrl: issueUrl(input.repository, input.issue),
+      outputDir,
+      parentSessionId: input.parentSessionId,
+      phase: "queued",
+      repository: input.repository.alias,
+      reviewers: Object.fromEntries(
+        (input.repository.agents.triage ?? []).map((agent) => [
+          agent.key,
+          {
+            account: "",
+            repairAttempts: 0,
+            status: "pending" as const,
+            toolCalls: 0,
+          },
+        ]),
+      ),
+      runId,
+      status: "preparing",
+      updatedAt: createdAt,
+    }
+
+    this.active.set(runId, state)
+    this.runPaths.set(runId, join(outputDir, "state.json"))
+    for (const dir of outputBaseDirs(this.input.directory, input.config))
+      this.outputDirs.add(dir)
+    await this.persist(state)
+    await this.notify(
+      state,
+      `Started Magi triage for ${issueMarkdownLink(state)}.`,
+    )
+
+    const controller = new AbortController()
+    this.controllers.set(runId, controller)
+
+    void this.executeTriage({
+      ...input,
+      runId,
+      signal: controller.signal,
+    }).catch(async (error) => {
+      await this.failRun(runId, error)
+    })
+
+    return state
+  }
+
   async status(
     input: {
       block?: boolean
+      issue?: number
       outputDir?: string | string[]
       pr?: number
       runId?: string
@@ -804,6 +894,7 @@ export class MagiRunManager {
 
   async output(input: {
     command?: MagiRunState["command"]
+    issue?: number
     outputDir?: string | string[]
     pr?: number
     reviewer?: string
@@ -863,7 +954,12 @@ export class MagiRunManager {
   async cancel(
     input:
       | string
-      | { outputDir?: string | string[]; pr?: number; runId?: string },
+      | {
+          issue?: number
+          outputDir?: string | string[]
+          pr?: number
+          runId?: string
+        },
   ): Promise<MagiRunState | undefined> {
     const selector = typeof input === "string" ? { runId: input } : input
     const state = await this.selectState(selector)
@@ -934,6 +1030,7 @@ export class MagiRunManager {
   }
 
   async clear(input: {
+    issue?: number
     options?: ClearConfig
     outputDir?: string | string[]
     pr?: number
@@ -1734,6 +1831,63 @@ export class MagiRunManager {
     this.controllers.delete(input.runId)
   }
 
+  private async executeTriage(input: {
+    config: MagiConfig
+    dryRun?: boolean
+    issue: number
+    parentSessionId?: string
+    repository: ResolvedRepository
+    runId: string
+    signal?: AbortSignal
+  }): Promise<void> {
+    const state = this.active.get(input.runId)
+    if (state) {
+      state.status = "running"
+      state.phase = "triaging"
+      await this.persist(state)
+    }
+
+    const result = await runTriage({
+      client: this.input.client,
+      config: input.config,
+      directory: this.input.directory,
+      dryRun: input.dryRun,
+      exec: withGitHubApiRetry(
+        this.input.exec,
+        input.config.github?.apiRetryAttempts ?? 3,
+      ),
+      issue: input.issue,
+      repository: input.repository,
+      runId: input.runId,
+      signal: input.signal,
+    })
+
+    const completed = this.active.get(input.runId)
+    if (!completed || completed.status === "cancelled") return
+
+    completed.status = result.result === "FAILED" ? "failed" : "completed"
+    completed.phase = result.result
+    completed.completedAt = now()
+    completed.verdict = result.result
+    completed.reportPath = join(completed.outputDir, "report.md")
+    for (const agent of Object.values(completed.reviewers)) {
+      if (agent.status === "pending") agent.status = "completed"
+    }
+
+    await this.persist(completed)
+    await this.notify(
+      completed,
+      [
+        `Finished triage for ${issueMarkdownLink(completed)}.`,
+        "",
+        result.report,
+      ].join("\n"),
+      { reply: true },
+    )
+    this.active.delete(input.runId)
+    this.controllers.delete(input.runId)
+  }
+
   private async applyReviewProgress(
     runId: string,
     progress: ReviewRunProgress,
@@ -2254,6 +2408,7 @@ export class MagiRunManager {
 
   private async filteredStates(input: {
     command?: MagiRunState["command"]
+    issue?: number
     outputDir?: string | string[]
     pr?: number
     runId?: string
@@ -2268,12 +2423,14 @@ export class MagiRunManager {
       .filter(
         (state) => input.command == null || state.command === input.command,
       )
+      .filter((state) => input.issue == null || state.issue === input.issue)
       .filter((state) => input.pr == null || state.pr === input.pr)
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
   }
 
   private async selectState(input: {
     command?: MagiRunState["command"]
+    issue?: number
     outputDir?: string | string[]
     pr?: number
     runId?: string
@@ -2283,9 +2440,14 @@ export class MagiRunManager {
     return (await this.filteredStates(input))[0]
   }
 
-  private selectorText(input: { pr?: number; runId?: string }): string {
+  private selectorText(input: {
+    issue?: number
+    pr?: number
+    runId?: string
+  }): string {
     if (input.runId) return input.runId
     if (input.pr != null) return `PR #${input.pr}`
+    if (input.issue != null) return `issue #${input.issue}`
 
     return "all runs"
   }

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -1,5 +1,68 @@
 import { describe, expect, test } from "vitest"
-import { chooseDuplicateOutput } from "./triage"
+import type { IssueComment } from "../github/commands"
+import type { ResolvedRepository } from "../types"
+import {
+  chooseDuplicateOutput,
+  eligibleMentionReplies,
+  mentionAllowed,
+} from "./triage"
+
+const repository: ResolvedRepository = {
+  agents: { reviewers: [] },
+  alias: "repo",
+  automation: { close: false, merge: true },
+  checks: {
+    exclude: [],
+    retryFailedJobs: 3,
+    waitAfterEdit: true,
+    waitBeforeReview: true,
+  },
+  concurrency: { runs: 3, reviewers: 3 },
+  github: {
+    apiRetryAttempts: 3,
+    host: "github.com",
+    owner: "owner",
+    repo: "repo",
+  },
+  merge: {
+    approvalPolicy: "majority",
+    auto: true,
+    deleteBranch: true,
+    maxThreadResolutionCycles: 5,
+    mergeQueue: false,
+    method: "squash",
+  },
+  prompts: {},
+  safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
+  triage: {
+    account: "magi-bot",
+    automation: { clear: ["triage"], close: false, pr: false },
+    concurrency: { runs: 3 },
+    kind: {
+      bug: { label: ["bug"], type: ["Bug"] },
+      feature: { label: ["enhancement"], type: ["Feature"] },
+    },
+    prompts: {},
+    safety: {
+      allowAuthors: [],
+      allowMentionActors: [],
+      allowMentionRoles: ["MEMBER"],
+      blockedLabels: [],
+      requiredLabels: ["triage"],
+    },
+  },
+}
+
+function comment(overrides: Partial<IssueComment>): IssueComment {
+  return {
+    author: "user",
+    body: "body",
+    createdAt: "2026-01-01T00:00:00Z",
+    id: 1,
+    url: "https://example.com/comment/1",
+    ...overrides,
+  }
+}
 
 describe("triage orchestration", () => {
   test("requires majority support for the same duplicate target", () => {
@@ -39,5 +102,57 @@ describe("triage orchestration", () => {
     })
 
     expect(result).toBeUndefined()
+  })
+
+  test("allows reconsideration mentions by actor or role", () => {
+    expect(
+      mentionAllowed(comment({ authorAssociation: "MEMBER" }), repository),
+    ).toBe(true)
+    expect(
+      mentionAllowed(comment({ authorAssociation: "CONTRIBUTOR" }), repository),
+    ).toBe(false)
+    expect(
+      mentionAllowed(comment({ author: "maintainer" }), {
+        ...repository,
+        triage: {
+          ...repository.triage!,
+          safety: {
+            ...repository.triage!.safety,
+            allowMentionActors: ["maintainer"],
+            allowMentionRoles: [],
+          },
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("selects unprocessed allowed mention replies after marker checkpoint", () => {
+    const replies = eligibleMentionReplies({
+      account: "magi-bot",
+      comments: [
+        comment({ body: "old @magi-bot", id: 9, authorAssociation: "MEMBER" }),
+        comment({
+          body: "processed @magi-bot",
+          id: 11,
+          authorAssociation: "MEMBER",
+        }),
+        comment({
+          body: "allowed @magi-bot",
+          id: 12,
+          authorAssociation: "MEMBER",
+        }),
+        comment({
+          body: "not allowed @magi-bot",
+          id: 13,
+          authorAssociation: "CONTRIBUTOR",
+        }),
+        comment({ body: "no mention", id: 14, authorAssociation: "MEMBER" }),
+      ],
+      marker: { commentId: 10, processed: [11], v: 1 },
+      processed: [11],
+      repository,
+    })
+
+    expect(replies.map((reply) => reply.id)).toEqual([12])
   })
 })

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -10,10 +10,14 @@ import type {
   MagiConfig,
   ResolvedRepository,
   ResolvedTriageAgent,
+  TriageAction,
+  TriageActionOutput,
   TriageBinaryVote,
+  TriageCommentClassification,
   TriageDuplicateOutput,
   TriageDuplicateVote,
   TriageExistingPrVote,
+  TriageFinalVote,
   TriageKindVote,
   TriageVoteOutput,
 } from "../types"
@@ -35,20 +39,29 @@ import {
   removeWorktree,
   searchDuplicateIssues,
   shellQuote,
+  updateIssueComment,
 } from "../github/commands"
 import {
   composeTriageBugPrompt,
+  composeTriageActionPrompt,
+  composeTriageCommentClassificationPrompt,
   composeTriageCommentPrompt,
+  composeTriageCreatePrPrompt,
   composeTriageDuplicatePrompt,
   composeTriageExistingPrPrompt,
   composeTriageFeaturePrompt,
   composeTriageKindPrompt,
+  composeTriageQuestionPrompt,
+  composeTriageReconsiderPrompt,
 } from "../prompts/compose"
 import {
   parseEditOutput,
+  parseTriageActionOutput,
   parseTriageBinaryOutput,
+  parseTriageCommentClassificationOutput,
   parseTriageDuplicateOutput,
   parseTriageExistingPrOutput,
+  parseTriageFinalOutput,
   parseTriageKindOutput,
 } from "../prompts/output"
 import { aggregateStringMajority, majorityThreshold } from "./majority"
@@ -86,6 +99,7 @@ export interface TriageRunResult {
 interface TriageMarker {
   action?: string
   checkpoint?: number
+  commentId?: number
   issue?: number
   pr?: string
   processed: number[]
@@ -96,8 +110,18 @@ interface TriageMarker {
 interface RelationshipSummary {
   comments: IssueComment[]
   duplicateCandidates: DuplicateIssueCandidate[]
+  mentionReplies: IssueComment[]
   previousMarker?: TriageMarker
   relatedPullRequests: RelatedPullRequest[]
+}
+
+interface ActionPlan {
+  action: TriageAction
+  allowedActions: TriageAction[]
+  clearLabels: boolean
+  closeIssue: boolean
+  createPr: boolean
+  postComment: boolean
 }
 
 type TriagePromptComposer = (input: {
@@ -116,15 +140,29 @@ const EXISTING_PR_VOTES = [
   "RELATED_PR_DOES_NOT_HANDLE_ISSUE",
   "RELATED_PR_HANDLES_ISSUE",
 ] as const
+const FINAL_VOTES = [
+  "ASK",
+  "BUG_ACCEPTED",
+  "BUG_REJECTED",
+  "DUPLICATE",
+  "FEATURE_ACCEPTED",
+  "FEATURE_REJECTED",
+] as const
+const RECONSIDERATION_CLASSES = new Set<TriageCommentClassification>([
+  "CLARIFICATION",
+  "NEW_EVIDENCE",
+  "OBJECTION",
+])
 
 function marker(input: {
   action: string
+  checkpoint?: number | "pending"
   issue: number
   pr?: number
   processed?: number[]
   result: string
 }): string {
-  return `<!-- ${MARKER_PREFIX} v=1 issue=${input.issue} result=${input.result} action=${input.action} checkpoint=pending pr=${input.pr ?? "none"} processed=${(input.processed ?? []).join(",")} -->`
+  return `<!-- ${MARKER_PREFIX} v=1 issue=${input.issue} result=${input.result} action=${input.action} checkpoint=${input.checkpoint ?? "pending"} pr=${input.pr ?? "none"} processed=${(input.processed ?? []).join(",")} -->`
 }
 
 export function parseTriageMarker(body: string): TriageMarker | undefined {
@@ -148,7 +186,10 @@ export function parseTriageMarker(body: string): TriageMarker | undefined {
 
   return {
     action: entries.action,
-    checkpoint: entries.checkpoint ? Number(entries.checkpoint) : undefined,
+    checkpoint:
+      entries.checkpoint && Number.isFinite(Number(entries.checkpoint))
+        ? Number(entries.checkpoint)
+        : undefined,
     issue: entries.issue ? Number(entries.issue) : undefined,
     pr: entries.pr,
     processed: entries.processed
@@ -187,12 +228,18 @@ export function resolveIssueKind(
 function issueContext(input: {
   issue: IssueMeta
   relationship: RelationshipSummary
+  reconsideration?: {
+    classifications?: unknown
+    previousMarker: TriageMarker
+    triggeringComments: IssueComment[]
+  }
 }): string {
   return JSON.stringify(
     {
       duplicateCandidates: input.relationship.duplicateCandidates,
       issue: input.issue,
       recentComments: input.relationship.comments.slice(-20),
+      reconsideration: input.reconsideration,
       relatedPullRequests: input.relationship.relatedPullRequests,
     },
     null,
@@ -204,18 +251,21 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
 }
 
-async function runVote<T extends string>(input: {
+async function runVote<
+  T extends string,
+  O extends TriageVoteOutput<T> = TriageVoteOutput<T>,
+>(input: {
   agent: ResolvedTriageAgent
   client: ModelClient
   context: string
   directory: string
   issue: number
-  parse: (text: string) => TriageVoteOutput<T>
+  parse: (text: string) => O
   prompt: TriagePromptComposer
   repository: ResolvedRepository
   schemaName: string
   signal?: AbortSignal
-}): Promise<TriageVoteOutput<T> & { raw: string; sessionId: string }> {
+}): Promise<O & { promptText: string; raw: string; sessionId: string }> {
   const prompt = await input.prompt({
     context: input.context,
     directory: input.directory,
@@ -236,7 +286,28 @@ async function runVote<T extends string>(input: {
     title: `Magi triage ${input.schemaName} #${input.issue} (${input.agent.key})`,
   })
 
-  return { ...result.value, raw: result.raw, sessionId: result.sessionId }
+  return {
+    ...result.value,
+    promptText: prompt,
+    raw: result.raw,
+    sessionId: result.sessionId,
+  }
+}
+
+async function writeVoteArtifacts(input: {
+  output: TriageVoteOutput & { promptText: string; raw: string }
+  outputDir: string
+  phase: string
+  reviewer: string
+}): Promise<void> {
+  const base = join(input.outputDir, `${input.reviewer}.${input.phase}`)
+
+  await writeFile(`${base}.prompt.txt`, `${input.output.promptText}\n`)
+  await writeFile(`${base}.raw.txt`, `${input.output.raw}\n`)
+  await writeJson(`${base}.json`, {
+    reason: input.output.reason,
+    vote: input.output.vote,
+  })
 }
 
 export function chooseDuplicateOutput(input: {
@@ -279,7 +350,7 @@ async function runDuplicateVote(input: {
 
   const outputs = await Promise.all(
     agents.map((agent) =>
-      runVote<TriageDuplicateVote>({
+      runVote<TriageDuplicateVote, TriageDuplicateOutput>({
         agent,
         client: input.input.client,
         context: input.context,
@@ -299,6 +370,26 @@ async function runDuplicateVote(input: {
       vote: output.vote,
     })),
     DUPLICATE_VOTES,
+  )
+
+  await Promise.all(
+    outputs.map((output, index) =>
+      writeVoteArtifacts({
+        output,
+        outputDir: input.outputDir,
+        phase: "duplicate",
+        reviewer: agents[index].key,
+      }),
+    ),
+  )
+  await Promise.all(
+    outputs.map((output, index) =>
+      writeJson(join(input.outputDir, `${agents[index].key}.duplicate.json`), {
+        duplicateOf: output.duplicateOf,
+        reason: output.reason,
+        vote: output.vote,
+      }),
+    ),
   )
 
   await writeJson(join(input.outputDir, "duplicate-majority.json"), majority)
@@ -348,6 +439,17 @@ async function runPhaseVote<T extends string>(input: {
     input.votes,
   )
 
+  await Promise.all(
+    outputs.map((output, index) =>
+      writeVoteArtifacts({
+        output,
+        outputDir: input.outputDir,
+        phase: input.phase,
+        reviewer: agents[index].key,
+      }),
+    ),
+  )
+
   await writeJson(
     join(input.outputDir, `${input.phase}-majority.json`),
     majority,
@@ -363,12 +465,436 @@ async function relationshipScan(input: TriageRunInput, issue: IssueMeta) {
       fetchRelatedPullRequests(input.exec, input.repository, input.issue),
       searchDuplicateIssues(input.exec, input.repository, issue),
     ])
-  const previousMarker = comments
-    .map((comment) => parseTriageMarker(comment.body))
-    .filter((item): item is TriageMarker => Boolean(item))
-    .at(-1)
+  const markers = comments
+    .filter((comment) => comment.author === input.repository.triage?.account)
+    .map((comment) => {
+      const parsed = parseTriageMarker(comment.body)
+      return parsed ? { ...parsed, commentId: comment.id } : undefined
+    })
+    .filter(Boolean) as TriageMarker[]
+  const previousMarker = markers.at(-1)
+  const mentionReplies = previousMarker
+    ? eligibleMentionReplies({
+        account: input.repository.triage?.account ?? "",
+        comments,
+        marker: previousMarker,
+        processed: previousMarker.processed,
+        repository: input.repository,
+      })
+    : []
 
-  return { comments, duplicateCandidates, previousMarker, relatedPullRequests }
+  return {
+    comments,
+    duplicateCandidates,
+    mentionReplies,
+    previousMarker,
+    relatedPullRequests,
+  }
+}
+
+function mentionsAccount(body: string, account: string): boolean {
+  return new RegExp(
+    `@${account.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+    "i",
+  ).test(body)
+}
+
+function markerCheckpoint(marker: TriageMarker): number | undefined {
+  return marker.checkpoint ?? marker.commentId
+}
+
+export function mentionAllowed(
+  comment: IssueComment,
+  repository: ResolvedRepository,
+): boolean {
+  const safety = repository.triage?.safety
+  if (!safety) return false
+
+  const actorAllowed = safety.allowMentionActors.length
+    ? safety.allowMentionActors.includes(comment.author)
+    : false
+  const roleAllowed = safety.allowMentionRoles.length
+    ? safety.allowMentionRoles.includes(comment.authorAssociation ?? "")
+    : false
+
+  return safety.allowMentionActors.length || safety.allowMentionRoles.length
+    ? actorAllowed || roleAllowed
+    : true
+}
+
+export function eligibleMentionReplies(input: {
+  account: string
+  comments: IssueComment[]
+  marker: TriageMarker
+  processed: number[]
+  repository: ResolvedRepository
+}): IssueComment[] {
+  const checkpoint = markerCheckpoint(input.marker)
+  const processed = new Set(input.processed)
+
+  return input.comments.filter((comment) => {
+    if (checkpoint != null && comment.id <= checkpoint) return false
+    if (processed.has(comment.id)) return false
+    if (!mentionsAccount(comment.body, input.account)) return false
+
+    return mentionAllowed(comment, input.repository)
+  })
+}
+
+function finalResultFromMarker(marker: TriageMarker): FinalResult {
+  if (marker.result === "RESOLVED_BY_MERGED_PR") return "BUG_ACCEPTED"
+
+  return isFinalResult(marker.result) ? marker.result : "FAILED"
+}
+
+function isFinalResult(value: unknown): value is FinalResult {
+  return (
+    value === "ASK" ||
+    value === "BUG_ACCEPTED" ||
+    value === "BUG_REJECTED" ||
+    value === "CLEAR_ONLY" ||
+    value === "DUPLICATE" ||
+    value === "FEATURE_ACCEPTED" ||
+    value === "FEATURE_REJECTED" ||
+    value === "FAILED"
+  )
+}
+
+function actionPlan(input: {
+  result: FinalResult
+  triage: NonNullable<ResolvedRepository["triage"]>
+}): ActionPlan {
+  if (input.result === "CLEAR_ONLY") {
+    return {
+      action: "CLEAR_ONLY",
+      allowedActions: ["CLEAR_ONLY"],
+      clearLabels: true,
+      closeIssue: false,
+      createPr: false,
+      postComment: false,
+    }
+  }
+  if (input.result === "ASK") {
+    return {
+      action: "ASK",
+      allowedActions: ["ASK"],
+      clearLabels: false,
+      closeIssue: false,
+      createPr: false,
+      postComment: true,
+    }
+  }
+
+  const closeIssue =
+    input.triage.automation.close &&
+    (input.result === "BUG_REJECTED" ||
+      input.result === "DUPLICATE" ||
+      input.result === "FEATURE_REJECTED")
+  const createPr =
+    input.triage.automation.pr &&
+    (input.result === "BUG_ACCEPTED" || input.result === "FEATURE_ACCEPTED")
+
+  return {
+    action: closeIssue ? "CLOSE" : createPr ? "PR" : "COMMENT",
+    allowedActions: [closeIssue ? "CLOSE" : createPr ? "PR" : "COMMENT"],
+    clearLabels: true,
+    closeIssue,
+    createPr,
+    postComment: true,
+  }
+}
+
+async function runActionPrompt(input: {
+  context: string
+  input: TriageRunInput
+  outputDir: string
+  plan: ActionPlan
+  result: FinalResult
+}): Promise<TriageActionOutput> {
+  const agent = input.input.repository.agents.triage?.[0]
+  if (!agent) throw new Error("triage.agents is required")
+  const context = JSON.stringify(
+    {
+      allowedActions: input.plan.allowedActions,
+      deterministicPlan: input.plan,
+      result: input.result,
+      triageContext: input.context,
+    },
+    null,
+    2,
+  )
+  const prompt = await composeTriageActionPrompt({
+    context,
+    directory: input.input.directory,
+    issue: input.input.issue,
+    repository: input.input.repository,
+    reviewer: agent,
+  })
+  const result = await runModelWithRepair<TriageActionOutput>({
+    client: input.input.client,
+    model: agent.model,
+    options: agent.options,
+    parse: parseTriageActionOutput,
+    permission: agent.permission,
+    prompt,
+    repairAttempts: 3,
+    schemaName: "triage action",
+    signal: input.input.signal,
+    title: `Magi triage action #${input.input.issue}`,
+  })
+
+  await writeJson(join(input.outputDir, "action.json"), {
+    model: result.value,
+    plan: input.plan,
+  })
+
+  return result.value
+}
+
+async function classifyMentionReplies(input: {
+  context: string
+  input: TriageRunInput
+  outputDir: string
+  replies: IssueComment[]
+}) {
+  const agent = input.input.repository.agents.triage?.[0]
+  if (!agent) throw new Error("triage.agents is required")
+  const prompt = await composeTriageCommentClassificationPrompt({
+    context: JSON.stringify(
+      { context: input.context, mentionReplies: input.replies },
+      null,
+      2,
+    ),
+    directory: input.input.directory,
+    issue: input.input.issue,
+    repository: input.input.repository,
+    reviewer: agent,
+  })
+  const result = await runModelWithRepair({
+    client: input.input.client,
+    model: agent.model,
+    options: agent.options,
+    parse: parseTriageCommentClassificationOutput,
+    permission: agent.permission,
+    prompt,
+    repairAttempts: 3,
+    schemaName: "triage comment classification",
+    signal: input.input.signal,
+    title: `Magi triage comment classification #${input.input.issue}`,
+  })
+
+  await writeJson(
+    join(input.outputDir, "comment-classification.json"),
+    result.value,
+  )
+
+  return result.value
+}
+
+async function runReconsiderationVote(input: {
+  context: string
+  input: TriageRunInput
+  outputDir: string
+}): Promise<TriageFinalVote | undefined> {
+  return runPhaseVote<TriageFinalVote>({
+    context: input.context,
+    input: input.input,
+    outputDir: input.outputDir,
+    parse: parseTriageFinalOutput,
+    phase: "reconsider",
+    prompt: composeTriageReconsiderPrompt,
+    schemaName: "triage reconsider",
+    votes: FINAL_VOTES,
+  })
+}
+
+async function composeResultComment(input: {
+  action: string
+  context: string
+  input: TriageRunInput
+  issue: IssueMeta
+  outputDir: string
+  processed?: number[]
+  result: FinalResult
+}): Promise<string> {
+  const agents = input.input.repository.agents.triage
+  if (!agents?.length) throw new Error("triage.agents is required")
+  const prompt = await (
+    input.result === "ASK"
+      ? composeTriageQuestionPrompt
+      : composeTriageCommentPrompt
+  )({
+    author: input.issue.author,
+    context: input.context,
+    directory: input.input.directory,
+    issue: input.issue.number,
+    repository: input.input.repository,
+  })
+  const comment =
+    (
+      await runModelText({
+        allowEmpty: false,
+        client: input.input.client,
+        model: agents[0].model,
+        options: agents[0].options,
+        permission: agents[0].permission,
+        prompt,
+        signal: input.input.signal,
+        title: `Magi triage comment #${input.issue.number}`,
+      })
+    ).raw +
+    `\n\n${marker({
+      action: input.action,
+      checkpoint: "pending",
+      issue: input.issue.number,
+      processed: input.processed,
+      result: input.result,
+    })}`
+
+  await writeFile(join(input.outputDir, "comment.md"), `${comment}\n`)
+
+  return comment
+}
+
+async function postMarkedIssueComment(input: {
+  account: string
+  body: string
+  exec: Exec
+  issue: number
+  outputDir: string
+  repository: ResolvedRepository
+}): Promise<{ id: number; url: string }> {
+  const posted = await postIssueComment(
+    input.exec,
+    input.repository,
+    input.issue,
+    input.account,
+    input.body,
+  )
+  const body = input.body.replace(
+    "checkpoint=pending",
+    `checkpoint=${posted.id}`,
+  )
+  const updated =
+    body === input.body
+      ? posted
+      : await updateIssueComment(
+          input.exec,
+          input.repository,
+          posted.id,
+          input.account,
+          body,
+        )
+
+  await writeJson(join(input.outputDir, "posted.json"), updated)
+
+  return updated
+}
+
+async function finishWithResult(input: {
+  context: string
+  input: TriageRunInput
+  issue: IssueMeta
+  outputDir: string
+  processed?: number[]
+  relationship: RelationshipSummary
+  result: FinalResult
+}): Promise<TriageRunResult> {
+  const triage = input.input.repository.triage
+  if (!triage) throw new Error("triage configuration is required")
+  const plan = actionPlan({ result: input.result, triage })
+  await runActionPrompt({
+    context: input.context,
+    input: input.input,
+    outputDir: input.outputDir,
+    plan,
+    result: input.result,
+  })
+
+  let prUrl: string | undefined
+  const comment = plan.postComment
+    ? await composeResultComment({
+        action: plan.action,
+        context: `Result: ${input.result}\nAction: ${plan.action}\n\n${input.context}`,
+        input: input.input,
+        issue: input.issue,
+        outputDir: input.outputDir,
+        processed: input.processed,
+        result: input.result,
+      })
+    : undefined
+
+  if (!input.input.dryRun) {
+    if (comment) {
+      await postMarkedIssueComment({
+        account: triage.account ?? "",
+        body: comment,
+        exec: input.input.exec,
+        issue: input.issue.number,
+        outputDir: input.outputDir,
+        repository: input.input.repository,
+      })
+    }
+    if (plan.closeIssue) {
+      const closedPrs: number[] = []
+      for (const pr of input.relationship.relatedPullRequests.filter(
+        (pr) => pr.state === "OPEN",
+      )) {
+        await closePullRequest(
+          input.input.exec,
+          input.input.repository,
+          pr.number,
+          triage.account ?? "",
+        )
+        closedPrs.push(pr.number)
+      }
+      if (closedPrs.length)
+        await writeJson(join(input.outputDir, "closed-prs.json"), closedPrs)
+      await closeIssue(
+        input.input.exec,
+        input.input.repository,
+        input.issue.number,
+        triage.account ?? "",
+      )
+    }
+    if (plan.createPr) {
+      prUrl = await createImplementationPr({
+        context: input.context,
+        input: input.input,
+        issue: input.issue,
+        outputDir: input.outputDir,
+      })
+      if (prUrl)
+        await writeJson(join(input.outputDir, "pr.json"), { url: prUrl })
+    }
+    if (plan.clearLabels) {
+      await removeIssueLabels(
+        input.input.exec,
+        input.input.repository,
+        input.issue.number,
+        triage.automation.clear,
+        triage.account ?? "",
+      )
+    }
+  }
+
+  const report = [
+    `Magi triage result for #${input.issue.number}: ${input.result}`,
+    prUrl ? `Created PR: ${prUrl}` : undefined,
+    input.input.dryRun
+      ? "Dry run: no GitHub mutations were performed."
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n")
+  await writeFile(join(input.outputDir, "report.md"), `${report}\n`)
+
+  return {
+    issue: input.issue.number,
+    outputDir: input.outputDir,
+    report,
+    result: input.result,
+  }
 }
 
 function safetyBlocked(
@@ -422,7 +948,13 @@ async function createImplementationPr(input: {
   )
   try {
     await configureGitIdentity(input.input.exec, worktreePath, creator.author)
-    const prompt = `Implement issue #${input.issue.number}.\n\n${input.context}\n\nReturn the edit output contract.`
+    const prompt = await composeTriageCreatePrPrompt({
+      context: input.context,
+      directory: input.input.directory,
+      issue: input.issue.number,
+      repository: input.input.repository,
+      worktreePath,
+    })
     const result = await runModelWithRepair<EditOutput>({
       client: input.input.client,
       model: creator.model,
@@ -492,7 +1024,13 @@ export async function runTriage(
   )
 
   await writeJson(join(outputDir, "issue.json"), issue)
+  await writeJson(join(outputDir, "comments.json"), relationship.comments)
   await writeJson(join(outputDir, "relationship-summary.json"), relationship)
+  if (relationship.previousMarker)
+    await writeJson(
+      join(outputDir, "previous-triage.json"),
+      relationship.previousMarker,
+    )
 
   if (block) {
     const report = `Magi triage blocked for #${input.issue}: ${block}`
@@ -500,9 +1038,61 @@ export async function runTriage(
     return { issue: input.issue, outputDir, report, result: "FAILED" }
   }
 
-  const context = issueContext({ issue, relationship })
+  let context = issueContext({ issue, relationship })
+  await writeFile(join(outputDir, "context.md"), `${context}\n`)
+  let processed = relationship.previousMarker?.processed ?? []
+  let result: FinalResult | undefined
 
-  if (relationship.relatedPullRequests.length) {
+  if (relationship.previousMarker) {
+    if (!relationship.mentionReplies.length) {
+      const result = finalResultFromMarker(relationship.previousMarker)
+      const report = `Magi triage skipped #${issue.number} because no eligible mention replies were found for reconsideration.`
+      await writeFile(join(outputDir, "report.md"), `${report}\n`)
+      return { issue: issue.number, outputDir, report, result }
+    }
+
+    const classifications = await classifyMentionReplies({
+      context,
+      input,
+      outputDir,
+      replies: relationship.mentionReplies,
+    })
+    const triggeringComments = relationship.mentionReplies.filter((comment) =>
+      classifications.comments.some(
+        (item) =>
+          item.commentId === comment.id &&
+          RECONSIDERATION_CLASSES.has(item.classification),
+      ),
+    )
+    processed = [
+      ...new Set([
+        ...processed,
+        ...classifications.comments.map((comment) => comment.commentId),
+      ]),
+    ]
+
+    if (!triggeringComments.length) {
+      const result = finalResultFromMarker(relationship.previousMarker)
+      const report = `Magi triage skipped #${issue.number} because allowed mention replies did not request reconsideration.`
+      await writeFile(join(outputDir, "report.md"), `${report}\n`)
+      return { issue: issue.number, outputDir, report, result }
+    }
+
+    context = issueContext({
+      issue,
+      relationship,
+      reconsideration: {
+        classifications,
+        previousMarker: relationship.previousMarker,
+        triggeringComments,
+      },
+    })
+    await writeFile(join(outputDir, "context.md"), `${context}\n`)
+    result =
+      (await runReconsiderationVote({ context, input, outputDir })) ?? "ASK"
+  }
+
+  if (!result && relationship.relatedPullRequests.length) {
     const vote = await runPhaseVote<TriageExistingPrVote>({
       context,
       input,
@@ -518,15 +1108,53 @@ export async function runTriage(
         (pr) => pr.state === "MERGED",
       )
       if (merged && triage.automation.close) {
-        const body = `@${issue.author} Magi found a related merged pull request that appears to resolve this issue.\n\n${marker({ action: "CLOSE", issue: issue.number, result: "RESOLVED_BY_MERGED_PR" })}`
+        const plan: ActionPlan = {
+          action: "CLOSE",
+          allowedActions: ["CLOSE"],
+          clearLabels: true,
+          closeIssue: true,
+          createPr: false,
+          postComment: true,
+        }
+        await runActionPrompt({
+          context,
+          input,
+          outputDir,
+          plan,
+          result: "BUG_ACCEPTED",
+        })
+        const body = await composeResultComment({
+          action: "CLOSE",
+          context: `Result: BUG_ACCEPTED\nAction: CLOSE\n\n${context}`,
+          input,
+          issue,
+          outputDir,
+          processed,
+          result: "BUG_ACCEPTED",
+        })
         if (!input.dryRun) {
-          await postIssueComment(
-            input.exec,
-            input.repository,
-            issue.number,
-            triage.account,
+          await postMarkedIssueComment({
+            account: triage.account,
             body,
-          )
+            exec: input.exec,
+            issue: issue.number,
+            outputDir,
+            repository: input.repository,
+          })
+          const closedPrs: number[] = []
+          for (const pr of relationship.relatedPullRequests.filter(
+            (pr) => pr.state === "OPEN",
+          )) {
+            await closePullRequest(
+              input.exec,
+              input.repository,
+              pr.number,
+              triage.account,
+            )
+            closedPrs.push(pr.number)
+          }
+          if (closedPrs.length)
+            await writeJson(join(outputDir, "closed-prs.json"), closedPrs)
           await closeIssue(
             input.exec,
             input.repository,
@@ -550,22 +1178,19 @@ export async function runTriage(
           result: "BUG_ACCEPTED",
         }
       }
-      if (!input.dryRun) {
-        await removeIssueLabels(
-          input.exec,
-          input.repository,
-          issue.number,
-          triage.automation.clear,
-          triage.account,
-        )
-      }
-      const report = `Magi triage cleared #${issue.number} because a related PR handles it.`
-      await writeFile(join(outputDir, "report.md"), `${report}\n`)
-      return { issue: issue.number, outputDir, report, result: "CLEAR_ONLY" }
+      return finishWithResult({
+        context,
+        input,
+        issue,
+        outputDir,
+        processed,
+        relationship,
+        result: "CLEAR_ONLY",
+      })
     }
   }
 
-  if (relationship.duplicateCandidates.length) {
+  if (!result && relationship.duplicateCandidates.length) {
     const duplicate = await runDuplicateVote({
       candidateNumbers: relationship.duplicateCandidates.map(
         (candidate) => candidate.number,
@@ -575,173 +1200,73 @@ export async function runTriage(
       outputDir,
     })
     if (duplicate) {
-      const body = `@${issue.author} Magi triage found this issue duplicates #${duplicate.duplicateOf}.\n\nReason: ${duplicate.reason}\n\n${marker({ action: "CLOSE", issue: issue.number, result: "DUPLICATE" })}`
-      if (!input.dryRun) {
-        await postIssueComment(
-          input.exec,
-          input.repository,
-          issue.number,
-          triage.account,
-          body,
-        )
-      }
-      if (!input.dryRun && triage.automation.close) {
-        for (const pr of relationship.relatedPullRequests.filter(
-          (pr) => pr.state === "OPEN",
-        )) {
-          await closePullRequest(
-            input.exec,
-            input.repository,
-            pr.number,
-            triage.account,
-          )
-        }
-        await closeIssue(
-          input.exec,
-          input.repository,
-          issue.number,
-          triage.account,
-        )
-      }
-      if (!input.dryRun) {
-        await removeIssueLabels(
-          input.exec,
-          input.repository,
-          issue.number,
-          triage.automation.clear,
-          triage.account,
-        )
-      }
-      const report = `Magi triage marked #${issue.number} duplicate of #${duplicate.duplicateOf}.`
-      await writeFile(join(outputDir, "report.md"), `${report}\n`)
-      return { issue: issue.number, outputDir, report, result: "DUPLICATE" }
+      context = `${context}\n\nDuplicate decision: ${JSON.stringify(duplicate)}`
+      result = "DUPLICATE"
     }
   }
 
-  const kind =
-    resolveIssueKind(issue, input.repository) ??
-    (await runPhaseVote<TriageKindVote>({
-      context,
-      input,
-      outputDir,
-      parse: parseTriageKindOutput,
-      phase: "kind",
-      prompt: composeTriageKindPrompt,
-      schemaName: "triage kind",
-      votes: KIND_VOTES,
-    })) ??
-    "ASK"
-
-  let result: FinalResult = "ASK"
-  if (kind === "BUG") {
-    const vote = await runPhaseVote<TriageBinaryVote>({
-      context,
-      input,
-      outputDir,
-      parse: parseTriageBinaryOutput,
-      phase: "bug",
-      prompt: composeTriageBugPrompt,
-      schemaName: "triage bug",
-      votes: BINARY_VOTES,
+  if (!result) {
+    const resolvedKind = resolveIssueKind(issue, input.repository)
+    await writeJson(join(outputDir, "kind-resolution.json"), {
+      kind: resolvedKind,
+      source: resolvedKind ? "config" : "vote",
     })
-    result =
-      vote === "YES" ? "BUG_ACCEPTED" : vote === "NO" ? "BUG_REJECTED" : "ASK"
-  }
-  if (kind === "FEATURE") {
-    const vote = await runPhaseVote<TriageBinaryVote>({
-      context,
-      input,
-      outputDir,
-      parse: parseTriageBinaryOutput,
-      phase: "feature",
-      prompt: composeTriageFeaturePrompt,
-      schemaName: "triage feature",
-      votes: BINARY_VOTES,
-    })
-    result =
-      vote === "YES"
-        ? "FEATURE_ACCEPTED"
-        : vote === "NO"
-          ? "FEATURE_REJECTED"
-          : "ASK"
-  }
+    const kind =
+      resolvedKind ??
+      (await runPhaseVote<TriageKindVote>({
+        context,
+        input,
+        outputDir,
+        parse: parseTriageKindOutput,
+        phase: "kind",
+        prompt: composeTriageKindPrompt,
+        schemaName: "triage kind",
+        votes: KIND_VOTES,
+      })) ??
+      "ASK"
 
-  const needsClose =
-    triage.automation.close &&
-    (result === "BUG_REJECTED" || result === "FEATURE_REJECTED")
-  const needsPr =
-    triage.automation.pr &&
-    (result === "BUG_ACCEPTED" || result === "FEATURE_ACCEPTED")
-  const commentContext = `Result: ${result}\n\n${context}`
-  const commentPrompt = composeTriageCommentPrompt({
-    author: issue.author,
-    context: commentContext,
-    directory: input.directory,
-    issue: issue.number,
-    repository: input.repository,
-  })
-  const comment =
-    (
-      await runModelText({
-        allowEmpty: false,
-        client: input.client,
-        model: agents[0].model,
-        options: agents[0].options,
-        permission: agents[0].permission,
-        prompt: commentPrompt,
-        signal: input.signal,
-        title: `Magi triage comment #${issue.number}`,
+    result = "ASK"
+    if (kind === "BUG") {
+      const vote = await runPhaseVote<TriageBinaryVote>({
+        context,
+        input,
+        outputDir,
+        parse: parseTriageBinaryOutput,
+        phase: "bug",
+        prompt: composeTriageBugPrompt,
+        schemaName: "triage bug",
+        votes: BINARY_VOTES,
       })
-    ).raw + `\n\n${marker({ action: result, issue: issue.number, result })}`
-
-  let prUrl: string | undefined
-  if (!input.dryRun) {
-    await postIssueComment(
-      input.exec,
-      input.repository,
-      issue.number,
-      triage.account,
-      comment,
-    )
-    if (needsClose) {
-      for (const pr of relationship.relatedPullRequests.filter(
-        (pr) => pr.state === "OPEN",
-      )) {
-        await closePullRequest(
-          input.exec,
-          input.repository,
-          pr.number,
-          triage.account,
-        )
-      }
-      await closeIssue(
-        input.exec,
-        input.repository,
-        issue.number,
-        triage.account,
-      )
+      result =
+        vote === "YES" ? "BUG_ACCEPTED" : vote === "NO" ? "BUG_REJECTED" : "ASK"
     }
-    if (needsPr)
-      prUrl = await createImplementationPr({ context, input, issue, outputDir })
-    if (result !== "ASK") {
-      await removeIssueLabels(
-        input.exec,
-        input.repository,
-        issue.number,
-        triage.automation.clear,
-        triage.account,
-      )
+    if (kind === "FEATURE") {
+      const vote = await runPhaseVote<TriageBinaryVote>({
+        context,
+        input,
+        outputDir,
+        parse: parseTriageBinaryOutput,
+        phase: "feature",
+        prompt: composeTriageFeaturePrompt,
+        schemaName: "triage feature",
+        votes: BINARY_VOTES,
+      })
+      result =
+        vote === "YES"
+          ? "FEATURE_ACCEPTED"
+          : vote === "NO"
+            ? "FEATURE_REJECTED"
+            : "ASK"
     }
   }
 
-  const report = [
-    `Magi triage result for #${issue.number}: ${result}`,
-    prUrl ? `Created PR: ${prUrl}` : undefined,
-    input.dryRun ? "Dry run: no GitHub mutations were performed." : undefined,
-  ]
-    .filter(Boolean)
-    .join("\n")
-  await writeFile(join(outputDir, "report.md"), `${report}\n`)
-
-  return { issue: issue.number, outputDir, report, result }
+  return finishWithResult({
+    context,
+    input,
+    issue,
+    outputDir,
+    processed,
+    relationship,
+    result: result ?? "ASK",
+  })
 }

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -503,6 +503,12 @@ function markerCheckpoint(marker: TriageMarker): number | undefined {
   return marker.checkpoint ?? marker.commentId
 }
 
+function markerPr(marker: TriageMarker): number | undefined {
+  const pr = Number(marker.pr)
+
+  return Number.isInteger(pr) && pr > 0 ? pr : undefined
+}
+
 export function mentionAllowed(
   comment: IssueComment,
   repository: ResolvedRepository,
@@ -791,6 +797,49 @@ async function postMarkedIssueComment(input: {
   return updated
 }
 
+async function persistProcessedMarker(input: {
+  account: string
+  comments: IssueComment[]
+  exec: Exec
+  issue: IssueMeta
+  marker: TriageMarker
+  outputDir: string
+  processed: number[]
+  repository: ResolvedRepository
+}): Promise<void> {
+  if (!input.marker.commentId) return
+  const previousComment = input.comments.find(
+    (comment) => comment.id === input.marker.commentId,
+  )
+  if (!previousComment) return
+  const updatedMarker = marker({
+    action: input.marker.action ?? input.marker.result ?? "ASK",
+    checkpoint: markerCheckpoint(input.marker),
+    issue: input.issue.number,
+    pr: markerPr(input.marker),
+    processed: input.processed,
+    result: input.marker.result ?? "ASK",
+  })
+  const body = previousComment.body.replace(
+    /<!--\s*opencode-magi:triage\s+[^>]+?\s*-->/,
+    updatedMarker,
+  )
+
+  if (body === previousComment.body) return
+
+  const updated = await updateIssueComment(
+    input.exec,
+    input.repository,
+    input.marker.commentId,
+    input.account,
+    body,
+  )
+  await writeJson(join(input.outputDir, "processed.json"), {
+    processed: input.processed,
+    updated,
+  })
+}
+
 async function finishWithResult(input: {
   context: string
   input: TriageRunInput
@@ -1072,6 +1121,18 @@ export async function runTriage(
     ]
 
     if (!triggeringComments.length) {
+      if (!input.dryRun) {
+        await persistProcessedMarker({
+          account: triage.account,
+          comments: relationship.comments,
+          exec: input.exec,
+          issue,
+          marker: relationship.previousMarker,
+          outputDir,
+          processed,
+          repository: input.repository,
+        })
+      }
       const result = finalResultFromMarker(relationship.previousMarker)
       const report = `Magi triage skipped #${issue.number} because allowed mention replies did not request reconsideration.`
       await writeFile(join(outputDir, "report.md"), `${report}\n`)

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -12,6 +12,9 @@ import {
   composeRereviewCloseReconsiderationPrompt,
   composeRereviewPrompt,
   composeReviewPrompt,
+  composeTriageCommentPrompt,
+  composeTriageCreatePrPrompt,
+  composeTriageQuestionPrompt,
 } from "./compose"
 
 function evidence(
@@ -432,5 +435,110 @@ describe("prompt composer", () => {
 
     expect(prompt).toContain("After edit cycle 2: inspect old...new.")
     expect(prompt).toContain("caused by the PR changes or the editor changes")
+  })
+
+  test("uses configured triage comment, question, and create PR prompts", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "magi-prompt-"))
+    await writeFile(
+      join(dir, "triage-comment.md"),
+      "Comment for @{author}: {context}",
+    )
+    await writeFile(
+      join(dir, "triage-question.md"),
+      "Question for @{author}: {context}",
+    )
+    await writeFile(
+      join(dir, "triage-create-pr.md"),
+      "Implement in {worktreePath}: {context}",
+    )
+
+    const repository: ResolvedRepository = {
+      agents: {
+        reviewers: [],
+        triageCreator: {
+          account: "creator",
+          author: { email: "bot@example.com", name: "Bot" },
+          model: "openai/gpt",
+          permission: { edit: "allow" },
+          persona: "Keep the PR minimal.",
+        },
+      },
+      alias: "repo",
+      automation: { close: true, merge: true },
+      checks: {
+        exclude: [],
+        retryFailedJobs: 3,
+        waitAfterEdit: true,
+        waitBeforeReview: true,
+      },
+      concurrency: { runs: 3, reviewers: 3 },
+      github: {
+        apiRetryAttempts: 3,
+        host: "github.com",
+        owner: "owner",
+        repo: "repo",
+      },
+      merge: {
+        approvalPolicy: "majority",
+        auto: true,
+        deleteBranch: true,
+        maxThreadResolutionCycles: 5,
+        mergeQueue: false,
+        method: "squash",
+      },
+      prompts: {},
+      safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
+      triage: {
+        account: "magi-bot",
+        automation: { clear: ["triage"], close: false, pr: true },
+        concurrency: { runs: 3 },
+        kind: {
+          bug: { label: ["bug"], type: ["Bug"] },
+          feature: { label: ["enhancement"], type: ["Feature"] },
+        },
+        prompts: {
+          comment: "triage-comment.md",
+          createPr: "triage-create-pr.md",
+          question: "triage-question.md",
+        },
+        safety: {
+          allowAuthors: [],
+          allowMentionActors: [],
+          allowMentionRoles: ["MEMBER"],
+          blockedLabels: [],
+          requiredLabels: ["triage"],
+        },
+      },
+    }
+
+    const commentPrompt = await composeTriageCommentPrompt({
+      author: "octocat",
+      context: "accepted",
+      directory: dir,
+      issue: 58,
+      repository,
+    })
+    const questionPrompt = await composeTriageQuestionPrompt({
+      author: "octocat",
+      context: "missing logs",
+      directory: dir,
+      issue: 58,
+      repository,
+    })
+    const createPrPrompt = await composeTriageCreatePrPrompt({
+      context: "fix issue",
+      directory: dir,
+      issue: 58,
+      repository,
+      worktreePath: "/tmp/issue-58",
+    })
+
+    expect(commentPrompt).toContain("Comment for @octocat: accepted")
+    expect(questionPrompt).toContain("Question for @octocat: missing logs")
+    expect(createPrPrompt).toContain("Implement in /tmp/issue-58: fix issue")
+    expect(createPrPrompt).toContain(
+      "<persona>\nKeep the PR minimal.\n</persona>",
+    )
+    expect(createPrPrompt).toContain('"mode": "EDITED" | "REPLIED"')
   })
 })

--- a/src/prompts/compose.ts
+++ b/src/prompts/compose.ts
@@ -16,6 +16,7 @@ import {
   rereviewOutputContract,
   reviewOutputContract,
   triageCommentClassificationOutputContract,
+  triageActionOutputContract,
   triageDuplicateOutputContract,
   triageVoteOutputContract,
 } from "./contracts"
@@ -108,6 +109,14 @@ export interface TriageCommentPromptInput {
   repository: ResolvedRepository
 }
 
+export interface TriageCreatePrPromptInput {
+  context: string
+  directory: string
+  issue: number
+  repository: ResolvedRepository
+  worktreePath: string
+}
+
 async function readOptionalPrompt(
   directory: string,
   path?: string,
@@ -198,14 +207,18 @@ function editValues(input: EditPromptInput): Record<string, string> {
 }
 
 function triageValues(input: {
+  author?: string
   context: string
   issue: number
   repository: ResolvedRepository
+  worktreePath?: string
 }): Record<string, string> {
   return {
     ...repositoryValues(input.repository),
+    author: input.author ?? "",
     context: input.context,
     issue: String(input.issue),
+    worktreePath: input.worktreePath ?? "",
   }
 }
 
@@ -524,13 +537,74 @@ async function composeTriageVotePrompt(input: {
     .join("\n\n")
 }
 
-export function composeTriageCommentPrompt(
+export async function composeTriageActionPrompt(
+  input: TriagePromptInput,
+): Promise<string> {
+  return composeTriageVotePrompt({
+    ...input,
+    builtin: "action",
+    customPath: input.repository.triage?.prompts.action,
+    outputContract: triageActionOutputContract,
+  })
+}
+
+export async function composeTriageCommentPrompt(
   input: TriageCommentPromptInput,
-): string {
+): Promise<string> {
+  const values = triageValues(input)
+  const task = await taskBlock({
+    builtin: "triage/comment",
+    customPath: input.repository.triage?.prompts.comment,
+    directory: input.directory,
+    values,
+  })
+
   return [
-    `<task>\nCompose one concise GitHub issue comment for issue #${input.issue}. Mention @${input.author}. Use the context below and do not include markdown fences.\n</task>`,
+    task,
     languageBlock(input.repository.language),
     `<context>\n${input.context}\n</context>`,
+  ]
+    .filter(Boolean)
+    .join("\n\n")
+}
+
+export async function composeTriageQuestionPrompt(
+  input: TriageCommentPromptInput,
+): Promise<string> {
+  const values = triageValues(input)
+  const task = await taskBlock({
+    builtin: "triage/question",
+    customPath: input.repository.triage?.prompts.question,
+    directory: input.directory,
+    values,
+  })
+
+  return [
+    task,
+    languageBlock(input.repository.language),
+    `<context>\n${input.context}\n</context>`,
+  ]
+    .filter(Boolean)
+    .join("\n\n")
+}
+
+export async function composeTriageCreatePrPrompt(
+  input: TriageCreatePrPromptInput,
+): Promise<string> {
+  const values = triageValues(input)
+  const task = await taskBlock({
+    builtin: "triage/create-pr",
+    customPath: input.repository.triage?.prompts.createPr,
+    directory: input.directory,
+    values,
+  })
+  const persona = input.repository.agents.triageCreator?.persona
+
+  return [
+    task,
+    languageBlock(input.repository.language),
+    personaBlock(persona),
+    editOutputContract,
   ]
     .filter(Boolean)
     .join("\n\n")
@@ -601,5 +675,18 @@ export async function composeTriageCommentClassificationPrompt(
     builtin: "comment-classification",
     customPath: input.repository.triage?.prompts.commentClassification,
     outputContract: triageCommentClassificationOutputContract,
+  })
+}
+
+export async function composeTriageReconsiderPrompt(
+  input: TriagePromptInput,
+): Promise<string> {
+  return composeTriageVotePrompt({
+    ...input,
+    builtin: "reconsider",
+    customPath: input.repository.triage?.prompts.reconsider,
+    outputContract: triageVoteOutputContract(
+      '"ASK" | "BUG_ACCEPTED" | "BUG_REJECTED" | "DUPLICATE" | "FEATURE_ACCEPTED" | "FEATURE_REJECTED"',
+    ),
   })
 }

--- a/src/prompts/contracts.ts
+++ b/src/prompts/contracts.ts
@@ -224,6 +224,25 @@ The object must match this shape:
 }
 </output_contract>`.trim()
 
+export const triageActionOutputContract = `
+<output_contract>
+Return exactly one JSON object and nothing else. Do not wrap it in markdown.
+
+The object must match this shape:
+{
+  "action": "ASK" | "COMMENT" | "CLOSE" | "PR" | "CLEAR_ONLY",
+  "reason": "Short rationale."
+}
+
+Rules:
+- Choose only an action listed as allowed in the task context.
+- ASK means post an author-mentioned question and do not close, create a PR, or clear labels.
+- COMMENT means post a decision comment only.
+- CLOSE means post a decision comment and close the issue.
+- PR means post a decision comment and create an implementation PR.
+- CLEAR_ONLY means clear labels without posting a comment.
+</output_contract>`.trim()
+
 const outputContractsBySchemaName: Record<string, string> = {
   "CI classification": ciClassificationOutputContract,
   "close reconsideration": closeReconsiderationOutputContract,
@@ -232,6 +251,7 @@ const outputContractsBySchemaName: Record<string, string> = {
   rereview: rereviewOutputContract,
   "rereview close reconsideration": rereviewCloseReconsiderationOutputContract,
   review: reviewOutputContract,
+  "triage action": triageActionOutputContract,
   "triage bug": triageVoteOutputContract('"YES" | "NO" | "ASK"'),
   "triage comment classification": triageCommentClassificationOutputContract,
   "triage duplicate": triageDuplicateOutputContract,
@@ -240,6 +260,9 @@ const outputContractsBySchemaName: Record<string, string> = {
   ),
   "triage feature": triageVoteOutputContract('"YES" | "NO" | "ASK"'),
   "triage kind": triageVoteOutputContract('"BUG" | "FEATURE" | "ASK"'),
+  "triage reconsider": triageVoteOutputContract(
+    '"ASK" | "BUG_ACCEPTED" | "BUG_REJECTED" | "DUPLICATE" | "FEATURE_ACCEPTED" | "FEATURE_REJECTED"',
+  ),
 }
 
 export function repairPrompt(schemaName: string): string {

--- a/src/prompts/output.test.ts
+++ b/src/prompts/output.test.ts
@@ -5,7 +5,10 @@ import {
   parseRereviewOutput,
   parseReviewOutput,
   parseTriageBinaryOutput,
+  parseTriageActionOutput,
+  parseTriageCommentClassificationOutput,
   parseTriageDuplicateOutput,
+  parseTriageFinalOutput,
   parseTriageKindOutput,
 } from "./output"
 
@@ -161,5 +164,26 @@ describe("triage output parsing", () => {
     expect(() =>
       parseTriageDuplicateOutput('{"vote":"DUPLICATE","reason":"same"}'),
     ).toThrow("DUPLICATE requires duplicateOf")
+  })
+
+  test("parses triage action, final, and comment classification output", () => {
+    expect(
+      parseTriageActionOutput('{"action":"PR","reason":"accepted"}'),
+    ).toEqual({
+      action: "PR",
+      reason: "accepted",
+    })
+    expect(
+      parseTriageFinalOutput('{"vote":"FEATURE_ACCEPTED","reason":"valuable"}'),
+    ).toEqual({ reason: "valuable", vote: "FEATURE_ACCEPTED" })
+    expect(
+      parseTriageCommentClassificationOutput(
+        '{"comments":[{"commentId":123,"classification":"NEW_EVIDENCE","reason":"log"}]}',
+      ),
+    ).toEqual({
+      comments: [
+        { classification: "NEW_EVIDENCE", commentId: 123, reason: "log" },
+      ],
+    })
   })
 })

--- a/src/prompts/output.ts
+++ b/src/prompts/output.ts
@@ -6,12 +6,15 @@ import type {
   RereviewCloseReconsiderationOutput,
   RereviewOutput,
   ReviewOutput,
+  TriageAction,
+  TriageActionOutput,
   TriageBinaryVote,
   TriageCommentClassification,
   TriageCommentClassificationOutput,
   TriageDuplicateOutput,
   TriageDuplicateVote,
   TriageExistingPrVote,
+  TriageFinalVote,
   TriageKindVote,
   TriageVoteOutput,
   Verdict,
@@ -147,6 +150,19 @@ export function parseTriageKindOutput(
   return parseTriageVote(text, ["ASK", "BUG", "FEATURE"])
 }
 
+export function parseTriageFinalOutput(
+  text: string,
+): TriageVoteOutput<TriageFinalVote> {
+  return parseTriageVote(text, [
+    "ASK",
+    "BUG_ACCEPTED",
+    "BUG_REJECTED",
+    "DUPLICATE",
+    "FEATURE_ACCEPTED",
+    "FEATURE_REJECTED",
+  ])
+}
+
 export function parseTriageBinaryOutput(
   text: string,
 ): TriageVoteOutput<TriageBinaryVote> {
@@ -209,6 +225,23 @@ export function parseTriageCommentClassificationOutput(
         reason: requireString(value.reason, `comments[${index}].reason`),
       }
     }),
+  }
+}
+
+export function parseTriageActionOutput(text: string): TriageActionOutput {
+  const data = extractJson(text) as Record<string, unknown>
+  if (!data || typeof data !== "object")
+    throw new Error("triage action output must be an object")
+
+  return {
+    action: requireOneOf<TriageAction>(data.action, "action", [
+      "ASK",
+      "CLEAR_ONLY",
+      "CLOSE",
+      "COMMENT",
+      "PR",
+    ]),
+    reason: requireString(data.reason, "reason"),
   }
 }
 

--- a/src/prompts/templates/triage/action.md
+++ b/src/prompts/templates/triage/action.md
@@ -1,4 +1,4 @@
-Decide the next action for issue #{issue} in {owner}/{repo} from the provided triage result.
+Decide the next action for issue #{issue} in {owner}/{repo} from the provided triage result and allowed actions.
 
 <context>
 {context}

--- a/src/prompts/templates/triage/comment.md
+++ b/src/prompts/templates/triage/comment.md
@@ -1,4 +1,4 @@
-Compose a final triage comment for issue #{issue} in {owner}/{repo}.
+Compose one concise final triage comment for issue #{issue} in {owner}/{repo}. Mention @{author}. Do not include markdown fences.
 
 <context>
 {context}

--- a/src/prompts/templates/triage/create-pr.md
+++ b/src/prompts/templates/triage/create-pr.md
@@ -1,6 +1,6 @@
 Create an implementation pull request for issue #{issue} in {owner}/{repo}.
 
-Use the checked-out worktree and commit your changes. Return the required structured output.
+Use the checked-out worktree at {worktreePath} and commit your changes. Return the required structured output.
 
 <context>
 {context}

--- a/src/prompts/templates/triage/question.md
+++ b/src/prompts/templates/triage/question.md
@@ -1,4 +1,4 @@
-Compose concrete questions for issue #{issue} in {owner}/{repo}.
+Compose concrete, actionable questions for issue #{issue} in {owner}/{repo}. Mention @{author}. Do not include markdown fences.
 
 <context>
 {context}

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,6 +374,14 @@ export type TriageCommentClassification =
   | "NEW_EVIDENCE"
   | "OBJECTION"
   | "UNRELATED"
+export type TriageAction = "ASK" | "CLEAR_ONLY" | "CLOSE" | "COMMENT" | "PR"
+export type TriageFinalVote =
+  | "ASK"
+  | "BUG_ACCEPTED"
+  | "BUG_REJECTED"
+  | "DUPLICATE"
+  | "FEATURE_ACCEPTED"
+  | "FEATURE_REJECTED"
 
 export interface TriageVoteOutput<T extends string = string> {
   reason: string
@@ -390,6 +398,11 @@ export interface TriageCommentClassificationOutput {
     commentId: number
     reason: string
   }[]
+}
+
+export interface TriageActionOutput {
+  action: TriageAction
+  reason: string
 }
 
 export type EditResponseAction = "ASK" | "DISAGREE" | "FIXED"


### PR DESCRIPTION
Closes #58

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Completes the remaining `/magi:triage` runtime implementation that was left partially exposed by the original triage command work. This wires the documented triage config and prompt keys into runtime behavior and fills the broader missing pieces tracked in issue #58, based on the original issue #47 design.

## Current behavior (updates)

Several triage settings and templates were accepted by schema/docs but were not fully connected to orchestration. Triage runs were also mostly synchronous and were not integrated with Magi run lifecycle tooling.

## New behavior

- Wires triage action, comment, question, comment classification, reconsideration, and create-PR prompt overrides.
- Uses mention actor/role safety settings for reconsideration triggers.
- Adds marker checkpoint handling, posted/comment/PR/closed-PR/context/previous-triage artifacts, and per-agent prompt/raw/json artifacts.
- Improves bounded related PR and duplicate candidate discovery.
- Integrates triage runs with status, output, cancel, and clear lifecycle handling.
- Adds prompt docs, parser coverage, prompt composition tests, mention gating tests, and related command/helper tests.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Targeted tests run locally:

```txt
pnpm test src/orchestrator/triage.test.ts src/prompts/output.test.ts src/prompts/compose.test.ts src/github/commands.test.ts src/index.test.ts src/commands.test.ts
```