### PR TITLE
fix(docs): add triage project config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,23 @@ Add the following content to the configuration file.
         "email": "your-email@example.com"
       }
     }
+  },
+  "triage": {
+    "account": "your-triage-account",
+    "agents": [
+      {
+        "id": "general",
+        "model": "openai/gpt-5.5"
+      },
+      {
+        "id": "maintenance",
+        "model": "anthropic/claude-opus-4-7"
+      },
+      {
+        "id": "product",
+        "model": "opencode/kimi-k2-6"
+      }
+    ]
   }
 }
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -81,6 +81,23 @@ If at least one config exists, Magi validates the merged effective config and re
     "prompts": {
       "editGuidelines": ".agents/references/edit-guidelines.md"
     }
+  },
+  "triage": {
+    "account": "your-triage-account",
+    "agents": [
+      {
+        "id": "general",
+        "model": "openai/gpt-5.5"
+      },
+      {
+        "id": "maintenance",
+        "model": "anthropic/claude-opus-4-7"
+      },
+      {
+        "id": "product",
+        "model": "opencode/kimi-k2-6"
+      }
+    ]
   }
 }
 ```


### PR DESCRIPTION
Closes #110

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds triage configuration blocks to the project config examples in README.md and docs/config.md.

## Current behavior (updates)

The project config examples show review and merge configuration but omit the required triage.account and triage.agents settings for /magi:triage.

## New behavior

The project config examples include a triage block below the merge block with a triage account and three triage agents.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change. Pre-commit format and commitlint hooks passed.