### PR TITLE
fix(status): accept multiple PR filters

### DIFF
--- a/.changeset/soft-timers-juggle.md
+++ b/.changeset/soft-timers-juggle.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Allow magi_status to accept multiple PR filters.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,6 +96,63 @@ describe("tool descriptions", () => {
   })
 })
 
+describe("magi_status", () => {
+  test("accepts space-separated PR filters", async () => {
+    const directory = await mkdtemp(
+      join(process.env.TMPDIR ?? "/tmp", "magi-status-"),
+    )
+
+    try {
+      for (const pr of [96, 99, 100]) {
+        const outputDir = join(
+          directory,
+          ".magi",
+          "runs",
+          "pr",
+          String(pr),
+          `run-${pr}`,
+        )
+        await mkdir(outputDir, { recursive: true })
+        await writeFile(
+          join(outputDir, "state.json"),
+          JSON.stringify({
+            command: "merge",
+            createdAt: "now",
+            outputDir,
+            phase: "completed",
+            pr,
+            repository: "repo",
+            reviewers: {},
+            runId: `run-${pr}`,
+            status: "completed",
+            updatedAt: `now-${pr}`,
+          }),
+        )
+      }
+
+      const plugin = await MagiPlugin({
+        client: { session: {} },
+        directory,
+      } as never)
+      const result = await plugin.tool?.magi_status.execute(
+        {
+          block: true,
+          pr: "96 99",
+          timeoutSeconds: 1,
+          verbose: false,
+        } as never,
+        { abort: new AbortController().signal, sessionID: "parent" } as never,
+      )
+
+      expect(result).toContain("PR: #96")
+      expect(result).toContain("PR: #99")
+      expect(result).not.toContain("PR: #100")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+})
+
 describe("magi_validate", () => {
   beforeEach(() => {
     vi.restoreAllMocks()

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,12 @@ function parseOptionalPr(value: string | undefined): number | undefined {
   return parsePrToken(value)
 }
 
+function parseOptionalPrs(value: string | undefined): number[] | undefined {
+  if (!value?.trim()) return undefined
+
+  return parsePrs(value)
+}
+
 function parseOptionalIssue(value: string | undefined): number | undefined {
   if (!value?.trim()) return undefined
 
@@ -614,7 +620,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
             block: args.block,
             issue: parseOptionalIssue(args.issue),
             outputDir: await configuredOutputDir(),
-            pr: parseOptionalPr(args.pr),
+            pr: parseOptionalPrs(args.pr),
             runId: args.runId,
             timeoutMs:
               args.timeoutSeconds == null

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -120,6 +120,8 @@ export interface MagiRunState {
   worktreePath?: string
 }
 
+type NumberFilter = number | number[]
+
 export interface MagiClearOptions extends Required<ClearConfig> {}
 
 export interface MagiClearSummary {
@@ -177,6 +179,25 @@ function isActiveStatus(status: MagiRunStatus): boolean {
     status === "running" ||
     status === "posting"
   )
+}
+
+function matchesNumberFilter(value: number | undefined, filter?: NumberFilter) {
+  if (filter == null) return true
+
+  return Array.isArray(filter)
+    ? value != null && filter.includes(value)
+    : value === filter
+}
+
+function hasAllRequestedPrStates(
+  states: MagiRunState[],
+  pr?: NumberFilter,
+): boolean {
+  if (pr == null) return true
+
+  const prs = Array.isArray(pr) ? pr : [pr]
+
+  return prs.every((item) => states.some((state) => state.pr === item))
 }
 
 function isWithinDirectory(directory: string, path: string): boolean {
@@ -866,7 +887,7 @@ export class MagiRunManager {
       block?: boolean
       issue?: number
       outputDir?: string | string[]
-      pr?: number
+      pr?: NumberFilter
       runId?: string
       timeoutMs?: number
     } = {},
@@ -878,6 +899,7 @@ export class MagiRunManager {
       const states = await this.filteredStates(input)
       if (
         states.length &&
+        hasAllRequestedPrStates(states, input.pr) &&
         states.every((state) => !isActiveStatus(state.status))
       )
         return states
@@ -2410,7 +2432,7 @@ export class MagiRunManager {
     command?: MagiRunState["command"]
     issue?: number
     outputDir?: string | string[]
-    pr?: number
+    pr?: NumberFilter
     runId?: string
   }): Promise<MagiRunState[]> {
     const states = input.runId
@@ -2424,7 +2446,7 @@ export class MagiRunManager {
         (state) => input.command == null || state.command === input.command,
       )
       .filter((state) => input.issue == null || state.issue === input.issue)
-      .filter((state) => input.pr == null || state.pr === input.pr)
+      .filter((state) => matchesNumberFilter(state.pr, input.pr))
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
   }
 


### PR DESCRIPTION
Closes #101

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Allow the assistant-facing `magi_status` tool to accept multiple PR filters when the `pr` argument is passed as a space- or comma-separated string.

## Current behavior (updates)

`magi_status` parsed `pr` with the single-PR parser, so values like `"96 99"` failed with `Specify one or more PR numbers or PR URLs.`

## New behavior

`magi_status` now reuses the multi-PR parser and filters run states by any requested PR. Blocking status waits until every requested PR has a state before returning completed results.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/index.test.ts src/orchestrator/run-manager.test.ts`.
