### PR TITLE
fix(commands): remove internal slash commands

### DIFF
--- a/.changeset/remove-internal-commands.md
+++ b/.changeset/remove-internal-commands.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Remove internal follow-up tools from the public Magi slash command list.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -71,9 +71,6 @@ body:
         - "/magi:validate"
         - "/magi:review"
         - "/magi:merge"
-        - "/magi:status"
-        - "/magi:output"
-        - "/magi:cancel"
         - "Other (add additional context)"
   - type: textarea
     id: steps

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, test } from "vitest"
 import { MAGI_COMMANDS } from "./commands"
 
 describe("Magi slash commands", () => {
+  test("exposes only user-facing commands", () => {
+    expect(Object.keys(MAGI_COMMANDS)).toEqual([
+      "magi:clear",
+      "magi:merge",
+      "magi:triage",
+      "magi:review",
+      "magi:validate",
+    ])
+  })
+
   test("keeps review and merge templates terse", () => {
     expect(MAGI_COMMANDS["magi:clear"].template).toBe(
       "Call the `magi_clear` tool.",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,12 +3,6 @@ export const MAGI_COMMANDS = {
     description: "Clear inactive Magi runs, sessions, worktrees, and outputs",
     template: "Call the `magi_clear` tool.",
   },
-  "magi:cancel": {
-    description: "Cancel a Magi background run",
-    template: [`Call the \`magi_cancel\` tool.`, "Selector: $ARGUMENTS"].join(
-      "\n",
-    ),
-  },
   "magi:merge": {
     description: "Review and merge pull requests with Magi",
     template: [`Call the \`magi_merge\` tool.`, "PR: $ARGUMENTS"].join("\n"),
@@ -22,18 +16,6 @@ export const MAGI_COMMANDS = {
   "magi:review": {
     description: "Review pull requests with Magi",
     template: [`Call the \`magi_review\` tool.`, "PR: $ARGUMENTS"].join("\n"),
-  },
-  "magi:output": {
-    description: "Show Magi run output artifacts",
-    template: [`Call the \`magi_output\` tool.`, "Selector: $ARGUMENTS"].join(
-      "\n",
-    ),
-  },
-  "magi:status": {
-    description: "Show Magi background run status",
-    template: [`Call the \`magi_status\` tool.`, "Selector: $ARGUMENTS"].join(
-      "\n",
-    ),
   },
   "magi:validate": {
     description: "Validate Magi config",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -85,7 +85,7 @@ describe("tool descriptions", () => {
     expect(tools.magi_merge.description).toContain(
       "do not tell users to call follow-up tools by name",
     )
-    for (const name of ["magi_status", "magi_output"]) {
+    for (const name of ["magi_status", "magi_output", "magi_cancel"]) {
       expect(tools[name]?.description).toContain(
         "Assistant-facing follow-up tool.",
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -653,7 +653,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         },
       }),
       magi_cancel: tool({
-        description: "Cancel a Magi background run by runId, PR, or issue.",
+        description: [
+          "Cancel a Magi background run by runId, PR, or issue.",
+          INTERNAL_FOLLOW_UP_TOOL_NOTE,
+        ].join(" "),
         args: {
           runId: tool.schema.string().optional(),
           pr: tool.schema.string().optional(),


### PR DESCRIPTION
Closes #79

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Removes assistant-facing internal utility commands from the public Magi slash command registry.

## Current behavior (updates)

`/magi:cancel`, `/magi:status`, and `/magi:output` are exposed as public slash commands even though they call follow-up tools intended for assistant use.

## New behavior

Only user-facing commands remain in `MAGI_COMMANDS`. The underlying `magi_cancel`, `magi_status`, and `magi_output` tools remain available internally, and `magi_cancel` now carries the same assistant-facing tool guidance as the other follow-up tools.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Tested with `pnpm test src/commands.test.ts src/index.test.ts`.
