### PR TITLE
docs: add documentation link rules

### DIFF
--- a/.agents/rules/branch.md
+++ b/.agents/rules/branch.md
@@ -2,7 +2,7 @@
 
 **Format:** `<type>/<description>`
 
-- `type` matches the [Commit Rules](./commit.md) types (`feat`, `fix`, `test`, `docs`, `refactor`, `chore`, `ci`, `build`, `perf`, `style`).
+- `type` matches the [Commit Rules](commit.md) types (`feat`, `fix`, `test`, `docs`, `refactor`, `chore`, `ci`, `build`, `perf`, `style`).
 - `description` is kebab-case and briefly identifies the scope or area (command, config, workflow, prompt, or topic).
 
 **Examples:**

--- a/.agents/rules/documentation.md
+++ b/.agents/rules/documentation.md
@@ -1,0 +1,9 @@
+# Documentation Rules
+
+Use plain filenames for same-directory links. Use relative paths without a leading `./` for links within the current directory tree. Use repository-root absolute paths when a link would otherwise need to traverse up with `../`.
+
+For same-directory links, omit the `./` prefix. For example, write `[Commit Rules](commit.md)` instead of `[Commit Rules](./commit.md)`.
+
+For links within the current directory tree, omit the leading `/`. For example, write `[Review](review/review.md)` instead of `[Review](/docs/prompts/review/review.md)`.
+
+When a link would need to traverse up with `../`, use a repository-root absolute path instead. For example, write `[Pull Request Template](/.github/pull_request_template.md)` instead of `[Pull Request Template](../../.github/pull_request_template.md)`.

--- a/.agents/rules/issue.md
+++ b/.agents/rules/issue.md
@@ -2,6 +2,6 @@
 
 Templates are provided for each type. Always follow the appropriate template.
 
-- [Bug Report](../../.github/ISSUE_TEMPLATE/bug_report.yml): Create a bug report.
-- [Feature Request](../../.github/ISSUE_TEMPLATE/feature_request.yml): Request for features or enhancements.
-- [Task](../../.github/ISSUE_TEMPLATE/task.yml): Track internal maintenance work that is not a bug report or feature request.
+- [Bug Report](/.github/ISSUE_TEMPLATE/bug_report.yml): Create a bug report.
+- [Feature Request](/.github/ISSUE_TEMPLATE/feature_request.yml): Request for features or enhancements.
+- [Task](/.github/ISSUE_TEMPLATE/task.yml): Track internal maintenance work that is not a bug report or feature request.

--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -1,10 +1,10 @@
 # PR Rules
 
-Read the [template](../../.github/pull_request_template.md) and use its structure for the PR body. Replace the HTML comments with actual content.
+Read the [template](/.github/pull_request_template.md) and use its structure for the PR body. Replace the HTML comments with actual content.
 
 - Use the same format as the commit message for the title.
 - Always include `Closes #<issue-number>`.
 - Clearly state whether this is a breaking change.
 - The template includes an "AI used" section. If AI generated the PR, uncheck "I did not use AI" and check "I checked the generated content before submitting."
 
-After creating a PR, the [Quality](../../.github/workflows/quality.yml) GitHub Action runs automatically to validate format, lint, typecheck, and tests. Monitor it to ensure there are no issues. If problems are found, fix them and resubmit.
+After creating a PR, the [Quality](/.github/workflows/quality.yml) GitHub Action runs automatically to validate format, lint, typecheck, and tests. Monitor it to ensure there are no issues. If problems are found, fix them and resubmit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ When editing or reviewing files that match a pattern below, read the linked rule
   - `schema.json`
   - `package.json`
   - `README.md`
+- [Documentation](.agents/rules/documentation.md):
+  - `{.agents,docs}/**/*.md`
+  - `./*.md`
 
 ## Development Commands
 


### PR DESCRIPTION
Closes #70

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds documentation link path rules and updates existing agent rule links to follow them.

## Current behavior (updates)

Documentation rules did not define how to format same-directory links, links within a directory tree, or links that would otherwise need parent-directory traversal.

## New behavior

Documentation rules now require plain filenames for same-directory links, relative paths without a leading `./` within the current directory tree, and repository-root absolute paths instead of `../` traversal. Existing agent rule links are updated accordingly.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change.