### PR TITLE
fix(triage): report PR creation progress

### DIFF
--- a/.changeset/cancel-triage-creator.md
+++ b/.changeset/cancel-triage-creator.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Mark active triage creators as cancelled when cancelling a Magi run.

--- a/.changeset/triage-pr-progress.md
+++ b/.changeset/triage-pr-progress.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Report triage implementation PR creation progress to the parent Magi run.

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -349,6 +349,144 @@ describe("MagiRunManager notifications", () => {
     ])
   })
 
+  test("tracks triage creator progress and notifications", async () => {
+    const { manager, prompts } = managerWithPromptCapture()
+    const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
+    const state: MagiRunState = {
+      command: "triage",
+      createdAt: "now",
+      issue: 105,
+      issueUrl: "https://example.com/issues/105",
+      outputDir: directory,
+      parentSessionId: "parent-session",
+      phase: "triaging",
+      repository: "repo",
+      reviewers: {
+        Melchior: {
+          account: "",
+          repairAttempts: 0,
+          status: "pending",
+          toolCalls: 0,
+        },
+      },
+      runId: "run",
+      status: "running",
+      triageCreator: {
+        account: "creator-bot",
+        repairAttempts: 0,
+        status: "pending",
+        toolCalls: 0,
+      },
+      updatedAt: "now",
+    }
+    const privateManager = manager as unknown as {
+      active: Map<string, MagiRunState>
+      applyTriageProgress(runId: string, progress: unknown): Promise<void>
+      sessionToRun: Map<string, { agent: string; runId: string }>
+    }
+
+    privateManager.active.set("run", state)
+    try {
+      await privateManager.applyTriageProgress("run", {
+        type: "pr_creation_started",
+      })
+      await privateManager.applyTriageProgress("run", {
+        type: "triage_creator_started",
+      })
+      await privateManager.applyTriageProgress("run", {
+        sessionId: "creator-session",
+        type: "triage_creator_session",
+      })
+      await privateManager.applyTriageProgress("run", {
+        sessionId: "creator-session",
+        type: "triage_creator_completed",
+      })
+      await privateManager.applyTriageProgress("run", {
+        type: "pr_created",
+        url: "https://example.com/pull/106",
+      })
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+
+    expect(state.phase).toBe("creating implementation PR")
+    expect(state.triageCreator).toMatchObject({
+      sessionId: "creator-session",
+      status: "completed",
+    })
+    expect(privateManager.sessionToRun.get("creator-session")).toEqual({
+      agent: "triageCreator",
+      runId: "run",
+    })
+    expect(
+      prompts.map(
+        (prompt) =>
+          (prompt as { body: { parts: { text: string }[] } }).body.parts[0]
+            .text,
+      ),
+    ).toEqual([
+      "Started implementation PR creation for [#105](https://example.com/issues/105).",
+      "**Triage creator** started creating an implementation PR for [#105](https://example.com/issues/105).",
+      "**Triage creator** completed implementation changes for [#105](https://example.com/issues/105).",
+      "Created implementation PR for [#105](https://example.com/issues/105): https://example.com/pull/106",
+    ])
+  })
+
+  test("notifies triage creator failures", async () => {
+    const { manager, prompts } = managerWithPromptCapture()
+    const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
+    const state: MagiRunState = {
+      command: "triage",
+      createdAt: "now",
+      issue: 105,
+      issueUrl: "https://example.com/issues/105",
+      outputDir: directory,
+      parentSessionId: "parent-session",
+      phase: "creating implementation PR",
+      repository: "repo",
+      reviewers: {},
+      runId: "run",
+      status: "running",
+      triageCreator: {
+        account: "creator-bot",
+        repairAttempts: 1,
+        status: "repairing",
+        toolCalls: 0,
+      },
+      updatedAt: "now",
+    }
+    const privateManager = manager as unknown as {
+      active: Map<string, MagiRunState>
+      applyTriageProgress(runId: string, progress: unknown): Promise<void>
+    }
+
+    privateManager.active.set("run", state)
+    try {
+      await privateManager.applyTriageProgress("run", {
+        error: "Invalid JSON",
+        type: "triage_creator_failed",
+      })
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+
+    expect(state.triageCreator?.status).toBe("failed")
+    expect(prompts).toMatchObject([
+      {
+        body: {
+          parts: [
+            {
+              synthetic: true,
+              text: "**Triage creator** failed creating an implementation PR for [#105](https://example.com/issues/105) after 1 JSON regeneration attempt: Invalid JSON",
+              type: "text",
+            },
+          ],
+        },
+        path: { id: "parent-session" },
+      },
+    ])
+  })
+
   test("notifies thread resolution attempt limits with links", async () => {
     const { manager, prompts } = managerWithPromptCapture()
     const state: MagiRunState = {
@@ -987,6 +1125,39 @@ describe("MagiRunManager notifications", () => {
     expect(text).not.toContain("session=child-session")
     expect(text).not.toContain("tools=2")
     expect(text).toContain("- security: completed (MERGE)")
+  })
+
+  test("formats triage creator status", () => {
+    const { manager } = managerWithPromptCapture()
+    const text = manager.formatStates(
+      [
+        {
+          command: "triage",
+          createdAt: "now",
+          issue: 105,
+          outputDir: ".",
+          phase: "creating implementation PR",
+          repository: "repo",
+          reviewers: {},
+          runId: "run",
+          status: "running",
+          triageCreator: {
+            account: "creator-bot",
+            repairAttempts: 0,
+            sessionId: "creator-session",
+            status: "running",
+            toolCalls: 1,
+          },
+          updatedAt: "now",
+        },
+      ],
+      { verbose: true },
+    )
+
+    expect(text).toContain("Issue: #105")
+    expect(text).toContain(
+      "- triageCreator: running (session=creator-session, tools=1)",
+    )
   })
 
   test("clears inactive sessions, worktrees, branches, and outputs", async () => {

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -487,6 +487,48 @@ describe("MagiRunManager notifications", () => {
     ])
   })
 
+  test("marks active triage creator cancelled when cancelling run", async () => {
+    const { manager } = managerWithPromptCapture()
+    const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
+    const state: MagiRunState = {
+      command: "triage",
+      createdAt: "now",
+      error: "User cancelled run",
+      issue: 105,
+      issueUrl: "https://example.com/issues/105",
+      outputDir: directory,
+      parentSessionId: "parent-session",
+      phase: "creating implementation PR",
+      repository: "repo",
+      reviewers: {},
+      runId: "run",
+      status: "running",
+      triageCreator: {
+        account: "creator-bot",
+        repairAttempts: 0,
+        sessionId: "creator-session",
+        status: "running",
+        toolCalls: 0,
+      },
+      updatedAt: "now",
+    }
+    const privateManager = manager as unknown as {
+      active: Map<string, MagiRunState>
+    }
+
+    privateManager.active.set("run", state)
+    try {
+      const cancelled = await manager.cancel({ runId: "run" })
+
+      expect(cancelled?.triageCreator).toMatchObject({
+        status: "cancelled",
+      })
+      expect(cancelled?.triageCreator?.error).toBeUndefined()
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   test("notifies thread resolution attempt limits with links", async () => {
     const { manager, prompts } = managerWithPromptCapture()
     const state: MagiRunState = {

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -34,7 +34,7 @@ import {
 } from "./merge"
 import type { ModelClient } from "./model"
 import { runReview, type ReviewRunProgress } from "./review"
-import { runTriage } from "./triage"
+import { runTriage, type TriageRunProgress } from "./triage"
 
 export type MagiAgentStatus =
   | "blocked"
@@ -113,6 +113,7 @@ export interface MagiRunState {
   sessionIds?: Record<string, string>
   status: MagiRunStatus
   threadAttempts?: Record<string, ThreadResolutionAttempt>
+  triageCreator?: MagiRunAgentState
   updatedAt: string
   verdict?: string
   warnings?: string[]
@@ -363,6 +364,24 @@ function editorFailureText(input: {
   const repairs = repairAttemptsText(input.repairAttempts)
 
   return `**Editor** failed editing ${input.pr}${repairs}: ${input.error}`
+}
+
+function triageCreatorFailureText(input: {
+  error: string
+  issue: string
+  repairAttempts: number
+}): string {
+  const repairs = repairAttemptsText(input.repairAttempts)
+
+  return `**Triage creator** failed creating an implementation PR for ${input.issue}${repairs}: ${input.error}`
+}
+
+function triageDecisionNotification(input: {
+  action: string
+  issue: string
+  result: string
+}): string {
+  return `Triage decided ${input.issue}: ${input.result}. Planned action: ${input.action}.`
 }
 
 function repairAttemptsText(attempts: number): string {
@@ -855,6 +874,14 @@ export class MagiRunManager {
       ),
       runId,
       status: "preparing",
+      triageCreator: input.repository.agents.triageCreator
+        ? {
+            account: input.repository.agents.triageCreator.account,
+            repairAttempts: 0,
+            status: "pending",
+            toolCalls: 0,
+          }
+        : undefined,
       updatedAt: createdAt,
     }
 
@@ -1003,6 +1030,20 @@ export class MagiRunManager {
     if (state.editor?.sessionId) {
       await this.input.client.session
         .abort?.({ path: { id: state.editor.sessionId } })
+        .catch(() => undefined)
+    }
+    if (
+      state.triageCreator?.status === "pending" ||
+      state.triageCreator?.status === "running" ||
+      state.triageCreator?.status === "repairing" ||
+      state.triageCreator?.status === "blocked"
+    ) {
+      state.triageCreator.status = "failed"
+      state.triageCreator.error = state.error
+    }
+    if (state.triageCreator?.sessionId) {
+      await this.input.client.session
+        .abort?.({ path: { id: state.triageCreator.sessionId } })
         .catch(() => undefined)
     }
     for (const reviewer of Object.values(state.reviewers)) {
@@ -1390,7 +1431,7 @@ export class MagiRunManager {
           state,
           questionWaitText({
             agent: mapping.agent,
-            pr: prMarkdownLink(state),
+            pr: runLabel(state),
             question,
           }),
           { reply: true },
@@ -1417,7 +1458,7 @@ export class MagiRunManager {
         dirty = true
         await this.notify(
           state,
-          `Magi ${mapping.agent} is waiting for permission on ${prMarkdownLink(state)}: ${agent.error}`,
+          `Magi ${mapping.agent} is waiting for permission on ${runLabel(state)}: ${agent.error}`,
           { reply: true },
         )
       }
@@ -1445,7 +1486,7 @@ export class MagiRunManager {
           state,
           questionWaitText({
             agent: mapping.agent,
-            pr: prMarkdownLink(state),
+            pr: runLabel(state),
             question,
           }),
           { reply: true },
@@ -1535,6 +1576,9 @@ export class MagiRunManager {
         const editorLine = state.editor
           ? this.formatAgentLine("editor", state.editor, options)
           : undefined
+        const triageCreatorLine = state.triageCreator
+          ? this.formatAgentLine("triageCreator", state.triageCreator, options)
+          : undefined
         const reviewerLines = Object.entries(state.reviewers).map(
           ([key, reviewer]) => {
             return this.formatAgentLine(key, reviewer, options)
@@ -1547,6 +1591,7 @@ export class MagiRunManager {
         const lines = [
           options.verbose ? `Run: ${state.runId}` : undefined,
           state.pr == null ? undefined : `PR: #${state.pr}`,
+          state.issue == null ? undefined : `Issue: #${state.issue}`,
           `Command: ${state.command}`,
           state.dryRun ? "Dry run: true" : undefined,
           `Status: ${state.status}`,
@@ -1575,6 +1620,7 @@ export class MagiRunManager {
             ? `Report: ${state.reportPath}`
             : undefined,
           editorLine,
+          triageCreatorLine,
           ...classifierLines,
           ...reviewerLines,
         ]
@@ -1613,6 +1659,7 @@ export class MagiRunManager {
   private collectSessionIds(state: MagiRunState): string[] {
     const ids = [
       state.editor?.sessionId,
+      state.triageCreator?.sessionId,
       ...Object.values(state.reviewers).map((reviewer) => reviewer.sessionId),
       ...Object.values(state.ciClassifiers ?? {}).map(
         (classifier) => classifier.sessionId,
@@ -1672,13 +1719,23 @@ export class MagiRunManager {
     key: string,
   ): MagiRunAgentState | undefined {
     if (key.startsWith("ci:")) return state.ciClassifiers?.[key.slice(3)]
-    return key === "editor" ? state.editor : state.reviewers[key]
+    if (key === "editor") return state.editor
+    if (key === "triageCreator") return state.triageCreator
+    return state.reviewers[key]
   }
 
   private agentEntries(state: MagiRunState): [string, MagiRunAgentState][] {
     return [
       ...(state.editor
         ? [["editor", state.editor] as [string, MagiRunAgentState]]
+        : []),
+      ...(state.triageCreator
+        ? [
+            ["triageCreator", state.triageCreator] as [
+              string,
+              MagiRunAgentState,
+            ],
+          ]
         : []),
       ...Object.entries(state.ciClassifiers ?? {}).map(
         ([key, value]) => [`ci:${key}`, value] as [string, MagiRunAgentState],
@@ -1709,10 +1766,10 @@ export class MagiRunManager {
     if (!matches.length) {
       return key
         ? `No pending ${kind} request found for ${key}.`
-        : `No pending ${kind} request found for ${prMarkdownLink(state)}.`
+        : `No pending ${kind} request found for ${runLabel(state)}.`
     }
     if (matches.length > 1) {
-      return `Multiple pending ${kind} requests found for ${prMarkdownLink(state)}. Specify agent or requestId.`
+      return `Multiple pending ${kind} requests found for ${runLabel(state)}. Specify agent or requestId.`
     }
 
     return { key: matches[0][0], state: matches[0][1] }
@@ -1879,6 +1936,7 @@ export class MagiRunManager {
         input.config.github?.apiRetryAttempts ?? 3,
       ),
       issue: input.issue,
+      onProgress: (progress) => this.applyTriageProgress(input.runId, progress),
       repository: input.repository,
       runId: input.runId,
       signal: input.signal,
@@ -1897,6 +1955,9 @@ export class MagiRunManager {
     for (const agent of Object.values(completed.reviewers)) {
       if (agent.status === "pending") agent.status = "completed"
     }
+    if (completed.triageCreator?.status === "pending") {
+      completed.triageCreator.status = "skipped"
+    }
 
     await this.persist(completed)
     await this.notify(
@@ -1910,6 +1971,270 @@ export class MagiRunManager {
     )
     this.active.delete(input.runId)
     this.controllers.delete(input.runId)
+  }
+
+  private async applyTriageProgress(
+    runId: string,
+    progress: TriageRunProgress,
+  ): Promise<void> {
+    const state = this.active.get(runId)
+    if (!state) return
+
+    const issue = issueMarkdownLink(state)
+    const creatorState = () =>
+      state.triageCreator ??
+      (state.triageCreator = {
+        account: "triageCreator",
+        repairAttempts: 0,
+        status: "pending",
+        toolCalls: 0,
+      })
+
+    state.updatedAt = now()
+
+    if (progress.type === "phase") {
+      state.phase = progress.phase
+      state.status = "running"
+    }
+
+    if (progress.type === "decision") {
+      state.phase = `decision: ${progress.result.disposition}`
+      state.verdict = JSON.stringify(progress.result)
+    }
+
+    if (progress.type === "comment_posting") {
+      state.phase = "posting triage comment"
+      state.status = "posting"
+    }
+
+    if (progress.type === "comment_posted") {
+      state.status = "running"
+    }
+
+    if (progress.type === "pr_creation_started") {
+      state.phase = "creating implementation PR"
+      state.status = "running"
+    }
+
+    if (progress.type === "worktree_created") {
+      state.worktreePath = progress.worktreePath
+      state.worktreeBranch = progress.branch
+    }
+
+    if (progress.type === "triage_agent_started") {
+      const reviewer = state.reviewers[progress.reviewer]
+      if (reviewer) reviewer.status = "running"
+    }
+
+    if (progress.type === "triage_agent_session") {
+      const reviewer = state.reviewers[progress.reviewer]
+      if (reviewer) {
+        if (progress.options)
+          this.input.setSessionOptions?.(progress.sessionId, progress.options)
+        reviewer.sessionId = progress.sessionId
+        reviewer.status = "running"
+        reviewer.lastUpdate = now()
+        this.sessionToRun.set(progress.sessionId, {
+          agent: progress.reviewer,
+          runId,
+        })
+      }
+    }
+
+    if (progress.type === "triage_agent_repair") {
+      const reviewer = state.reviewers[progress.reviewer]
+      if (reviewer) {
+        reviewer.status = "repairing"
+        reviewer.repairAttempts += 1
+        reviewer.lastUpdate = now()
+      }
+    }
+
+    if (progress.type === "triage_agent_response") {
+      const reviewer = state.reviewers[progress.reviewer]
+      if (reviewer) {
+        reviewer.sessionId = progress.sessionId
+        reviewer.lastUpdate = now()
+      }
+    }
+
+    if (progress.type === "triage_agent_completed") {
+      const reviewer = state.reviewers[progress.reviewer]
+      if (reviewer) {
+        reviewer.sessionId = progress.sessionId
+        reviewer.status = "completed"
+        reviewer.verdict = progress.vote
+        reviewer.rawPath = join(
+          state.outputDir,
+          `${progress.reviewer}.${progress.phase}.raw.txt`,
+        )
+        reviewer.parsedPath = join(
+          state.outputDir,
+          `${progress.reviewer}.${progress.phase}.json`,
+        )
+        reviewer.lastUpdate = now()
+      }
+    }
+
+    if (progress.type === "triage_agent_failed") {
+      const reviewer = state.reviewers[progress.reviewer]
+      if (reviewer) {
+        reviewer.status = "failed"
+        reviewer.error = redactSecrets(progress.error)
+        reviewer.lastUpdate = now()
+      }
+    }
+
+    if (progress.type === "triage_creator_started") {
+      creatorState().status = "running"
+    }
+
+    if (progress.type === "triage_creator_session") {
+      const creator = creatorState()
+      if (progress.options)
+        this.input.setSessionOptions?.(progress.sessionId, progress.options)
+      creator.sessionId = progress.sessionId
+      creator.status = "running"
+      creator.lastUpdate = now()
+      this.sessionToRun.set(progress.sessionId, {
+        agent: "triageCreator",
+        runId,
+      })
+    }
+
+    if (progress.type === "triage_creator_repair") {
+      const creator = creatorState()
+      creator.status = "repairing"
+      creator.repairAttempts += 1
+      creator.lastUpdate = now()
+    }
+
+    if (progress.type === "triage_creator_response") {
+      const creator = creatorState()
+      creator.sessionId = progress.sessionId
+      creator.lastUpdate = now()
+    }
+
+    if (progress.type === "triage_creator_completed") {
+      const creator = creatorState()
+      creator.sessionId = progress.sessionId
+      creator.status = "completed"
+      creator.parsedPath = join(state.outputDir, "create-pr.json")
+      creator.lastUpdate = now()
+    }
+
+    if (progress.type === "triage_creator_failed") {
+      const creator = creatorState()
+      creator.status = "failed"
+      creator.error = redactSecrets(progress.error)
+      creator.lastUpdate = now()
+    }
+
+    await this.persist(state)
+
+    if (progress.type === "phase") {
+      await this.notify(state, `Triage phase for ${issue}: ${progress.phase}.`)
+    }
+
+    if (progress.type === "decision") {
+      await this.notify(
+        state,
+        triageDecisionNotification({
+          action: progress.action,
+          issue,
+          result: JSON.stringify(progress.result),
+        }),
+      )
+    }
+
+    if (progress.type === "triage_agent_started") {
+      await this.notify(
+        state,
+        `**Triage agent ${progress.reviewer}** started ${progress.phase} for ${issue}.`,
+      )
+    }
+
+    if (progress.type === "triage_agent_repair") {
+      await this.notify(
+        state,
+        `**Triage agent ${progress.reviewer}** started JSON regeneration for ${issue}.`,
+      )
+    }
+
+    if (progress.type === "triage_agent_completed") {
+      await this.notify(
+        state,
+        `**Triage agent ${progress.reviewer}** completed ${progress.phase} for ${issue}: ${progress.vote}.`,
+      )
+    }
+
+    if (progress.type === "triage_agent_failed") {
+      await this.notify(
+        state,
+        `**Triage agent ${progress.reviewer}** failed ${progress.phase} for ${issue}: ${redactSecrets(progress.error)}`,
+      )
+    }
+
+    if (progress.type === "comment_posting") {
+      await this.notify(state, `Posting triage comment for ${issue}.`)
+    }
+
+    if (progress.type === "comment_posted") {
+      await this.notify(
+        state,
+        `Posted triage comment for ${issue}: ${progress.url}`,
+      )
+    }
+
+    if (progress.type === "pr_creation_started") {
+      await this.notify(
+        state,
+        `Started implementation PR creation for ${issue}.`,
+      )
+    }
+
+    if (progress.type === "worktree_created") {
+      await this.notify(state, `Worktree is ready for ${issue}.`)
+    }
+
+    if (progress.type === "triage_creator_started") {
+      await this.notify(
+        state,
+        `**Triage creator** started creating an implementation PR for ${issue}.`,
+      )
+    }
+
+    if (progress.type === "triage_creator_repair") {
+      await this.notify(
+        state,
+        `**Triage creator** started JSON regeneration for ${issue}.`,
+      )
+    }
+
+    if (progress.type === "triage_creator_completed") {
+      await this.notify(
+        state,
+        `**Triage creator** completed implementation changes for ${issue}.`,
+      )
+    }
+
+    if (progress.type === "triage_creator_failed") {
+      await this.notify(
+        state,
+        triageCreatorFailureText({
+          error: redactSecrets(progress.error),
+          issue,
+          repairAttempts: state.triageCreator?.repairAttempts ?? 0,
+        }),
+      )
+    }
+
+    if (progress.type === "pr_created") {
+      await this.notify(
+        state,
+        `Created implementation PR for ${issue}: ${progress.url}`,
+      )
+    }
   }
 
   private async applyReviewProgress(

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -1038,8 +1038,7 @@ export class MagiRunManager {
       state.triageCreator?.status === "repairing" ||
       state.triageCreator?.status === "blocked"
     ) {
-      state.triageCreator.status = "failed"
-      state.triageCreator.error = state.error
+      state.triageCreator.status = "cancelled"
     }
     if (state.triageCreator?.sessionId) {
       await this.input.client.session

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -331,6 +331,7 @@ async function runScenario(input: {
     issue: input.issue,
     relatedPullRequests: input.relatedPullRequests,
   })
+  const progress: unknown[] = []
   const result = await runTriage({
     client: model.client,
     config: {},
@@ -338,11 +339,14 @@ async function runScenario(input: {
     dryRun: input.dryRun ?? true,
     exec: exec.exec,
     issue: 1,
+    onProgress: (item) => {
+      progress.push(item)
+    },
     repository: input.repository ?? repository,
     runId: "run-test",
   })
 
-  return { ...exec, ...model, result }
+  return { ...exec, ...model, progress, result }
 }
 
 function vote(vote: string): string {
@@ -701,6 +705,35 @@ describe("triage orchestration", () => {
     expect(assignIndex).toBeLessThan(worktreeIndex)
     expect(assignIndex).toBeLessThan(prIndex)
     expect(result.commands[prIndex]).not.toContain("--add-assignee")
+    expect(result.progress).toEqual(
+      expect.arrayContaining([
+        { phase: "acceptance", type: "phase" },
+        {
+          action: "PR",
+          result: decision("feature", "accepted"),
+          type: "decision",
+        },
+        { type: "comment_posting" },
+        {
+          type: "comment_posted",
+          url: "https://github.com/owner/repo/issues/1#issuecomment-9001",
+        },
+        { type: "pr_creation_started" },
+        { type: "triage_creator_started" },
+        {
+          sessionId: expect.any(String),
+          type: "triage_creator_session",
+        },
+        {
+          sessionId: expect.any(String),
+          type: "triage_creator_completed",
+        },
+        {
+          type: "pr_created",
+          url: "https://github.com/owner/repo/pull/30",
+        },
+      ]),
+    )
   })
 
   test("skips reconsideration when a previous marker has no eligible mentions", async () => {

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -65,7 +65,13 @@ import {
   parseTriageExistingPrOutput,
 } from "../prompts/output"
 import { aggregateStringMajority, majorityThreshold } from "./majority"
-import { runModelText, runModelWithRepair, type ModelClient } from "./model"
+import {
+  runModelText,
+  runModelWithRepair,
+  type ModelClient,
+  type ModelRunResult,
+  type ModelRunProgress,
+} from "./model"
 
 type FinalResult = TriageDecision
 
@@ -76,6 +82,7 @@ export interface TriageRunInput {
   dryRun?: boolean
   exec: Exec
   issue: number
+  onProgress?: (progress: TriageRunProgress) => void | Promise<void>
   repository: ResolvedRepository
   runId?: string
   signal?: AbortSignal
@@ -87,6 +94,53 @@ export interface TriageRunResult {
   report: string
   result: FinalResult
 }
+
+export type TriageRunProgress =
+  | { phase: string; type: "phase" }
+  | { action: TriageAction; result: FinalResult; type: "decision" }
+  | { phase: string; reviewer: string; type: "triage_agent_started" }
+  | {
+      options?: ModelRunProgress["options"]
+      phase: string
+      reviewer: string
+      sessionId: string
+      type: "triage_agent_session"
+    }
+  | {
+      phase: string
+      reviewer: string
+      sessionId: string
+      type: "triage_agent_response"
+    }
+  | { phase: string; reviewer: string; type: "triage_agent_repair" }
+  | {
+      phase: string
+      reviewer: string
+      sessionId: string
+      type: "triage_agent_completed"
+      vote: string
+    }
+  | {
+      error: string
+      phase: string
+      reviewer: string
+      type: "triage_agent_failed"
+    }
+  | { type: "comment_posting" }
+  | { type: "comment_posted"; url: string }
+  | { type: "pr_creation_started" }
+  | { type: "triage_creator_started" }
+  | {
+      options?: ModelRunProgress["options"]
+      sessionId: string
+      type: "triage_creator_session"
+    }
+  | { sessionId: string; type: "triage_creator_response" }
+  | { type: "triage_creator_repair" }
+  | { sessionId: string; type: "triage_creator_completed" }
+  | { error: string; type: "triage_creator_failed" }
+  | { type: "pr_created"; url: string }
+  | { branch: string; type: "worktree_created"; worktreePath: string }
 
 interface TriageMarker {
   action?: string
@@ -262,6 +316,45 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
 }
 
+async function emitProgress(
+  input: TriageRunInput,
+  progress: TriageRunProgress,
+): Promise<void> {
+  await input.onProgress?.(progress)
+}
+
+async function emitTriageModelProgress(input: {
+  progress: ModelRunProgress
+  phase: string
+  run: TriageRunInput
+  reviewer: string
+}): Promise<void> {
+  if (input.progress.type === "session_created") {
+    await emitProgress(input.run, {
+      options: input.progress.options,
+      phase: input.phase,
+      reviewer: input.reviewer,
+      sessionId: input.progress.sessionId,
+      type: "triage_agent_session",
+    })
+  }
+  if (input.progress.type === "repair") {
+    await emitProgress(input.run, {
+      phase: input.phase,
+      reviewer: input.reviewer,
+      type: "triage_agent_repair",
+    })
+  }
+  if (input.progress.type === "response") {
+    await emitProgress(input.run, {
+      phase: input.phase,
+      reviewer: input.reviewer,
+      sessionId: input.progress.sessionId,
+      type: "triage_agent_response",
+    })
+  }
+}
+
 async function runVote<
   T extends string,
   O extends TriageVoteOutput<T> = TriageVoteOutput<T>,
@@ -272,8 +365,10 @@ async function runVote<
   directory: string
   issue: number
   parse: (text: string) => O
+  phase: string
   prompt: TriagePromptComposer
   repository: ResolvedRepository
+  run: TriageRunInput
   schemaName: string
   signal?: AbortSignal
 }): Promise<O & { promptText: string; raw: string; sessionId: string }> {
@@ -284,17 +379,48 @@ async function runVote<
     repository: input.repository,
     reviewer: input.agent,
   })
-  const result = await runModelWithRepair({
-    client: input.client,
-    model: input.agent.model,
-    options: input.agent.options,
-    parse: input.parse,
-    permission: input.agent.permission,
-    prompt,
-    repairAttempts: 3,
-    schemaName: input.schemaName,
-    signal: input.signal,
-    title: `Magi triage ${input.schemaName} #${input.issue} (${input.agent.key})`,
+  await emitProgress(input.run, {
+    phase: input.phase,
+    reviewer: input.agent.key,
+    type: "triage_agent_started",
+  })
+  let result: ModelRunResult<O>
+  try {
+    result = await runModelWithRepair({
+      client: input.client,
+      model: input.agent.model,
+      onProgress: (progress) =>
+        emitTriageModelProgress({
+          phase: input.phase,
+          progress,
+          reviewer: input.agent.key,
+          run: input.run,
+        }),
+      options: input.agent.options,
+      parse: input.parse,
+      permission: input.agent.permission,
+      prompt,
+      repairAttempts: 3,
+      schemaName: input.schemaName,
+      signal: input.signal,
+      title: `Magi triage ${input.schemaName} #${input.issue} (${input.agent.key})`,
+    })
+  } catch (error) {
+    await emitProgress(input.run, {
+      error: error instanceof Error ? error.message : String(error),
+      phase: input.phase,
+      reviewer: input.agent.key,
+      type: "triage_agent_failed",
+    })
+    throw error
+  }
+
+  await emitProgress(input.run, {
+    phase: input.phase,
+    reviewer: input.agent.key,
+    sessionId: result.sessionId,
+    type: "triage_agent_completed",
+    vote: result.value.vote,
   })
 
   return {
@@ -358,6 +484,7 @@ async function runDuplicateVote(input: {
 }): Promise<TriageDuplicateOutput | undefined> {
   const agents = input.input.repository.agents.triage
   if (!agents?.length) throw new Error("triage.agents is required")
+  await emitProgress(input.input, { phase: "duplicate", type: "phase" })
 
   const outputs = await Promise.all(
     agents.map((agent) =>
@@ -368,8 +495,10 @@ async function runDuplicateVote(input: {
         directory: input.input.directory,
         issue: input.input.issue,
         parse: parseTriageDuplicateOutput,
+        phase: "duplicate",
         prompt: composeTriageDuplicatePrompt,
         repository: input.input.repository,
+        run: input.input,
         schemaName: "triage duplicate",
         signal: input.input.signal,
       }),
@@ -425,6 +554,7 @@ async function runPhaseVote<T extends string>(input: {
 }): Promise<T | undefined> {
   const agents = input.input.repository.agents.triage
   if (!agents?.length) throw new Error("triage.agents is required")
+  await emitProgress(input.input, { phase: input.phase, type: "phase" })
 
   const outputs = await Promise.all(
     agents.map((agent) =>
@@ -435,8 +565,10 @@ async function runPhaseVote<T extends string>(input: {
         directory: input.input.directory,
         issue: input.input.issue,
         parse: input.parse,
+        phase: input.phase,
         prompt: input.prompt,
         repository: input.input.repository,
+        run: input.input,
         schemaName: input.schemaName,
         signal: input.input.signal,
       }),
@@ -946,6 +1078,11 @@ async function finishWithResult(input: {
   const triage = input.input.repository.triage
   if (!triage) throw new Error("triage configuration is required")
   const plan = input.plan ?? actionPlan({ result: input.result, triage })
+  await emitProgress(input.input, {
+    action: plan.action,
+    result: input.result,
+    type: "decision",
+  })
   await runActionPrompt({
     context: input.context,
     input: input.input,
@@ -969,13 +1106,18 @@ async function finishWithResult(input: {
 
   if (!input.input.dryRun) {
     if (comment) {
-      await postMarkedIssueComment({
+      await emitProgress(input.input, { type: "comment_posting" })
+      const posted = await postMarkedIssueComment({
         account: triage.account ?? "",
         body: comment,
         exec: input.input.exec,
         issue: input.issue.number,
         outputDir: input.outputDir,
         repository: input.input.repository,
+      })
+      await emitProgress(input.input, {
+        type: "comment_posted",
+        url: posted.url,
       })
     }
     if (plan.clearLabels) {
@@ -1023,8 +1165,10 @@ async function finishWithResult(input: {
         issue: input.issue,
         outputDir: input.outputDir,
       })
-      if (prUrl)
+      if (prUrl) {
         await writeJson(join(input.outputDir, "pr.json"), { url: prUrl })
+        await emitProgress(input.input, { type: "pr_created", url: prUrl })
+      }
     }
     if (input.previousMarker && prUrl) {
       await persistProcessedMarker({
@@ -1101,72 +1245,111 @@ async function createImplementationPr(input: {
   if (!creator) return undefined
   const triage = input.input.repository.triage
   if (!triage?.account) throw new Error("triage.account is required")
+  await emitProgress(input.input, { type: "pr_creation_started" })
+  await emitProgress(input.input, { type: "triage_creator_started" })
 
-  await assignIssue(
-    input.input.exec,
-    input.input.repository,
-    input.issue.number,
-    triage.account,
-  )
-
-  const branch = `magi/issue-${input.issue.number}-${Date.now().toString(36)}`
-  const worktreePath = join(
-    worktreeBaseDir(input.input.directory, input.input.config, "issue"),
-    `issue-${input.issue.number}`,
-  )
-  await mkdir(dirname(worktreePath), { recursive: true })
-  await input.input.exec(
-    `git worktree add -b ${shellQuote(branch)} ${shellQuote(worktreePath)}`,
-  )
   try {
-    await configureGitIdentity(input.input.exec, worktreePath, creator.author)
-    const prompt = await composeTriageCreatePrPrompt({
-      context: input.context,
-      directory: input.input.directory,
-      issue: input.issue.number,
-      repository: input.input.repository,
-      worktreePath,
-    })
-    const result = await runModelWithRepair<EditOutput>({
-      client: input.input.client,
-      model: creator.model,
-      options: creator.options,
-      parse: parseTriageCreatePrOutput,
-      permission: creator.permission,
-      prompt,
-      repairAttempts: 3,
-      schemaName: "edit",
-      signal: input.input.signal,
-      title: `Magi triage create PR #${input.issue.number}`,
-    })
-
-    await writeJson(join(input.outputDir, "create-pr.json"), result.value)
-    if (result.value.mode !== "EDITED") return undefined
-
-    await pushHead(
+    await assignIssue(
       input.input.exec,
       input.input.repository,
-      worktreePath,
-      creator.account,
-      {
-        owner: input.input.repository.github.owner,
-        ref: branch,
-        repo: input.input.repository.github.repo,
-      },
+      input.issue.number,
+      triage.account,
     )
 
-    return createPullRequest(
-      input.input.exec,
-      input.input.repository,
-      creator.account,
-      {
-        body: `Closes #${input.issue.number}`,
-        head: branch,
-        title: `fix: address issue #${input.issue.number}`,
-      },
+    const branch = `magi/issue-${input.issue.number}-${Date.now().toString(36)}`
+    const worktreePath = join(
+      worktreeBaseDir(input.input.directory, input.input.config, "issue"),
+      `issue-${input.issue.number}`,
     )
-  } finally {
-    await removeWorktree(input.input.exec, worktreePath).catch(() => undefined)
+    await mkdir(dirname(worktreePath), { recursive: true })
+    await input.input.exec(
+      `git worktree add -b ${shellQuote(branch)} ${shellQuote(worktreePath)}`,
+    )
+    await emitProgress(input.input, {
+      branch,
+      type: "worktree_created",
+      worktreePath,
+    })
+    try {
+      await configureGitIdentity(input.input.exec, worktreePath, creator.author)
+      const prompt = await composeTriageCreatePrPrompt({
+        context: input.context,
+        directory: input.input.directory,
+        issue: input.issue.number,
+        repository: input.input.repository,
+        worktreePath,
+      })
+      const result = await runModelWithRepair<EditOutput>({
+        client: input.input.client,
+        model: creator.model,
+        onProgress: async (progress) => {
+          if (progress.type === "session_created") {
+            await emitProgress(input.input, {
+              options: progress.options,
+              sessionId: progress.sessionId,
+              type: "triage_creator_session",
+            })
+          }
+          if (progress.type === "repair") {
+            await emitProgress(input.input, { type: "triage_creator_repair" })
+          }
+          if (progress.type === "response") {
+            await emitProgress(input.input, {
+              sessionId: progress.sessionId,
+              type: "triage_creator_response",
+            })
+          }
+        },
+        options: creator.options,
+        parse: parseTriageCreatePrOutput,
+        permission: creator.permission,
+        prompt,
+        repairAttempts: 3,
+        schemaName: "edit",
+        signal: input.input.signal,
+        title: `Magi triage create PR #${input.issue.number}`,
+      })
+      await emitProgress(input.input, {
+        sessionId: result.sessionId,
+        type: "triage_creator_completed",
+      })
+
+      await writeJson(join(input.outputDir, "create-pr.json"), result.value)
+      if (result.value.mode !== "EDITED") return undefined
+
+      await pushHead(
+        input.input.exec,
+        input.input.repository,
+        worktreePath,
+        creator.account,
+        {
+          owner: input.input.repository.github.owner,
+          ref: branch,
+          repo: input.input.repository.github.repo,
+        },
+      )
+
+      return createPullRequest(
+        input.input.exec,
+        input.input.repository,
+        creator.account,
+        {
+          body: `Closes #${input.issue.number}`,
+          head: branch,
+          title: `fix: address issue #${input.issue.number}`,
+        },
+      )
+    } finally {
+      await removeWorktree(input.input.exec, worktreePath).catch(
+        () => undefined,
+      )
+    }
+  } catch (error) {
+    await emitProgress(input.input, {
+      error: error instanceof Error ? error.message : String(error),
+      type: "triage_creator_failed",
+    })
+    throw error
   }
 }
 
@@ -1187,7 +1370,12 @@ export async function runTriage(
   })
   await mkdir(outputDir, { recursive: true })
 
+  await emitProgress(input, { phase: "fetching issue", type: "phase" })
   const issue = await fetchIssue(input.exec, input.repository, input.issue)
+  await emitProgress(input, {
+    phase: "scanning issue relationships",
+    type: "phase",
+  })
   const relationship = await relationshipScan(input, issue)
   const block = safetyBlocked(
     input,
@@ -1217,6 +1405,7 @@ export async function runTriage(
 
   let context = issueContext({ issue, relationship })
   await writeFile(join(outputDir, "context.md"), `${context}\n`)
+  await emitProgress(input, { phase: "triaging", type: "phase" })
   let processed = relationship.previousMarker?.processed ?? []
   let result: FinalResult | undefined
 
@@ -1341,6 +1530,11 @@ export async function runTriage(
           createPr: false,
           postComment: true,
         }
+        await emitProgress(input, {
+          action: plan.action,
+          result: relatedPrDecision,
+          type: "decision",
+        })
         await runActionPrompt({
           context,
           input,
@@ -1358,7 +1552,8 @@ export async function runTriage(
           result: relatedPrDecision,
         })
         if (!input.dryRun) {
-          await postMarkedIssueComment({
+          await emitProgress(input, { type: "comment_posting" })
+          const posted = await postMarkedIssueComment({
             account: triage.account,
             body,
             exec: input.exec,
@@ -1366,6 +1561,7 @@ export async function runTriage(
             outputDir,
             repository: input.repository,
           })
+          await emitProgress(input, { type: "comment_posted", url: posted.url })
           const clearLabels = existingClearLabels(
             issue,
             triage.automation.clear,


### PR DESCRIPTION
Closes #105

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds triage progress reporting for implementation PR creation and exposes the triage creator session in Magi run status.

## Current behavior (updates)

Triage could start a child PR creation session while the parent run still appeared as generic triaging work with pending agents.

## New behavior

Triage now emits phase, decision, comment posting, PR creation, triage agent, and triage creator progress. The run manager persists those updates, sends parent notifications, and tracks the creator session for status and OpenCode events.

## Is this a breaking change (Yes/No):

No

## Additional Information

Targeted tests run:

`pnpm vitest run src/orchestrator/triage.test.ts src/orchestrator/run-manager.test.ts`