### PR TITLE
fix(review): retry invalid inline finding targets

### DIFF
--- a/.changeset/fix-review-inline-target-validation.md
+++ b/.changeset/fix-review-inline-target-validation.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Retry review model output when inline finding targets are not valid PR diff lines.

--- a/src/orchestrator/inline-comments.test.ts
+++ b/src/orchestrator/inline-comments.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest"
+import {
+  parseRightSideDiffTargets,
+  validateInlineCommentTargets,
+} from "./inline-comments"
+
+const diff = `diff --git a/src/app.ts b/src/app.ts
+index 1111111..2222222 100644
+--- a/src/app.ts
++++ b/src/app.ts
+@@ -8,6 +8,7 @@ export function app() {
+ contextBefore()
+-oldCall()
++newCall()
+ contextAfter()
+ }
+diff --git a/src/new.ts b/src/new.ts
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/src/new.ts
+@@ -0,0 +1,2 @@
++export const value = 1
++export const other = 2`
+
+describe("inline comment targets", () => {
+  test("accepts right-side lines inside diff hunks", () => {
+    const targets = parseRightSideDiffTargets(diff)
+
+    expect(() =>
+      validateInlineCommentTargets(
+        [
+          { line: 10, path: "src/app.ts" },
+          { line: 2, path: "src/new.ts", startLine: 1 },
+        ],
+        targets,
+      ),
+    ).not.toThrow()
+  })
+
+  test("rejects wildcard paths that are not concrete PR diff files", () => {
+    const targets = parseRightSideDiffTargets(diff)
+
+    expect(() =>
+      validateInlineCommentTargets(
+        [{ line: 1, path: ".changeset/*.md" }],
+        targets,
+      ),
+    ).toThrow("path is not in the PR diff")
+  })
+
+  test("rejects changed files when the line is outside right-side hunks", () => {
+    const targets = parseRightSideDiffTargets(diff)
+
+    expect(() =>
+      validateInlineCommentTargets(
+        [{ line: 100, path: "src/app.ts" }],
+        targets,
+      ),
+    ).toThrow("line is not in a right-side PR diff hunk")
+  })
+
+  test("rejects multi-line comments that span outside right-side hunks", () => {
+    const targets = parseRightSideDiffTargets(diff)
+
+    expect(() =>
+      validateInlineCommentTargets(
+        [{ line: 12, path: "src/app.ts", startLine: 10 }],
+        targets,
+        "newFindings",
+      ),
+    ).toThrow("newFindings[0] targets src/app.ts:12")
+  })
+})

--- a/src/orchestrator/inline-comments.ts
+++ b/src/orchestrator/inline-comments.ts
@@ -1,0 +1,107 @@
+export type InlineCommentTargets = ReadonlyMap<string, ReadonlySet<number>>
+
+export interface InlineCommentFindingTarget {
+  line: number
+  path: string
+  startLine?: number
+}
+
+function parseDiffPath(value: string): string | undefined {
+  if (value === "/dev/null") return undefined
+
+  let path = value
+  if (path.startsWith('"') && path.endsWith('"')) {
+    try {
+      path = JSON.parse(path) as string
+    } catch {
+      path = path.slice(1, -1)
+    }
+  }
+
+  return path.startsWith("b/") ? path.slice(2) : path
+}
+
+function addTargetLine(
+  targets: Map<string, Set<number>>,
+  path: string,
+  line: number,
+): void {
+  const lines = targets.get(path) ?? new Set<number>()
+
+  lines.add(line)
+  targets.set(path, lines)
+}
+
+export function parseRightSideDiffTargets(diff: string): InlineCommentTargets {
+  const targets = new Map<string, Set<number>>()
+  let currentPath: string | undefined
+  let rightLine: number | undefined
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++ ")) {
+      currentPath = parseDiffPath(line.slice(4))
+      rightLine = undefined
+      continue
+    }
+
+    if (line.startsWith("@@ ")) {
+      const match = line.match(/\+(\d+)(?:,\d+)?/)
+
+      rightLine = match ? Number(match[1]) : undefined
+      continue
+    }
+
+    if (!currentPath || rightLine == null) continue
+
+    if (line.startsWith("+") || line.startsWith(" ")) {
+      addTargetLine(targets, currentPath, rightLine)
+      rightLine += 1
+      continue
+    }
+
+    if (line.startsWith("-")) continue
+  }
+
+  return targets
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+}
+
+export function validateInlineCommentTargets(
+  findings: readonly InlineCommentFindingTarget[],
+  targets: InlineCommentTargets,
+  label = "findings",
+): void {
+  for (const [index, finding] of findings.entries()) {
+    const name = `${label}[${index}]`
+
+    assertPositiveInteger(finding.line, `${name}.line`)
+    if (finding.startLine != null) {
+      assertPositiveInteger(finding.startLine, `${name}.startLine`)
+      if (finding.startLine > finding.line) {
+        throw new Error(`${name}.startLine must be before or equal to line`)
+      }
+    }
+
+    const lines = targets.get(finding.path)
+
+    if (!lines) {
+      throw new Error(
+        `${name} targets ${finding.path}:${finding.line}, but path is not in the PR diff`,
+      )
+    }
+
+    const startLine = finding.startLine ?? finding.line
+    for (let line = startLine; line <= finding.line; line += 1) {
+      if (!lines.has(line)) {
+        throw new Error(
+          `${name} targets ${finding.path}:${line}, but line is not in a right-side PR diff hunk`,
+        )
+      }
+    }
+  }
+}

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -25,6 +25,7 @@ import {
   pushHead,
   removeWorktree,
   resolveThread,
+  shellQuote,
   type ReviewThread,
   waitForMergeQueue,
   type CheckWaitReport,
@@ -41,6 +42,11 @@ import {
 } from "../prompts/output"
 import { throwIfAborted, withAbortSignal } from "./abort"
 import { waitForChecksWithClassification } from "./ci"
+import {
+  parseRightSideDiffTargets,
+  validateInlineCommentTargets,
+  type InlineCommentTargets,
+} from "./inline-comments"
 import { closeMinorityReviewers, mergeVerdictForPolicy } from "./majority"
 import { type ModelClient, runModelWithRepair } from "./model"
 import { mapPool } from "./pool"
@@ -359,6 +365,17 @@ async function postRereviewOutput(
   return replies[0] ?? ""
 }
 
+function parseRereviewOutputWithInlineTargets(
+  text: string,
+  targets: InlineCommentTargets,
+): RereviewOutput {
+  const output = parseRereviewOutput(text)
+
+  validateInlineCommentTargets(output.newFindings, targets, "newFindings")
+
+  return output
+}
+
 async function runRereview(
   input: MergeRunInput,
   worktreePath: string,
@@ -379,6 +396,12 @@ async function runRereview(
 
   const meta = await fetchPullRequest(input.exec, input.repository, input.pr)
   const headSha = options.dryRunHeadSha ?? meta.headRefOid
+  const inlineCommentTargets = parseRightSideDiffTargets(
+    await input.exec(
+      `git diff --no-ext-diff --unified=3 ${shellQuote(meta.baseRefOid)} ${shellQuote(headSha)}`,
+      { cwd: worktreePath },
+    ),
+  )
   const artifactDir = outputDir(input)
   let entries = await mapPool(
     input.repository.agents.reviewers,
@@ -444,7 +467,8 @@ async function runRereview(
               }
             },
             options: reviewer.options,
-            parse: parseRereviewOutput,
+            parse: (text) =>
+              parseRereviewOutputWithInlineTargets(text, inlineCommentTargets),
             permission: reviewer.permission,
             prompt,
             repairAttempts: input.config.output?.repairAttempts ?? 3,
@@ -549,7 +573,17 @@ async function runRereview(
                 }
               },
               options: reviewer.options,
-              parse: parseRereviewCloseReconsiderationOutput,
+              parse: (text) => {
+                const output = parseRereviewCloseReconsiderationOutput(text)
+
+                validateInlineCommentTargets(
+                  output.newFindings,
+                  inlineCommentTargets,
+                  "newFindings",
+                )
+
+                return output
+              },
               permission: reviewer.permission,
               prompt,
               repairAttempts: input.config.output?.repairAttempts ?? 3,

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -26,6 +26,7 @@ import {
   type PullRequestCommit,
   removeWorktree,
   resolveThread,
+  shellQuote,
 } from "../github/commands"
 import {
   composeFindingValidationPrompt,
@@ -44,6 +45,11 @@ import {
 import { throwIfAborted, withAbortSignal } from "./abort"
 import { waitForChecksWithClassification } from "./ci"
 import type { CiClassifierProgress } from "./ci"
+import {
+  parseRightSideDiffTargets,
+  validateInlineCommentTargets,
+  type InlineCommentTargets,
+} from "./inline-comments"
 import {
   applyFindingValidation,
   type FindingValidationSummary,
@@ -346,6 +352,28 @@ function previousReviewText(review: PullRequestReview): string {
   )
 }
 
+function parseReviewOutputWithInlineTargets(
+  text: string,
+  targets: InlineCommentTargets,
+): ReviewOutput {
+  const output = parseReviewOutput(text)
+
+  validateInlineCommentTargets(output.findings, targets)
+
+  return output
+}
+
+function parseRereviewOutputWithInlineTargets(
+  text: string,
+  targets: InlineCommentTargets,
+): RereviewOutput {
+  const output = parseRereviewOutput(text)
+
+  validateInlineCommentTargets(output.newFindings, targets, "newFindings")
+
+  return output
+}
+
 function reviewOutputFromState(review: PullRequestReview): ReviewOutput {
   const verdict = reviewStateToVerdict(review.state)
 
@@ -622,6 +650,7 @@ async function runFindingValidation(input: {
 
 async function runCloseReconsideration(input: {
   entries: ReviewEntry[]
+  inlineCommentTargets: InlineCommentTargets
   meta: { baseRefOid: string; headRefOid: string }
   outputDir: string
   reviewInput: ReviewRunInput
@@ -702,7 +731,16 @@ async function runCloseReconsideration(input: {
               }
             },
             options: reviewer.options,
-            parse: parseCloseReconsiderationOutput,
+            parse: (text) => {
+              const output = parseCloseReconsiderationOutput(text)
+
+              validateInlineCommentTargets(
+                output.findings,
+                input.inlineCommentTargets,
+              )
+
+              return output
+            },
             permission: reviewer.permission,
             prompt,
             repairAttempts:
@@ -969,6 +1007,12 @@ export async function runReview(
         return [{ assignment, reviewer }]
       },
     )
+    const inlineCommentTargets = parseRightSideDiffTargets(
+      await exec(
+        `git diff --no-ext-diff --unified=3 ${shellQuote(meta.baseRefOid)} ${shellQuote(meta.headRefOid)}`,
+        { cwd: worktreePath },
+      ),
+    )
     for (const reviewer of input.repository.agents.reviewers) {
       const assignment = mode.assignments.get(reviewer.account)
       if (assignment?.type !== "skip") continue
@@ -1048,7 +1092,11 @@ export async function runReview(
                   }
                 },
                 options: reviewer.options,
-                parse: parseRereviewOutput,
+                parse: (text) =>
+                  parseRereviewOutputWithInlineTargets(
+                    text,
+                    inlineCommentTargets,
+                  ),
                 permission: reviewer.permission,
                 prompt,
                 repairAttempts: input.config.output?.repairAttempts ?? 3,
@@ -1126,7 +1174,8 @@ export async function runReview(
                 }
               },
               options: reviewer.options,
-              parse: parseReviewOutput,
+              parse: (text) =>
+                parseReviewOutputWithInlineTargets(text, inlineCommentTargets),
               permission: reviewer.permission,
               prompt,
               repairAttempts: input.config.output?.repairAttempts ?? 3,
@@ -1210,6 +1259,7 @@ export async function runReview(
     )
     entries = await runCloseReconsideration({
       entries: [...entries, ...skippedCloseEntries],
+      inlineCommentTargets,
       meta,
       outputDir,
       reviewInput: { ...input, exec },


### PR DESCRIPTION
Closes #67

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Validate review finding inline targets against the PR diff before accepting model output.

## Current behavior (updates)

A validated finding with a non-concrete path or a line outside the PR diff can reach GitHub review posting and make the whole review submission fail with HTTP 422.

## New behavior

Review, rereview, and close reconsideration model outputs now fail parsing when findings target paths or right-side lines that are not present in the PR diff. The existing model repair flow retries those invalid outputs before posting.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verified with `pnpm test src/orchestrator`.