### PR TITLE
docs(agents): add create issue skill

### DIFF
--- a/.agents/rules/skills.md
+++ b/.agents/rules/skills.md
@@ -1,0 +1,63 @@
+# Skill Rules
+
+Follow these rules when creating or modifying skills.
+
+## Specification
+
+Conform to the [Agent Skills Specification](https://agentskills.io/specification.md).
+
+### Directory Structure
+
+```text
+skill-name/
+├── SKILL.md          # Required: metadata + instructions
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+└── assets/           # Optional: templates, resources
+```
+
+### `SKILL.md` Frontmatter
+
+| Field           | Required | Summary                                                   |
+| --------------- | -------- | --------------------------------------------------------- |
+| `name`          | Yes      | Lowercase alphanumeric + hyphens, 1-64 chars, matches dir |
+| `description`   | Yes      | What it does & when to use it, 1-1024 chars               |
+| `license`       | No       | License name                                              |
+| `compatibility` | No       | Environment requirements, 1-500 chars                     |
+| `metadata`      | No       | Arbitrary key-value pairs                                 |
+| `allowed-tools` | No       | Pre-approved tools (space-separated)                      |
+
+### Size Limits
+
+- Keep `SKILL.md` body under **500 lines / 5,000 tokens**
+- Split details into `references/` and load only when needed (Progressive Disclosure)
+
+## Best Practices
+
+Follow [Best practices for skill creators](https://agentskills.io/skill-creation/best-practices.md). Key points below.
+
+### Content
+
+- **Write only what the agent lacks** — skip general knowledge
+- **Write procedures, not answers** — reusable approaches, not instance-specific outputs
+- **Pick one default** — recommend one tool/approach, mention alternatives briefly
+- **Gotchas section** — list non-obvious pitfalls concretely
+
+### Patterns
+
+Use as needed. Not all are required for every skill.
+
+- **Templates** — show concrete output structure instead of prose descriptions
+- **Checklists** — track progress in multi-step workflows
+- **Validation loops** — do → validate → fix → re-validate cycle
+- **Plan-Validate-Execute** — validate intermediate plan before executing batch/destructive operations
+
+### Calibrating Control
+
+- Flexible areas → **explain why** (agent can judge from purpose)
+- Fragile areas → **prescribe exact steps** (no deviation)
+
+### Iterative Refinement
+
+- Run against real tasks, review execution traces, and improve
+- Add agent mistakes to the Gotchas section

--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: create-issue
+description: Create GitHub issues for opencode-magi. Use when asked to create, draft, file, open, or submit an issue, bug report, task, or feature request.
+---
+
+## Input
+
+Use the user's request text, and any command arguments if provided, as the initial issue context.
+
+Ask only for missing information that is needed to create a good issue.
+
+- Ask about required template fields only when they cannot be inferred.
+- Ask about optional fields only when they materially improve the issue.
+- Ask whether the user will work on the issue if that is unclear.
+- For bugs, collect environment details only when the selected template requires them. Use local commands only for issues about the current local environment; do not guess the user's environment.
+- If ambiguity changes the issue type or meaning, clarify before drafting.
+
+## Type Selection
+
+Every issue must use exactly one GitHub Issue Type: `Bug`, `Task`, or `Feature`.
+
+- `Bug`: broken behavior, unexpected results, documentation drift, workflow failures, or mismatches between expected and actual behavior.
+- `Feature`: new user-facing behavior, enhancements to existing behavior, or new APIs/configuration.
+- `Task`: internal maintenance that is not a bug or feature, such as AGENTS.md improvements, GitHub workflow cleanup, documentation organization, or repository operations.
+
+Choose the type yourself when the request is clear. Ask the user to choose `Bug`, `Task`, or `Feature` only when you cannot determine it.
+
+## References
+
+Read only the files needed for the selected issue.
+
+- Rules: `.agents/rules/issue.md`
+- `Bug`: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- `Feature`: `.github/ISSUE_TEMPLATE/feature_request.yml`
+- `Task`: `.github/ISSUE_TEMPLATE/task.yml`
+
+Build the issue body from the selected template. Do not keep a fixed field list in this skill.
+
+## Workflow
+
+1. Extract the useful information from the user's request and ask only for essential missing details.
+2. Select the issue type, asking the user only if you cannot determine it.
+3. Read `.agents/rules/issue.md` and the template for the selected type.
+4. Search open and closed issues for likely duplicates.
+5. If likely duplicates exist, show them to the user and ask whether to continue.
+6. Draft the title, body, labels, and assignee decision from the selected template.
+7. Show the generated issue content to the user for confirmation before submitting.
+8. Create the issue, then set and verify the GitHub Issue Type.
+9. Report the issue URL and Issue Type.
+10. Ask: "Do you want to create the PR for this issue now?"
+
+## Template Handling
+
+Follow the selected issue template. Prioritize required fields and include optional fields only when useful.
+
+When this skill creates the issue, the `AI used` section must be:
+
+```markdown
+## AI used
+
+- [ ] I did not use AI to create this issue.
+- [x] (If there is no check above) I checked the generated content before submitting.
+```
+
+## Assignment
+
+Following the selected template, ask whether the user will work on the issue. If they will, assign `@me` when possible.
+
+If assignment fails because of permissions or repository settings, continue creating the issue and report the assignment failure.
+
+## Gotchas
+
+- Do not create an issue without a `Bug`, `Task`, or `Feature` type.
+- Do not skip user confirmation before submitting the issue.
+- Pass the issue body through a temporary file. Do not pass bodies with backticks or other shell-sensitive text as inline command strings.
+- Do not assume `gh issue create` set the Issue Type. Verify it after creation and set it with GraphQL if needed.
+- If the user chooses to create a PR, read this repository's branch, commit, and PR rules before creating it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ When performing one of the actions below, read the linked rule first.
 
 When editing or reviewing files that match a pattern below, read the linked rule first.
 
+- [Skills](.agents/rules/skills.md):
+  - `.agents/skills/**/*.md`
 - [Changesets](.agents/rules/changesets.md):
   - `src/**/*.{ts,md,json}`
   - `!src/**/*.test.ts`


### PR DESCRIPTION
Closes #72

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a `create-issue` skill and skill authoring rules for repository agents.

## Current behavior (updates)

The repository has issue templates and issue rules, but no reusable skill for creating issues consistently. Skill files also did not have a dedicated rule reference in `AGENTS.md`.

## New behavior

Agents now have a `create-issue` skill that guides issue creation through the repository templates, Issue Type selection, duplicate checks, AI-used handling, assignment, and follow-up PR prompts. `AGENTS.md` also points skill edits to the new skill rules.

## Is this a breaking change (Yes/No):

No

## Additional Information

No local tests were run because this change only adds Markdown-based agent instructions.
