### PR TITLE
docs(agents): add testing rules

### DIFF
--- a/.agents/rules/test.md
+++ b/.agents/rules/test.md
@@ -1,0 +1,31 @@
+# Test Rules
+
+Use targeted automated tests to protect changed behavior. Keep tests deterministic and focused on the smallest behavior that could regress.
+
+## Required Coverage
+
+- Add or update unit tests when changing config validation, config resolution, majority logic, prompt composition, model output parsing, report formatting, or small pure helpers.
+- Add or update integration or flow tests when changing orchestration across modules, command sequencing, retry behavior, safety gates, run state, review flow, merge flow, triage flow, or CI handling.
+- Add or update scenario tests when a user-visible command or long-running workflow changes across multiple decisions, such as issue triage, PR review, merge orchestration, CI reruns, or thread resolution.
+- Prefer updating an existing nearby test file before adding a new one.
+
+## Test Placement
+
+- Put tests next to the related source as `src/**/*.test.ts`.
+- Keep fixtures small and explicit. Inline inputs are preferred unless a shared fixture materially improves readability.
+- Test observable behavior, not private implementation details.
+
+## GitHub And Model Calls
+
+- Automated tests must not rely on live GitHub calls, live OpenCode sessions, live model responses, network state, local authentication, or repository state outside the test.
+- Mock GitHub command execution by injecting fake exec functions, returning deterministic stdout or errors, and recording commands for assertions.
+- Mock `gh auth token`, `gh api`, `gh pr`, `gh issue`, `gh run`, and other CLI responses instead of shelling out to the real GitHub CLI.
+- Mock model responses with exact text or structured output needed by the flow. Include malformed output and repair cases when changing output parsing or retry logic.
+
+## Verification Commands
+
+- Run the most specific affected test file first, for example `pnpm vitest run src/config/validate.test.ts`.
+- When a change spans an area, run the relevant area tests, for example `pnpm vitest run src/orchestrator/merge.test.ts src/orchestrator/ci.test.ts`.
+- Run `pnpm test` when the change crosses several areas or when targeted coverage does not give enough confidence.
+- Do not run format, lint, or typecheck unless explicitly requested; those are handled by lefthook and CI.
+- For documentation-only changes, automated tests are not required unless the documentation change also modifies executable examples, schemas, or generated content.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ When performing one of the actions below, read the linked rule first.
 - Reviewing PRs:
   - [PR Merge Guidelines](.agents/references/pr-merge-guidelines.md)
   - [PR Review Guidelines](.agents/references/pr-review-guidelines.md)
+- Adding or changing tests:
+  - [Test Rules](.agents/rules/test.md)
 
 When editing or reviewing files that match a pattern below, read the linked rule first.
 
@@ -67,5 +69,6 @@ pnpm test
 
 ## Testing
 
+- Read [Test Rules](.agents/rules/test.md) before adding or changing tests.
 - Add or update unit tests for config validation, majority logic, prompt composition, and output parsing when changing those areas.
 - Do not rely on live GitHub calls in unit tests; mock command execution instead.


### PR DESCRIPTION
Closes #88

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a dedicated agent test rule and references it from `AGENTS.md`.

## Current behavior (updates)

Agents had brief testing guidance in `AGENTS.md`, but no dedicated rule for when to add tests, how to mock external systems, or which targeted verification commands to run.

## New behavior

Agents are directed to read `Test Rules` before adding or changing tests. The rule documents unit, integration/flow, and scenario coverage; forbids live GitHub, OpenCode, and model calls in automated tests; explains GitHub command and model response mocking; and lists targeted Vitest verification commands.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification: `git diff --check` passed. Automated tests were not run because this is a documentation-only change.
