### PR TITLE
fix(config): validate worktree config

### DIFF
--- a/.changeset/validate-worktree-config.md
+++ b/.changeset/validate-worktree-config.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Validate git worktree config before configuring editor or triage creator identity.

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -432,6 +432,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(config, {
       checkAuth: true,
       exec: async (command) => {
+        if (command.startsWith("git config --bool --get")) return "true"
         if (command.includes("bot-b")) throw new Error("not logged in")
 
         return "token"
@@ -448,6 +449,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(config, {
       checkAuth: true,
       exec: async (command, options) => {
+        if (command.startsWith("git config --bool --get")) return "true"
         if (command.startsWith("gh auth token")) {
           const account = command.match(/--user "([^"]+)"/)?.[1]
           return `${account}-token`
@@ -482,6 +484,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(config, {
       checkAuth: true,
       exec: async (command) => {
+        if (command.startsWith("git config --bool --get")) return "true"
         if (command.startsWith("gh auth token")) return "token"
         if (command.includes("gh api repos/owner/repo")) {
           throw new Error("api failed")
@@ -494,6 +497,59 @@ describe("validateConfig", () => {
     expect(result.ok).toBe(true)
     expect(result.warnings).toContain(
       "Could not validate repository permissions for GitHub account: bot-a (api failed)",
+    )
+  })
+
+  test("requires worktree config for editor identity configuration", async () => {
+    const result = await validateConfig(config, {
+      exec: async (command) => {
+        if (command.startsWith("git config --bool --get")) return "false"
+
+        throw new Error(`unexpected command: ${command}`)
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain(
+      "git config extensions.worktreeConfig must be true when editor or triage PR creator is configured",
+    )
+  })
+
+  test("requires worktree config for triage PR creator identity configuration", async () => {
+    const result = await validateConfig(
+      {
+        github: { owner: "owner", repo: "repo" },
+        triage: {
+          account: "magi-bot",
+          agents: [
+            { model: "openai/gpt" },
+            { model: "anthropic/claude" },
+            { model: "google/gemini" },
+          ],
+          automation: { pr: true },
+          creator: {
+            account: "creator-bot",
+            author: { email: "bot@example.com", name: "Magi Bot" },
+            model: "openai/gpt",
+          },
+        },
+      },
+      {
+        exec: async (command) => {
+          if (command.startsWith("git config --bool --get")) {
+            throw new Error("unset")
+          }
+
+          throw new Error(`unexpected command: ${command}`)
+        },
+        requireReview: false,
+        requireTriage: true,
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain(
+      "git config extensions.worktreeConfig must be true when editor or triage PR creator is configured",
     )
   })
 })

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -500,6 +500,16 @@ describe("validateConfig", () => {
     )
   })
 
+  test("does not require worktree config for review-only validation", async () => {
+    const result = await validateConfig(config, {
+      exec: async (command) => {
+        throw new Error(`unexpected command: ${command}`)
+      },
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
   test("requires worktree config for editor identity configuration", async () => {
     const result = await validateConfig(config, {
       exec: async (command) => {
@@ -507,6 +517,7 @@ describe("validateConfig", () => {
 
         throw new Error(`unexpected command: ${command}`)
       },
+      requireEditor: true,
     })
 
     expect(result.ok).toBe(false)

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -992,6 +992,42 @@ async function fetchPermissions(
   return JSON.parse(raw) as { pull?: boolean; push?: boolean }
 }
 
+async function validateWorktreeConfig(
+  config: MagiConfig,
+  exec: Exec | undefined,
+  options: ValidationOptions,
+  errors: string[],
+): Promise<void> {
+  const agents = resolveAgents(config)
+  const checkAll = !options.requireEditor && !options.requireTriage
+  const checkEditor = Boolean(
+    agents.editor && (checkAll || options.requireEditor),
+  )
+  const checkTriageCreator = Boolean(
+    config.triage?.automation?.pr &&
+    agents.triageCreator &&
+    (checkAll || options.requireTriage),
+  )
+
+  if (!checkEditor && !checkTriageCreator) return
+  if (!exec) return
+
+  const error =
+    "git config extensions.worktreeConfig must be true when editor or triage PR creator is configured"
+
+  try {
+    const value = (
+      await exec("git config --bool --get extensions.worktreeConfig")
+    )
+      .trim()
+      .toLowerCase()
+
+    if (value !== "true") errors.push(error)
+  } catch {
+    errors.push(error)
+  }
+}
+
 async function validateRepositoryPermissions(
   config: MagiConfig,
   exec: Exec,
@@ -1171,6 +1207,7 @@ export async function validateConfig(
 
   validateString(config.review?.output, "review.output", errors)
   validateString(config.review?.worktree, "review.worktree", errors)
+  await validateWorktreeConfig(config, options.exec, options, errors)
 
   if (options.checkAuth && !errors.length) {
     if (!options.exec) {

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -30,6 +30,7 @@ export interface ValidationOptions {
   requireGithub?: boolean
   requireReview?: boolean
   requireTriage?: boolean
+  requireWorktreeConfig?: boolean
 }
 
 export interface ValidationResult {
@@ -999,14 +1000,13 @@ async function validateWorktreeConfig(
   errors: string[],
 ): Promise<void> {
   const agents = resolveAgents(config)
-  const checkAll = !options.requireEditor && !options.requireTriage
   const checkEditor = Boolean(
-    agents.editor && (checkAll || options.requireEditor),
+    agents.editor && (options.requireEditor || options.requireWorktreeConfig),
   )
   const checkTriageCreator = Boolean(
     config.triage?.automation?.pr &&
     agents.triageCreator &&
-    (checkAll || options.requireTriage),
+    (options.requireTriage || options.requireWorktreeConfig),
   )
 
   if (!checkEditor && !checkTriageCreator) return

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -158,6 +158,51 @@ describe("magi_validate", () => {
     expect(result).toContain("Errors:\n- None")
   })
 
+  test("validates worktree config for full config validation", async () => {
+    const home = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "magi-home-"))
+    const directory = await mkdtemp(
+      join(process.env.TMPDIR ?? "/tmp", "magi-project-"),
+    )
+    mockState.home = home
+    const globalPath = join(home, ".config", "opencode", "magi.json")
+    const projectPath = join(directory, ".opencode", "magi.json")
+    const validateMagiConfigFiles = await loadValidateMagiConfigFiles()
+
+    await writeConfig(globalPath, {
+      merge: {
+        editor: {
+          account: "bot-c",
+          author: { email: "bot-c@example.com", name: "Bot C" },
+          model: "openai/gpt",
+        },
+      },
+      review: {
+        agents: [
+          { account: "bot-a", model: "openai/gpt" },
+          { account: "bot-b", model: "openai/gpt" },
+          { account: "bot-c", model: "openai/gpt" },
+        ],
+      },
+    })
+    await writeConfig(projectPath, {
+      github: { owner: "owner", repo: "repo" },
+    })
+
+    const result = await validateMagiConfigFiles(directory, {
+      checkAuth: false,
+      exec: async (command) => {
+        if (command.startsWith("git config --bool --get")) return "false"
+
+        throw new Error(`unexpected command: ${command}`)
+      },
+    })
+
+    expect(result).toContain("Magi config validation: failed")
+    expect(result).toContain(
+      "git config extensions.worktreeConfig must be true when editor or triage PR creator is configured",
+    )
+  })
+
   test("does not require GitHub settings for global-only config", async () => {
     const home = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "magi-home-"))
     const directory = await mkdtemp(

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,6 +352,7 @@ export async function validateMagiConfigFiles(
         : undefined,
       modelCatalog: options.modelCatalog,
       requireGithub: hasProjectConfig && Boolean(mergedConfig.review?.agents),
+      requireWorktreeConfig: true,
     })
 
     loadedFrom = existing.map((status) => status.path).join(", ")


### PR DESCRIPTION
Closes #92

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds shared config validation for the git `extensions.worktreeConfig` prerequisite used by editor and triage PR creator identity setup.

## Current behavior (updates)

Commands can pass config validation and fail later when `configureGitIdentity()` runs `git config --worktree` in a repository that has multiple worktrees but does not enable `extensions.worktreeConfig`.

## New behavior

`validateConfig()` checks `git config --bool --get extensions.worktreeConfig` before command execution paths that can configure editor or triage creator identity. Missing or non-true values are reported during validation.

## Is this a breaking change (Yes/No):

No

## Additional Information

Split out from #96 to keep triage automation behavior and shared validation changes separate.

Tests: pnpm test src/config/validate.test.ts