### PR TITLE
chore(config): add merge edit guidelines

### DIFF
--- a/.agents/references/pr-edit-guidelines.md
+++ b/.agents/references/pr-edit-guidelines.md
@@ -1,0 +1,3 @@
+# PR Edit Guidelines
+
+Before inspecting, testing, or committing fixes in a PR worktree, run `pnpm install` first so local dependencies and git hooks are available.

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -60,6 +60,9 @@
         "name": "hirotomoyamada",
         "email": "hirotomo.yamada@avap.co.jp"
       }
+    },
+    "prompts": {
+      "editGuidelines": ".agents/references/pr-edit-guidelines.md"
     }
   },
   "triage": {


### PR DESCRIPTION
Closes #N/A (no issue; issue creation intentionally skipped by request)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds merge editor guidelines so Magi editor sessions receive project-specific setup instructions.

## Current behavior (updates)

Merge editor prompts do not include a project-specific instruction to install dependencies before working in PR worktrees.

## New behavior

Merge editor prompts append `.agents/references/pr-edit-guidelines.md`, which instructs editors to run `pnpm install` before inspecting, testing, or committing fixes in a PR worktree.

## Is this a breaking change (Yes/No):

No.

## Additional Information

No issue was created for this configuration-only change.