### PR TITLE
fix(triage): use creator PR metadata

### DIFF
--- a/.changeset/triage-pr-metadata.md
+++ b/.changeset/triage-pr-metadata.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Use triage creator output for automated triage pull request titles and bodies.

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -671,6 +671,10 @@ describe("triage orchestration", () => {
           commitSha: "abc123",
           filesTouched: ["src/example.ts"],
           mode: "EDITED",
+          pullRequest: {
+            body: "Custom PR body from creator",
+            title: "fix(triage): use creator PR metadata",
+          },
           responses: [{ action: "FIXED", body: "Fixed.", commentId: 1 }],
         }),
       ],
@@ -705,6 +709,12 @@ describe("triage orchestration", () => {
     expect(assignIndex).toBeLessThan(worktreeIndex)
     expect(assignIndex).toBeLessThan(prIndex)
     expect(result.commands[prIndex]).not.toContain("--add-assignee")
+    expect(result.commands[prIndex]).toContain(
+      "--title 'fix(triage): use creator PR metadata'",
+    )
+    expect(result.commands[prIndex]).toContain(
+      "--body 'Custom PR body from creator'",
+    )
     expect(result.progress).toEqual(
       expect.arrayContaining([
         { phase: "acceptance", type: "phase" },
@@ -771,6 +781,10 @@ describe("triage orchestration", () => {
           commitSha: "abcdef1234567890",
           filesTouched: ["src/app.ts"],
           mode: "EDITED",
+          pullRequest: {
+            body: "Closes #1",
+            title: "fix: address issue #1",
+          },
           responses: [],
         }),
       ],
@@ -889,6 +903,10 @@ describe("triage orchestration", () => {
           commitSha: "abcdef1234567890",
           filesTouched: ["src/app.ts"],
           mode: "EDITED",
+          pullRequest: {
+            body: "Closes #1",
+            title: "fix: address issue #1",
+          },
           responses: [],
         }),
       ],

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -1305,7 +1305,7 @@ async function createImplementationPr(input: {
         permission: creator.permission,
         prompt,
         repairAttempts: 3,
-        schemaName: "edit",
+        schemaName: "triage create PR",
         signal: input.input.signal,
         title: `Magi triage create PR #${input.issue.number}`,
       })
@@ -1316,6 +1316,8 @@ async function createImplementationPr(input: {
 
       await writeJson(join(input.outputDir, "create-pr.json"), result.value)
       if (result.value.mode !== "EDITED") return undefined
+      const pullRequest = result.value.pullRequest
+      if (!pullRequest) throw new Error("EDITED requires pullRequest")
 
       await pushHead(
         input.input.exec,
@@ -1334,9 +1336,9 @@ async function createImplementationPr(input: {
         input.input.repository,
         creator.account,
         {
-          body: `Closes #${input.issue.number}`,
+          body: pullRequest.body,
           head: branch,
-          title: `fix: address issue #${input.issue.number}`,
+          title: pullRequest.title,
         },
       )
     } finally {

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -556,5 +556,9 @@ describe("prompt composer", () => {
       "<persona>\nKeep the PR minimal.\n</persona>",
     )
     expect(createPrPrompt).toContain('"mode": "EDITED" | "REPLIED"')
+    expect(createPrPrompt).toContain('"pullRequest"')
+    expect(createPrPrompt).toContain(
+      "The orchestrator pushes and creates the PR using pullRequest exactly as provided.",
+    )
   })
 })

--- a/src/prompts/compose.ts
+++ b/src/prompts/compose.ts
@@ -15,8 +15,9 @@ import {
   rereviewCloseReconsiderationOutputContract,
   rereviewOutputContract,
   reviewOutputContract,
-  triageCommentClassificationOutputContract,
   triageActionOutputContract,
+  triageCommentClassificationOutputContract,
+  triageCreatePrOutputContract,
   triageDuplicateOutputContract,
   triageVoteOutputContract,
 } from "./contracts"
@@ -625,7 +626,7 @@ export async function composeTriageCreatePrPrompt(
     task,
     languageBlock(input.repository.language),
     personaBlock(persona),
-    editOutputContract,
+    triageCreatePrOutputContract,
   ]
     .filter(Boolean)
     .join("\n\n")

--- a/src/prompts/contracts.ts
+++ b/src/prompts/contracts.ts
@@ -154,6 +154,33 @@ Rules:
 - REPLIED requires filesTouched to be empty and at least one DISAGREE or ASK response.
 </output_contract>`.trim()
 
+export const triageCreatePrOutputContract = `
+<output_contract>
+Return exactly one JSON object and nothing else. Do not wrap it in markdown.
+
+The object must match this shape:
+{
+  "mode": "EDITED" | "REPLIED",
+  "commitSha": "full sha, required only when mode is EDITED; omit when mode is REPLIED",
+  "commitMessage": "fix(scope): short description, required only when mode is EDITED; omit when mode is REPLIED",
+  "filesTouched": ["relative/path.ext"],
+  "pullRequest": {
+    "title": "PR title, required only when mode is EDITED; omit when mode is REPLIED",
+    "body": "PR body, required only when mode is EDITED; omit when mode is REPLIED"
+  },
+  "responses": [{ "commentId": 123, "action": "FIXED" | "DISAGREE" | "ASK", "body": "Fixed." }]
+}
+
+Rules:
+- Use EDITED only when you edited files, staged changes, and committed.
+- Use REPLIED when you only replied without code changes.
+- For EDITED, pullRequest.title and pullRequest.body must be non-empty and follow the repository's PR conventions.
+- Do not push or create the PR. The orchestrator pushes and creates the PR using pullRequest exactly as provided.
+- filesTouched must include every final changed file.
+- responses may be empty when no review threads were addressed.
+- REPLIED requires filesTouched to be empty and at least one DISAGREE or ASK response.
+</output_contract>`.trim()
+
 export const ciClassificationOutputContract = `
 <output_contract>
 Return exactly one JSON object and nothing else. Do not wrap it in markdown.
@@ -269,6 +296,7 @@ const outputContractsBySchemaName: Record<string, string> = {
   "triage category": triageVoteOutputContract(
     '"ASK" or one of the configured category IDs',
   ),
+  "triage create PR": triageCreatePrOutputContract,
   "triage comment classification": triageCommentClassificationOutputContract,
   "triage duplicate": triageDuplicateOutputContract,
   "triage existing PR": triageVoteOutputContract(

--- a/src/prompts/output.test.ts
+++ b/src/prompts/output.test.ts
@@ -199,6 +199,10 @@ describe("review output", () => {
           commitSha: "abcdef1234567890",
           filesTouched: ["src/app.ts"],
           mode: "EDITED",
+          pullRequest: {
+            body: "Closes #1",
+            title: "fix: address issue #1",
+          },
           responses: [],
         }),
       ),
@@ -207,8 +211,26 @@ describe("review output", () => {
       commitSha: "abcdef1234567890",
       filesTouched: ["src/app.ts"],
       mode: "EDITED",
+      pullRequest: {
+        body: "Closes #1",
+        title: "fix: address issue #1",
+      },
       responses: [],
     })
+  })
+
+  test("requires triage PR metadata for edited PR creation output", () => {
+    expect(() =>
+      parseTriageCreatePrOutput(
+        JSON.stringify({
+          commitMessage: "fix: address issue",
+          commitSha: "abcdef1234567890",
+          filesTouched: ["src/app.ts"],
+          mode: "EDITED",
+          responses: [],
+        }),
+      ),
+    ).toThrow("pullRequest is required")
   })
 })
 

--- a/src/prompts/output.ts
+++ b/src/prompts/output.ts
@@ -501,9 +501,28 @@ export function parseCiClassificationOutput(
   }
 }
 
+function parsePullRequest(
+  value: unknown,
+  options: { required: boolean },
+): EditOutput["pullRequest"] {
+  if (value == null) {
+    if (options.required) throw new Error("pullRequest is required")
+    return undefined
+  }
+  if (typeof value !== "object")
+    throw new Error("pullRequest must be an object")
+
+  const pullRequest = value as Record<string, unknown>
+
+  return {
+    body: requireString(pullRequest.body, "pullRequest.body"),
+    title: requireString(pullRequest.title, "pullRequest.title"),
+  }
+}
+
 function parseEditOutputWithOptions(
   text: string,
-  options: { requireResponses: boolean },
+  options: { requirePullRequest: boolean; requireResponses: boolean },
 ): EditOutput {
   const data = extractJson(text) as Record<string, unknown>
 
@@ -541,12 +560,16 @@ function parseEditOutputWithOptions(
 
   if (data.mode === "EDITED") {
     if (!filesTouched.length) throw new Error("EDITED requires filesTouched")
+    const pullRequest = parsePullRequest(data.pullRequest, {
+      required: options.requirePullRequest,
+    })
 
     return {
       commitMessage: requireString(data.commitMessage, "commitMessage"),
       commitSha: requireString(data.commitSha, "commitSha"),
       filesTouched,
       mode: data.mode,
+      ...(pullRequest ? { pullRequest } : {}),
       responses,
     }
   }
@@ -568,9 +591,15 @@ function parseEditOutputWithOptions(
 }
 
 export function parseEditOutput(text: string): EditOutput {
-  return parseEditOutputWithOptions(text, { requireResponses: true })
+  return parseEditOutputWithOptions(text, {
+    requirePullRequest: false,
+    requireResponses: true,
+  })
 }
 
 export function parseTriageCreatePrOutput(text: string): EditOutput {
-  return parseEditOutputWithOptions(text, { requireResponses: false })
+  return parseEditOutputWithOptions(text, {
+    requirePullRequest: true,
+    requireResponses: false,
+  })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -436,6 +436,10 @@ export interface EditOutput {
   commitSha?: string
   filesTouched: string[]
   mode: "EDITED" | "REPLIED"
+  pullRequest?: {
+    body: string
+    title: string
+  }
   responses: EditResponse[]
 }
 


### PR DESCRIPTION
Closes #108

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use triageCreator structured output for automated triage PR titles and bodies instead of orchestrator hardcoded defaults.

## Current behavior (updates)

Triage PR automation created implementation PRs with hardcoded `fix: address issue #<issue>` titles and `Closes #<issue>` bodies regardless of creator output.

## New behavior

The triage create-PR prompt and repair schema require `pullRequest.title` and `pullRequest.body` for `EDITED` output, and the orchestrator passes those values directly to `createPullRequest`.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tests: `pnpm test src/prompts/output.test.ts src/prompts/compose.test.ts src/orchestrator/triage.test.ts`