### PR TITLE
fix(triage): harden duplicate issue search

### DIFF
--- a/.changeset/fix-triage-duplicate-search.md
+++ b/.changeset/fix-triage-duplicate-search.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Fix triage duplicate searches for issue titles that look like GitHub qualifiers.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -165,9 +165,12 @@ describe("GitHub command helpers", () => {
   })
 
   test("excludes the current issue from duplicate search candidates", async () => {
+    const commands: string[] = []
     const result = await searchDuplicateIssues(
-      async () =>
-        JSON.stringify([
+      async (command) => {
+        commands.push(command)
+
+        return JSON.stringify([
           {
             body: "same issue",
             number: 42,
@@ -182,7 +185,8 @@ describe("GitHub command helpers", () => {
             title: "Bug report",
             url: "https://github.com/owner/repo/issues/43",
           },
-        ]),
+        ])
+      },
       repository,
       {
         author: "author",
@@ -195,7 +199,38 @@ describe("GitHub command helpers", () => {
       },
     )
 
+    expect(commands[0]).toContain("gh search issues --repo 'owner/repo'")
+    expect(commands[0]).toContain("-- 'Bug report'")
+    expect(commands[0]).not.toContain("repo:owner/repo")
+    expect(commands[0]).not.toContain(" -42")
     expect(result.map((item) => item.number)).toEqual([43])
+  })
+
+  test("keeps duplicate issue search qualifiers out of title query", async () => {
+    const commands: string[] = []
+
+    await searchDuplicateIssues(
+      async (command) => {
+        commands.push(command)
+
+        return "[]"
+      },
+      repository,
+      {
+        author: "author",
+        body: "body",
+        labels: [],
+        number: 75,
+        state: "OPEN",
+        title:
+          "Align docs/config.md triage.prompts entries with review and merge prompts",
+        url: "https://github.com/owner/repo/issues/75",
+      },
+    )
+
+    expect(commands).toEqual([
+      "gh search issues --repo 'owner/repo' --json number,title,url,state,body --limit 5 -- 'Align docs/config.md triage.prompts entries with review and merge prompts'",
+    ])
   })
 
   test("normalizes searched related pull request states", async () => {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -572,7 +572,7 @@ export async function searchDuplicateIssues(
   issue: IssueMeta,
   limit = 5,
 ): Promise<DuplicateIssueCandidate[]> {
-  const query = `${issue.title} repo:${repoSlug(repository)} is:issue -${issue.number}`
+  const query = issue.title
   const explicitCandidates = await Promise.all(
     duplicateReferences(issue.body)
       .filter((number) => number !== issue.number)
@@ -586,7 +586,7 @@ export async function searchDuplicateIssues(
       ),
   )
   const raw = await exec(
-    `gh search issues ${shellQuote(query)} --json number,title,url,state,body --limit ${limit}`,
+    `gh search issues --repo ${shellQuote(repoSlug(repository))} --json number,title,url,state,body --limit ${limit} -- ${shellQuote(query)}`,
   )
   const data = JSON.parse(raw) as {
     body?: string

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -1,14 +1,50 @@
-import { describe, expect, test } from "vitest"
-import type { IssueComment } from "../github/commands"
-import type { ResolvedRepository } from "../types"
+import { afterEach, describe, expect, test } from "vitest"
+import { mkdtemp, rm as removePath } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type {
+  DuplicateIssueCandidate,
+  IssueComment,
+  IssueMeta,
+  RelatedPullRequest,
+} from "../github/commands"
+import type { Exec, ResolvedRepository } from "../types"
+import type { ModelClient } from "./model"
 import {
   chooseDuplicateOutput,
   eligibleMentionReplies,
   mentionAllowed,
+  resolveIssueKind,
+  runTriage,
 } from "./triage"
 
 const repository: ResolvedRepository = {
-  agents: { reviewers: [] },
+  agents: {
+    reviewers: [],
+    triage: [
+      {
+        id: "Melchior",
+        index: 0,
+        key: "Melchior",
+        model: "mock/model",
+        permission: "deny",
+      },
+      {
+        id: "Balthasar",
+        index: 1,
+        key: "Balthasar",
+        model: "mock/model",
+        permission: "deny",
+      },
+      {
+        id: "Caspar",
+        index: 2,
+        key: "Caspar",
+        model: "mock/model",
+        permission: "deny",
+      },
+    ],
+  },
   alias: "repo",
   automation: { close: false, merge: true },
   checks: {
@@ -53,6 +89,17 @@ const repository: ResolvedRepository = {
   },
 }
 
+const temporaryDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirs.map((dir) =>
+      removePath(dir, { force: true, recursive: true }),
+    ),
+  )
+  temporaryDirs.length = 0
+})
+
 function comment(overrides: Partial<IssueComment>): IssueComment {
   return {
     author: "user",
@@ -64,7 +111,507 @@ function comment(overrides: Partial<IssueComment>): IssueComment {
   }
 }
 
+function issue(overrides: Partial<IssueMeta> = {}): IssueMeta {
+  return {
+    author: "author",
+    body: "Issue body",
+    labels: ["triage"],
+    number: 1,
+    state: "OPEN",
+    title: "Issue title",
+    url: "https://github.com/owner/repo/issues/1",
+    ...overrides,
+  }
+}
+
+function issueResponse(value: IssueMeta): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          author: { login: value.author },
+          body: value.body,
+          issueType: value.type ? { name: value.type } : null,
+          labels: { nodes: value.labels.map((name) => ({ name })) },
+          number: value.number,
+          state: value.state,
+          title: value.title,
+          url: value.url,
+        },
+      },
+    },
+  })
+}
+
+function commentsResponse(values: IssueComment[]): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          comments: {
+            nodes: values.map((value) => ({
+              author: { login: value.author },
+              authorAssociation: value.authorAssociation,
+              body: value.body,
+              createdAt: value.createdAt,
+              databaseId: value.id,
+              url: value.url,
+            })),
+          },
+        },
+      },
+    },
+  })
+}
+
+function relatedPullRequestsResponse(values: RelatedPullRequest[]): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          timelineItems: {
+            nodes: values.map((value) => ({
+              __typename: "CrossReferencedEvent",
+              source: {
+                __typename: "PullRequest",
+                author: { login: value.author },
+                body: value.body,
+                mergedAt: value.mergedAt,
+                number: value.number,
+                state: value.state,
+                title: value.title,
+                url: value.url,
+              },
+            })),
+          },
+        },
+      },
+    },
+  })
+}
+
+function createExec(input: {
+  comments?: IssueComment[]
+  duplicateCandidates?: DuplicateIssueCandidate[]
+  issue?: IssueMeta
+  relatedPullRequests?: RelatedPullRequest[]
+}): { commands: string[]; exec: Exec } {
+  const commands: string[] = []
+  const value = input.issue ?? issue()
+  const exec: Exec = async (command) => {
+    commands.push(command)
+
+    if (command.startsWith("gh auth token")) return "token\n"
+    if (
+      command.includes("repos/owner/repo/issues/1/comments") &&
+      command.includes("--method POST")
+    ) {
+      return JSON.stringify({
+        id: 9001,
+        url: "https://github.com/owner/repo/issues/1#issuecomment-9001",
+      })
+    }
+    if (
+      command.includes("repos/owner/repo/issues/comments/9001") &&
+      command.includes("--method PATCH")
+    ) {
+      return JSON.stringify({
+        id: 9001,
+        url: "https://github.com/owner/repo/issues/1#issuecomment-9001",
+      })
+    }
+    if (command.startsWith("gh issue close 1")) return "closed"
+    if (command.startsWith("gh issue edit 1")) return ""
+    if (command.startsWith("gh issue view 10")) {
+      return JSON.stringify({
+        body: "Original issue",
+        createdAt: "2026-01-01T00:00:00Z",
+        number: 10,
+        state: "OPEN",
+        title: "Original issue",
+        url: "https://github.com/owner/repo/issues/10",
+      })
+    }
+    if (command.startsWith("gh search issues")) {
+      return JSON.stringify(input.duplicateCandidates ?? [])
+    }
+    if (command.startsWith("gh search prs")) return "[]"
+    if (command.includes("comments(last:")) {
+      return commentsResponse(input.comments ?? [])
+    }
+    if (command.includes("timelineItems")) {
+      return relatedPullRequestsResponse(input.relatedPullRequests ?? [])
+    }
+    if (command.includes("issueType")) return issueResponse(value)
+
+    throw new Error(`Unexpected command: ${command}`)
+  }
+
+  return { commands, exec }
+}
+
+function createModelClient(outputs: string[]): {
+  client: ModelClient
+  prompts: string[]
+  sessionTitles: string[]
+} {
+  const prompts: string[] = []
+  const sessionTitles: string[] = []
+  const client: ModelClient = {
+    session: {
+      async create(input) {
+        sessionTitles.push(input.body.title)
+
+        return { id: `session-${sessionTitles.length}` }
+      },
+      async prompt(input) {
+        const parts = input.body.parts as { text?: string; type: string }[]
+        const text = outputs.shift()
+
+        prompts.push(parts.map((part) => part.text ?? "").join("\n"))
+        if (text == null) throw new Error("Missing mocked model output")
+
+        return { info: { text }, parts: [{ text, type: "text" }] }
+      },
+    },
+  }
+
+  return { client, prompts, sessionTitles }
+}
+
+async function runScenario(input: {
+  comments?: IssueComment[]
+  dryRun?: boolean
+  duplicateCandidates?: DuplicateIssueCandidate[]
+  issue?: IssueMeta
+  outputs: string[]
+  relatedPullRequests?: RelatedPullRequest[]
+  repository?: ResolvedRepository
+}) {
+  const directory = await mkdtemp(join(tmpdir(), "magi-triage-test-"))
+  temporaryDirs.push(directory)
+  const model = createModelClient([...input.outputs])
+  const exec = createExec({
+    comments: input.comments,
+    duplicateCandidates: input.duplicateCandidates,
+    issue: input.issue,
+    relatedPullRequests: input.relatedPullRequests,
+  })
+  const result = await runTriage({
+    client: model.client,
+    config: {},
+    directory,
+    dryRun: input.dryRun ?? true,
+    exec: exec.exec,
+    issue: 1,
+    repository: input.repository ?? repository,
+    runId: "run-test",
+  })
+
+  return { ...exec, ...model, result }
+}
+
+function vote(vote: string): string {
+  return JSON.stringify({ reason: `${vote} reason`, vote })
+}
+
+function duplicateVote(vote: string, duplicateOf?: number): string {
+  return JSON.stringify({ duplicateOf, reason: `${vote} reason`, vote })
+}
+
+function action(action: string): string {
+  return JSON.stringify({ action, reason: `${action} reason` })
+}
+
+function repositoryWithTriage(
+  triage: Partial<NonNullable<ResolvedRepository["triage"]>>,
+): ResolvedRepository {
+  return {
+    ...repository,
+    triage: {
+      ...repository.triage!,
+      ...triage,
+      automation: {
+        ...repository.triage!.automation,
+        ...triage.automation,
+      },
+      safety: {
+        ...repository.triage!.safety,
+        ...triage.safety,
+      },
+    },
+  }
+}
+
 describe("triage orchestration", () => {
+  test("resolves issue kind from configured labels and issue types", () => {
+    expect(resolveIssueKind(issue({ type: "Bug" }), repository)).toBe("BUG")
+    expect(resolveIssueKind(issue({ type: "Feature" }), repository)).toBe(
+      "FEATURE",
+    )
+    expect(resolveIssueKind(issue({ labels: ["bug"] }), repository)).toBe("BUG")
+    expect(
+      resolveIssueKind(issue({ labels: ["enhancement"] }), repository),
+    ).toBe("FEATURE")
+    expect(resolveIssueKind(issue({ type: undefined }), repository)).toBe(
+      undefined,
+    )
+    expect(
+      resolveIssueKind(issue({ labels: ["bug"], type: "Feature" }), repository),
+    ).toBe(undefined)
+  })
+
+  test("skips kind classification when issue type is Bug", async () => {
+    const result = await runScenario({
+      issue: issue({ type: "Bug" }),
+      outputs: [
+        vote("YES"),
+        vote("YES"),
+        vote("YES"),
+        action("COMMENT"),
+        "Bug accepted comment",
+      ],
+    })
+
+    expect(result.result.result).toBe("BUG_ACCEPTED")
+    expect(
+      result.sessionTitles.filter((title) => title.includes("triage bug")),
+    ).toHaveLength(3)
+    expect(
+      result.sessionTitles.some((title) => title.includes("triage kind")),
+    ).toBe(false)
+  })
+
+  test("skips kind classification when issue type is Feature", async () => {
+    const result = await runScenario({
+      issue: issue({ type: "Feature" }),
+      outputs: [
+        vote("YES"),
+        vote("YES"),
+        vote("YES"),
+        action("COMMENT"),
+        "Feature accepted comment",
+      ],
+    })
+
+    expect(result.result.result).toBe("FEATURE_ACCEPTED")
+    expect(
+      result.sessionTitles.filter((title) => title.includes("triage feature")),
+    ).toHaveLength(3)
+    expect(
+      result.sessionTitles.some((title) => title.includes("triage kind")),
+    ).toBe(false)
+  })
+
+  test("runs kind classification when issue type and kind labels are absent", async () => {
+    const result = await runScenario({
+      issue: issue({ type: undefined }),
+      outputs: [
+        vote("FEATURE"),
+        vote("FEATURE"),
+        vote("ASK"),
+        vote("YES"),
+        vote("YES"),
+        vote("YES"),
+        action("COMMENT"),
+        "Feature accepted comment",
+      ],
+    })
+
+    expect(result.result.result).toBe("FEATURE_ACCEPTED")
+    expect(
+      result.sessionTitles.filter((title) => title.includes("triage kind")),
+    ).toHaveLength(3)
+    expect(
+      result.sessionTitles.filter((title) => title.includes("triage feature")),
+    ).toHaveLength(3)
+  })
+
+  test("blocks unsafe issues before model classification", async () => {
+    const result = await runScenario({
+      issue: issue({ labels: [] }),
+      outputs: [],
+    })
+
+    expect(result.result.result).toBe("FAILED")
+    expect(result.result.report).toContain("missing required labels: triage")
+    expect(result.sessionTitles).toEqual([])
+  })
+
+  test("detects explicit duplicate candidates before kind classification", async () => {
+    const result = await runScenario({
+      issue: issue({ body: "Duplicate of #10" }),
+      outputs: [
+        duplicateVote("DUPLICATE", 10),
+        duplicateVote("DUPLICATE", 10),
+        duplicateVote("NOT_DUPLICATE"),
+        action("COMMENT"),
+        "Duplicate comment",
+      ],
+    })
+
+    expect(result.result.result).toBe("DUPLICATE")
+    expect(
+      result.sessionTitles.filter((title) =>
+        title.includes("triage duplicate"),
+      ),
+    ).toHaveLength(3)
+    expect(
+      result.sessionTitles.some((title) => title.includes("triage kind")),
+    ).toBe(false)
+  })
+
+  test("clears triage only when an open related PR already handles the issue", async () => {
+    const result = await runScenario({
+      outputs: [
+        vote("RELATED_PR_HANDLES_ISSUE"),
+        vote("RELATED_PR_HANDLES_ISSUE"),
+        vote("RELATED_PR_DOES_NOT_HANDLE_ISSUE"),
+        action("CLEAR_ONLY"),
+      ],
+      relatedPullRequests: [
+        {
+          author: "dev",
+          body: "Fixes #1",
+          number: 20,
+          state: "OPEN",
+          title: "Fix issue",
+          url: "https://github.com/owner/repo/pull/20",
+        },
+      ],
+    })
+
+    expect(result.result.result).toBe("CLEAR_ONLY")
+    expect(
+      result.sessionTitles.filter((title) =>
+        title.includes("triage existing PR"),
+      ),
+    ).toHaveLength(3)
+    expect(
+      result.sessionTitles.some((title) => title.includes("triage kind")),
+    ).toBe(false)
+  })
+
+  test("closes the issue when a merged related PR handles it and close automation is enabled", async () => {
+    const result = await runScenario({
+      dryRun: false,
+      outputs: [
+        vote("RELATED_PR_HANDLES_ISSUE"),
+        vote("RELATED_PR_HANDLES_ISSUE"),
+        vote("RELATED_PR_DOES_NOT_HANDLE_ISSUE"),
+        action("CLOSE"),
+        "Merged PR comment",
+      ],
+      relatedPullRequests: [
+        {
+          author: "dev",
+          body: "Fixes #1",
+          mergedAt: "2026-01-02T00:00:00Z",
+          number: 20,
+          state: "MERGED",
+          title: "Fix issue",
+          url: "https://github.com/owner/repo/pull/20",
+        },
+      ],
+      repository: repositoryWithTriage({
+        automation: { close: true, clear: ["triage"], pr: false },
+      }),
+    })
+
+    expect(result.result.result).toBe("BUG_ACCEPTED")
+    expect(
+      result.commands.some((command) => command.startsWith("gh issue close 1")),
+    ).toBe(true)
+    expect(
+      result.commands.some((command) =>
+        command.includes("--remove-label 'triage'"),
+      ),
+    ).toBe(true)
+  })
+
+  test("closes intentionally invalid bug reports when bug vote rejects them", async () => {
+    const result = await runScenario({
+      dryRun: false,
+      issue: issue({
+        body: "This bug report is intentionally wrong.",
+        type: "Bug",
+      }),
+      outputs: [
+        vote("NO"),
+        vote("NO"),
+        vote("ASK"),
+        action("CLOSE"),
+        "Rejected bug comment",
+      ],
+      repository: repositoryWithTriage({
+        automation: { close: true, clear: ["triage"], pr: false },
+      }),
+    })
+
+    expect(result.result.result).toBe("BUG_REJECTED")
+    expect(
+      result.commands.some((command) => command.startsWith("gh issue close 1")),
+    ).toBe(true)
+  })
+
+  test("skips reconsideration when a previous marker has no eligible mentions", async () => {
+    const result = await runScenario({
+      comments: [
+        comment({
+          author: "magi-bot",
+          body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=BUG_ACCEPTED action=COMMENT checkpoint=10 pr=none processed= -->",
+          id: 10,
+        }),
+      ],
+      outputs: [],
+    })
+
+    expect(result.result.result).toBe("BUG_ACCEPTED")
+    expect(result.sessionTitles).toEqual([])
+  })
+
+  test("runs reconsideration for eligible mention replies", async () => {
+    const result = await runScenario({
+      comments: [
+        comment({
+          author: "magi-bot",
+          body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=FEATURE_ACCEPTED action=COMMENT checkpoint=10 pr=none processed= -->",
+          id: 10,
+        }),
+        comment({
+          author: "maintainer",
+          authorAssociation: "MEMBER",
+          body: "@magi-bot this should be reconsidered",
+          id: 11,
+        }),
+      ],
+      outputs: [
+        JSON.stringify({
+          comments: [
+            { classification: "OBJECTION", commentId: 11, reason: "valid" },
+          ],
+        }),
+        vote("FEATURE_REJECTED"),
+        vote("FEATURE_REJECTED"),
+        vote("ASK"),
+        action("COMMENT"),
+        "Reconsidered comment",
+      ],
+    })
+
+    expect(result.result.result).toBe("FEATURE_REJECTED")
+    expect(
+      result.sessionTitles.some((title) =>
+        title.includes("triage comment classification"),
+      ),
+    ).toBe(true)
+    expect(
+      result.sessionTitles.filter((title) =>
+        title.includes("triage reconsider"),
+      ),
+    ).toHaveLength(3)
+  })
+
   test("requires majority support for the same duplicate target", () => {
     const result = chooseDuplicateOutput({
       candidateNumbers: [101, 202],


### PR DESCRIPTION
Closes #85

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes `/magi:triage` duplicate issue search so issue titles cannot corrupt GitHub search qualifiers. Adds scenario-style triage coverage around kind resolution, duplicate handling, related PR handling, reconsideration, and close automation.

## Current behavior (updates)

Duplicate search builds one query containing the issue title plus `repo:`, `is:issue`, and current issue exclusion. Titles containing path-like text such as `docs/config.md` can cause GitHub CLI to reject the query before triage agents vote.

## New behavior

Duplicate search now scopes the repository with `--repo` and passes only the issue title as the query after `--`. The current issue remains excluded by local result filtering. Tests cover the fixed query shape and broader triage flow scenarios.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification:

- `pnpm test src/orchestrator/triage.test.ts src/github/commands.test.ts`
- `pnpm build`

Manual validation:

- Re-ran `/magi:triage 75`; it completed successfully after the fix.
- Created dummy issue #82 and confirmed close automation reached `BUG_REJECTED` and closed it.
