### PR TITLE
feat(config): add triage create guidelines

### DIFF
--- a/.changeset/add-triage-create-guidelines.md
+++ b/.changeset/add-triage-create-guidelines.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Add `triage.prompts.createGuidelines` for appending shared implementation guidance to triage PR creation prompts.

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -93,6 +93,7 @@ Important settings:
 | `triage.automation.merge`  | Starts `/magi:merge` after implementation PR creation. Requires `triage.automation.create`.           |
 | `triage.automation.clear`  | Labels removed for non-ASK results.                                                                   |
 | `triage.safety.*`          | Gates for initial triage and reconsideration.                                                         |
+| `triage.prompts.*`         | Triage prompt templates and PR creation guidelines.                                                   |
 | `triage.concurrency.runs`  | Maximum issues processed concurrently.                                                                |
 | `triage.output`            | Issue triage artifact directory.                                                                      |
 | `triage.worktree`          | Worktree directory for validation and PR creation.                                                    |

--- a/docs/config.md
+++ b/docs/config.md
@@ -97,7 +97,10 @@ If at least one config exists, Magi validates the merged effective config and re
         "id": "product",
         "model": "opencode/kimi-k2-6"
       }
-    ]
+    ],
+    "prompts": {
+      "createGuidelines": ".agents/references/create-guidelines.md"
+    }
   }
 }
 ```
@@ -197,6 +200,7 @@ If at least one config exists, Magi validates the merged effective config and re
 | `triage.prompts.commentClassification` | Both    | No                               | [md](/docs/prompts/triage/comment-classification.md) | Task template override for classifying mention replies after triage.                                                 |
 | `triage.prompts.reconsider`            | Both    | No                               | [md](/docs/prompts/triage/reconsider.md)             | Task template override for reconsidering previous triage results.                                                    |
 | `triage.prompts.create`                | Both    | No                               | [md](/docs/prompts/triage/create.md)                 | Task template override for creating implementation PRs.                                                              |
+| `triage.prompts.createGuidelines`      | Both    | No                               | -                                                    | Markdown file appended to PR creation prompts as shared implementation guidance.                                     |
 | `triage.output`                        | Both    | No                               | `.magi/runs/issue`                                   | Directory for issue triage run artifacts.                                                                            |
 | `triage.worktree`                      | Both    | No                               | `.magi/worktrees/issue`                              | Directory for issue validation and PR creation worktrees.                                                            |
 | `merge`                                | Both    | No                               | -                                                    | Additional `/magi:merge` configuration.                                                                              |

--- a/docs/prompts/index.md
+++ b/docs/prompts/index.md
@@ -4,7 +4,7 @@ Magi keeps built-in task prompts as Markdown templates under [`src/prompts/templ
 
 Custom prompt files replace the built-in task template for that phase. They do not replace the fixed output contract, so prompt customization cannot change the required response schema.
 
-Guideline files are additive. Configure `review.prompts.reviewGuidelines` or `merge.prompts.editGuidelines` when you want to keep Magi's built-in task prompts and append shared guidance from a Markdown file.
+Guideline files are additive. Configure `review.prompts.reviewGuidelines`, `merge.prompts.editGuidelines`, or `triage.prompts.createGuidelines` when you want to keep Magi's built-in task prompts and append shared guidance from a Markdown file.
 
 Custom prompt and guideline files are rendered with the same placeholder values as the built-in template for that phase.
 
@@ -39,6 +39,7 @@ Triage prompts:
 - [Comment Classification](triage/comment-classification.md) - Classify mention replies for reconsideration.
 - [Reconsider](triage/reconsider.md) - Vote on mention-triggered reconsideration.
 - [Create PR](triage/create.md) - Instruct the creator agent for implementation PRs.
+- [Create Guidelines](triage/create-guidelines.md) - Shared implementation guidance.
 
 ## Final Prompt Shape
 
@@ -78,6 +79,10 @@ The final prompt has this shape:
 <edit_guidelines>
 ...optional Markdown loaded from merge.prompts.editGuidelines...
 </edit_guidelines>
+
+<create_guidelines>
+...optional Markdown loaded from triage.prompts.createGuidelines...
+</create_guidelines>
 
 <output_contract>
 ...fixed JSON schema rules controlled by Magi...

--- a/docs/prompts/index.md
+++ b/docs/prompts/index.md
@@ -39,7 +39,7 @@ Triage prompts:
 - [Comment Classification](triage/comment-classification.md) - Classify mention replies for reconsideration.
 - [Reconsider](triage/reconsider.md) - Vote on mention-triggered reconsideration.
 - [Create PR](triage/create.md) - Instruct the creator agent for implementation PRs.
-- [Create Guidelines](triage/create-guidelines.md) - Shared implementation guidance.
+- [Create PR Guidelines](triage/create-guidelines.md) - Shared implementation guidance.
 
 ## Final Prompt Shape
 

--- a/docs/prompts/triage/create-guidelines.md
+++ b/docs/prompts/triage/create-guidelines.md
@@ -1,0 +1,17 @@
+# Create Guidelines
+
+Use `triage.prompts.createGuidelines` to append repository-specific implementation standards without replacing Magi's built-in PR creation task prompt.
+
+```json
+{
+  "triage": {
+    "prompts": {
+      "createGuidelines": ".agents/references/create-guidelines.md"
+    }
+  }
+}
+```
+
+Magi loads the file and appends it in a `<create_guidelines>` block before the fixed output contract for the PR creation phase. It is not added to triage voting, comment, or question prompts.
+
+Guideline files support the same placeholders as the prompt phase they are appended to.

--- a/docs/prompts/triage/create-guidelines.md
+++ b/docs/prompts/triage/create-guidelines.md
@@ -1,4 +1,4 @@
-# Create Guidelines
+# Create PR Guidelines
 
 Use `triage.prompts.createGuidelines` to append repository-specific implementation standards without replacing Magi's built-in PR creation task prompt.
 

--- a/schema.json
+++ b/schema.json
@@ -201,7 +201,8 @@
         "comment": { "type": "string" },
         "commentClassification": { "type": "string" },
         "reconsider": { "type": "string" },
-        "create": { "type": "string" }
+        "create": { "type": "string" },
+        "createGuidelines": { "type": "string" }
       }
     },
     "triageCategory": {

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -396,6 +396,7 @@ describe("validateConfig", () => {
   test("checks prompt file paths when directory is provided", async () => {
     const dir = await mkdtemp(join(tmpdir(), "magi-validate-"))
     await writeFile(join(dir, "review.txt"), "Review guide")
+    await writeFile(join(dir, "create-guide.txt"), "Create guide")
 
     const result = await validateConfig(
       {
@@ -407,6 +408,15 @@ describe("validateConfig", () => {
             reviewGuidelines: "review.txt",
           },
         },
+        triage: {
+          account: "magi-bot",
+          agents: [
+            { model: "openai/gpt" },
+            { model: "anthropic/claude" },
+            { model: "google/gemini" },
+          ],
+          prompts: { createGuidelines: "create-guide.txt" },
+        },
       },
       { directory: dir },
     )
@@ -417,6 +427,9 @@ describe("validateConfig", () => {
     )
     expect(result.errors).not.toContain(
       "review.prompts.reviewGuidelines file is not readable: review.txt",
+    )
+    expect(result.errors).not.toContain(
+      "triage.prompts.createGuidelines file is not readable: create-guide.txt",
     )
   })
 

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -175,6 +175,7 @@ const TRIAGE_PROMPT_KEYS = new Set([
   "comment",
   "commentClassification",
   "create",
+  "createGuidelines",
   "duplicate",
   "existingPr",
   "question",

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -463,6 +463,10 @@ describe("prompt composer", () => {
       join(dir, "triage-create.md"),
       "Implement in {worktreePath}: {context}",
     )
+    await writeFile(
+      join(dir, "triage-create-guidelines.md"),
+      "Keep issue #{issue} fixes scoped to {owner}/{repo}.",
+    )
 
     const repository: ResolvedRepository = {
       agents: {
@@ -521,6 +525,7 @@ describe("prompt composer", () => {
         prompts: {
           comment: "triage-comment.md",
           create: "triage-create.md",
+          createGuidelines: "triage-create-guidelines.md",
           question: "triage-question.md",
         },
         safety: {
@@ -558,6 +563,12 @@ describe("prompt composer", () => {
     expect(commentPrompt).toContain("Comment for @octocat: accepted")
     expect(questionPrompt).toContain("Question for @octocat: missing logs")
     expect(createPrPrompt).toContain("Implement in /tmp/issue-58: fix issue")
+    expect(createPrPrompt).toContain(
+      "<create_guidelines>\nKeep issue #58 fixes scoped to owner/repo.\n</create_guidelines>",
+    )
+    expect(createPrPrompt.indexOf("<create_guidelines>")).toBeLessThan(
+      createPrPrompt.indexOf("<output_contract>"),
+    )
     expect(createPrPrompt).toContain(
       "<persona>\nKeep the PR minimal.\n</persona>",
     )

--- a/src/prompts/compose.ts
+++ b/src/prompts/compose.ts
@@ -277,6 +277,18 @@ async function editGuidelinesBlock(input: {
   return body ? `<edit_guidelines>\n${body}\n</edit_guidelines>` : ""
 }
 
+async function createGuidelinesBlock(input: {
+  directory: string
+  path?: string
+  values: Record<string, string>
+}): Promise<string> {
+  const body = (
+    await readOptionalPrompt(input.directory, input.path, input.values)
+  ).trim()
+
+  return body ? `<create_guidelines>\n${body}\n</create_guidelines>` : ""
+}
+
 async function sessionContextBlocks(input: {
   directory: string
   includeReviewGuidelines?: boolean
@@ -626,6 +638,11 @@ export async function composeTriageCreatePrPrompt(
     task,
     languageBlock(input.repository.language),
     personaBlock(persona),
+    await createGuidelinesBlock({
+      directory: input.directory,
+      path: input.repository.triage?.prompts.createGuidelines,
+      values,
+    }),
     triageCreatePrOutputContract,
   ]
     .filter(Boolean)

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,7 @@ export interface TriagePromptConfig {
   comment?: string
   commentClassification?: string
   create?: string
+  createGuidelines?: string
   duplicate?: string
   existingPr?: string
   question?: string


### PR DESCRIPTION
Closes #N/A (issue not created per request)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add `triage.prompts.createGuidelines` so repositories can append shared implementation guidance to triage PR creation prompts without replacing the built-in create task.

## Current behavior (updates)

Triage PR creation supports `triage.prompts.create` to replace the full task template, but there is no additive guideline file equivalent to `merge.prompts.editGuidelines`.

## New behavior

`triage.prompts.createGuidelines` points to a Markdown file that is rendered with the PR creation prompt values and appended as a `<create_guidelines>` block before the fixed output contract.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Updated config types, validation, JSON schema, prompt composition, docs, and changeset.
- Added coverage for prompt composition and prompt file validation.
- Verified with `pnpm vitest run src/config/validate.test.ts src/prompts/compose.test.ts`.