### PR TITLE
fix(github): fix related PR GraphQL query

### DIFF
--- a/.changeset/fix-related-pr-graphql.md
+++ b/.changeset/fix-related-pr-graphql.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Fix malformed GraphQL used when fetching issue-related pull requests.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -199,9 +199,13 @@ describe("GitHub command helpers", () => {
   })
 
   test("normalizes searched related pull request states", async () => {
+    let graphqlCommand = ""
+
     const result = await fetchRelatedPullRequests(
       async (command) => {
         if (command.includes("graphql")) {
+          graphqlCommand = command
+
           return JSON.stringify({
             data: {
               repository: {
@@ -244,6 +248,7 @@ describe("GitHub command helpers", () => {
       58,
     )
 
+    expectBalancedBraces(extractGraphqlQuery(graphqlCommand))
     expect(result.map((pr) => [pr.number, pr.state])).toEqual([
       [10, "MERGED"],
       [11, "CLOSED"],

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -462,7 +462,7 @@ export async function fetchRelatedPullRequests(
   repository: ResolvedRepository,
   issue: number,
 ): Promise<RelatedPullRequest[]> {
-  const query = `query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { timelineItems(first: 50, itemTypes: [CONNECTED_EVENT, CROSS_REFERENCED_EVENT]) { nodes { __typename ... on ConnectedEvent { subject { __typename ... on PullRequest { number title url state mergedAt body author { login } } } } ... on CrossReferencedEvent { source { __typename ... on PullRequest { number title url state mergedAt body author { login } } } } } } } } } }`
+  const query = `query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { timelineItems(first: 50, itemTypes: [CONNECTED_EVENT, CROSS_REFERENCED_EVENT]) { nodes { __typename ... on ConnectedEvent { subject { __typename ... on PullRequest { number title url state mergedAt body author { login } } } } ... on CrossReferencedEvent { source { __typename ... on PullRequest { number title url state mergedAt body author { login } } } } } } } } }`
   const raw = await exec(
     `gh api${ghHostOption(repository)} graphql -f query=${shellQuote(query)} -F owner=${shellQuote(repository.github.owner)} -F repo=${shellQuote(repository.github.repo)} -F issue=${issue}`,
   )


### PR DESCRIPTION
Closes #76

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes the malformed GraphQL query used when fetching pull requests related to an issue during triage.

## Current behavior (updates)

Magi triage can fail during related PR lookup because the inline GraphQL query has an extra closing brace.

## New behavior

The related PR GraphQL query is balanced, and the existing related PR test now verifies the generated query shape.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm test src/github/commands.test.ts`.