### PR TITLE
chore(config): add triage magi config

### DIFF
--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -55,5 +55,44 @@
         "email": "hirotomo.yamada@avap.co.jp"
       }
     }
+  },
+  "triage": {
+    "account": "hirotomoyamada",
+    "agents": [
+      {
+        "id": "Melchior",
+        "model": "openai/gpt-5.5",
+        "options": {
+          "reasoningEffort": "high"
+        }
+      },
+      {
+        "id": "Balthasar",
+        "model": "opencode/deepseek-v4-flash-free",
+        "options": {
+          "reasoningEffort": "high"
+        }
+      },
+      {
+        "id": "Caspar",
+        "model": "opencode/qwen3.6-plus-free",
+        "options": {
+          "thinking": {
+            "type": "enabled",
+            "budgetTokens": 16000
+          }
+        }
+      }
+    ],
+    "creator": {
+      "model": "openai/gpt-5.5",
+      "options": {
+        "reasoningEffort": "high"
+      },
+      "author": {
+        "name": "hirotomoyamada",
+        "email": "hirotomo.yamada@avap.co.jp"
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes N/A (no issue created per request)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds triage configuration to `.opencode/magi.json`.

## Current behavior (updates)

The local Magi configuration only defines the existing review and merge settings.

## New behavior

The configuration now includes triage account, agent, and creator settings.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validated `.opencode/magi.json` parses as JSON.