### PR TITLE
fix(config): allow editor package manager commands

### DIFF
--- a/.changeset/allow-editor-package-managers.md
+++ b/.changeset/allow-editor-package-managers.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Allow editor-style agents to run package manager commands by default.

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -135,13 +135,42 @@ describe("resolveRepository", () => {
     })
     expect(repo.agents.editor?.permission).toMatchObject({
       bash: {
+        "bun *": "allow",
+        "bunx *": "allow",
+        "corepack *": "allow",
         "git add*": "allow",
         "git commit*": "allow",
+        "npm *": "allow",
+        "npx *": "allow",
+        "pnpm *": "allow",
+        "yarn *": "allow",
       },
       edit: "allow",
     })
-    expect(repo.agents.editor?.permission).not.toMatchObject({
-      bash: { "pnpm test*": "allow" },
+  })
+
+  test("resolves package manager permissions for triage creators", () => {
+    const repo = resolveRepository({
+      ...config,
+      triage: {
+        creator: {
+          model: "openai/gpt",
+          author: { email: "bot-c@example.com", name: "Bot C" },
+        },
+      },
+    })
+
+    expect(repo.agents.triageCreator?.permission).toMatchObject({
+      bash: {
+        "bun *": "allow",
+        "bunx *": "allow",
+        "corepack *": "allow",
+        "npm *": "allow",
+        "npx *": "allow",
+        "pnpm *": "allow",
+        "yarn *": "allow",
+      },
+      edit: "allow",
     })
   })
 

--- a/src/permissions/editor.json
+++ b/src/permissions/editor.json
@@ -1,7 +1,14 @@
 {
   "bash": {
+    "bun *": "allow",
+    "bunx *": "allow",
+    "corepack *": "allow",
     "git add*": "allow",
-    "git commit*": "allow"
+    "git commit*": "allow",
+    "npm *": "allow",
+    "npx *": "allow",
+    "pnpm *": "allow",
+    "yarn *": "allow"
   },
   "edit": "allow"
 }


### PR DESCRIPTION
Closes #106

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Allow editor-style agents to run package manager commands with the default editor permission set.

## Current behavior (updates)

Default editor permissions allow git add and commit commands, but package manager commands are denied by the common bash fallback rule.

## New behavior

Merge editors and triage creators can run npm, npx, yarn, pnpm, bun, bunx, and corepack commands by default.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/config/resolve.test.ts`.
