### PR TITLE
fix(review): support file-level findings

### DIFF
--- a/.changeset/merge-skipped-review-findings.md
+++ b/.changeset/merge-skipped-review-findings.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Include skipped current review findings when merge editing addresses requested changes.

--- a/.changeset/review-file-level-findings.md
+++ b/.changeset/review-file-level-findings.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Allow review findings without inline diff line targets to be posted and handed to the merge editor.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -16,6 +16,7 @@ import {
   fetchUnresolvedThreads,
   ghHostOption,
   mergePullRequest,
+  postChangesRequested,
   postCloseComment,
   pushHead,
   repoSpecifier,
@@ -537,6 +538,59 @@ describe("GitHub command helpers", () => {
       body: "This PR should be closed.",
       event: "COMMENT",
     })
+  })
+
+  test("posts body-only findings in review body without inline comments", async () => {
+    const commands: string[] = []
+    let payload:
+      | { body: string; comments: unknown[]; event: string }
+      | undefined
+
+    await postChangesRequested(
+      async (command) => {
+        commands.push(command)
+        if (command.includes("gh auth token")) return "token"
+
+        const input = command.match(/--input '([^']+)'/)?.[1]
+        if (!input) throw new Error(`input path not found: ${command}`)
+        payload = JSON.parse(await readFile(input, "utf8"))
+
+        return "https://github.com/owner/repo/pull/7557#pullrequestreview-2"
+      },
+      repository,
+      7557,
+      "bot-a",
+      [
+        {
+          fix: "Pass structured findings to the editor.",
+          issue: "Body-only findings are lost.",
+          path: "src/orchestrator/merge.ts",
+        },
+        {
+          fix: "Validate only inline targets.",
+          issue: "Inline validation rejects file-level findings.",
+          line: 10,
+          path: "src/orchestrator/review.ts",
+        },
+      ],
+      [
+        {
+          evidence: "The runtime path is missing.",
+          fix: "Include requirement findings in the editor prompt.",
+          issueNumber: 121,
+          requirement: "Body-only findings must reach the editor.",
+        },
+      ],
+    )
+
+    expect(payload?.event).toBe("REQUEST_CHANGES")
+    expect(payload?.comments).toHaveLength(1)
+    expect(payload?.body).toContain("Inline findings:")
+    expect(payload?.body).toContain("src/orchestrator/review.ts:10")
+    expect(payload?.body).toContain("File-level findings:")
+    expect(payload?.body).toContain("src/orchestrator/merge.ts")
+    expect(payload?.body).toContain("Requirement findings:")
+    expect(commands[1]).toContain("repos/owner/repo/pulls/7557/reviews")
   })
 
   test("keeps GraphQL variables quoted in PR review query", async () => {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1253,7 +1253,15 @@ export async function postCloseComment(
   }
 }
 
-function findingComment(finding: Finding): Record<string, unknown> {
+function isInlineFinding(
+  finding: Finding,
+): finding is Finding & { line: number } {
+  return finding.line != null
+}
+
+function findingComment(
+  finding: Finding & { line: number },
+): Record<string, unknown> {
   const comment: Record<string, unknown> = {
     body: `**Issue:** ${finding.issue}\n\n**Fix:** ${finding.fix}`,
     line: finding.line,
@@ -1277,6 +1285,56 @@ function requirementFindingSummary(finding: RequirementFinding): string {
   ].join("\n")
 }
 
+function findingLocation(finding: Finding): string {
+  if (finding.line == null) return finding.path
+  if (finding.startLine == null) return `${finding.path}:${finding.line}`
+
+  return `${finding.path}:${finding.startLine}-${finding.line}`
+}
+
+function findingSummary(finding: Finding): string {
+  return [
+    `- ${findingLocation(finding)}: ${finding.issue}`,
+    `  Fix: ${finding.fix}`,
+  ]
+    .filter(Boolean)
+    .join("\n")
+}
+
+function changesRequestedBody(
+  findings: Finding[],
+  requirementFindings: RequirementFinding[],
+): string {
+  const inlineFindings = findings.filter(isInlineFinding)
+  const fileLevelFindings = findings.filter(
+    (finding) => !isInlineFinding(finding),
+  )
+  const sections: string[] = []
+
+  if (inlineFindings.length) {
+    sections.push(
+      ["Inline findings:", ...inlineFindings.map(findingSummary)].join("\n"),
+    )
+  }
+  if (fileLevelFindings.length) {
+    sections.push(
+      ["File-level findings:", ...fileLevelFindings.map(findingSummary)].join(
+        "\n",
+      ),
+    )
+  }
+  if (requirementFindings.length) {
+    sections.push(
+      [
+        "Requirement findings:",
+        ...requirementFindings.map(requirementFindingSummary),
+      ].join("\n"),
+    )
+  }
+
+  return sections.join("\n\n")
+}
+
 export async function postChangesRequested(
   exec: Exec,
   repository: ResolvedRepository,
@@ -1290,16 +1348,14 @@ export async function postChangesRequested(
     tmpdir(),
     `magi-review-${process.pid}-${Date.now()}.json`,
   )
-  const body = findings
-    .map((finding) => `- ${finding.issue.split("\n")[0]}`)
-    .concat(requirementFindings.map(requirementFindingSummary))
-    .join("\n")
+  const inlineFindings = findings.filter(isInlineFinding)
+  const body = changesRequestedBody(findings, requirementFindings)
 
   await writeFile(
     payloadPath,
     JSON.stringify({
       body,
-      comments: findings.map(findingComment),
+      comments: inlineFindings.map(findingComment),
       event: "REQUEST_CHANGES",
     }),
   )

--- a/src/orchestrator/inline-comments.test.ts
+++ b/src/orchestrator/inline-comments.test.ts
@@ -38,6 +38,28 @@ describe("inline comment targets", () => {
     ).not.toThrow()
   })
 
+  test("skips file-level findings without line targets", () => {
+    const targets = parseRightSideDiffTargets(diff)
+
+    expect(() =>
+      validateInlineCommentTargets(
+        [{ path: "src/app.ts" }, { line: 10, path: "src/app.ts" }],
+        targets,
+      ),
+    ).not.toThrow()
+  })
+
+  test("rejects startLine without a line target", () => {
+    const targets = parseRightSideDiffTargets(diff)
+
+    expect(() =>
+      validateInlineCommentTargets(
+        [{ path: "src/app.ts", startLine: 10 }],
+        targets,
+      ),
+    ).toThrow("findings[0].startLine requires line")
+  })
+
   test("rejects wildcard paths that are not concrete PR diff files", () => {
     const targets = parseRightSideDiffTargets(diff)
 

--- a/src/orchestrator/inline-comments.ts
+++ b/src/orchestrator/inline-comments.ts
@@ -1,7 +1,7 @@
 export type InlineCommentTargets = ReadonlyMap<string, ReadonlySet<number>>
 
 export interface InlineCommentFindingTarget {
-  line: number
+  line?: number
   path: string
   startLine?: number
 }
@@ -78,6 +78,13 @@ export function validateInlineCommentTargets(
 ): void {
   for (const [index, finding] of findings.entries()) {
     const name = `${label}[${index}]`
+
+    if (finding.line == null) {
+      if (finding.startLine != null) {
+        throw new Error(`${name}.startLine requires line`)
+      }
+      continue
+    }
 
     assertPositiveInteger(finding.line, `${name}.line`)
     if (finding.startLine != null) {

--- a/src/orchestrator/merge.test.ts
+++ b/src/orchestrator/merge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest"
 import type { ReviewThread } from "../github/commands"
 import {
+  blockingReviewFindings,
   editableReviewThreads,
   exhaustedReviewThreads,
   hasBlockingCiReports,
@@ -144,6 +145,47 @@ describe("merge", () => {
       label: "GitHub thread",
       url: "https://github.example.com/owner/repo/pull/7557#discussion_r123",
     })
+  })
+
+  test("extracts body-only and requirement findings for the editor", () => {
+    expect(
+      blockingReviewFindings({
+        alpha: {
+          findings: [
+            {
+              fix: "Pass findings to the editor.",
+              issue: "Body-only findings are lost.",
+              path: "src/orchestrator/merge.ts",
+            },
+          ],
+          requirementFindings: [
+            {
+              evidence: "Missing runtime behavior.",
+              fix: "Implement the runtime path.",
+              issueNumber: 121,
+              requirement: "Preserve body-only findings.",
+            },
+          ],
+          verdict: "CHANGES_REQUESTED",
+        },
+      }),
+    ).toEqual([
+      {
+        fix: "Pass findings to the editor.",
+        issue: "Body-only findings are lost.",
+        path: "src/orchestrator/merge.ts",
+        reviewer: "alpha",
+        type: "file",
+      },
+      {
+        evidence: "Missing runtime behavior.",
+        fix: "Implement the runtime path.",
+        issueNumber: 121,
+        requirement: "Preserve body-only findings.",
+        reviewer: "alpha",
+        type: "requirement",
+      },
+    ])
   })
 
   test("treats scope-in CI failures as merge blocking", () => {

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -3,6 +3,7 @@ import type {
   Exec,
   MagiConfig,
   ModelOptions,
+  NewFinding,
   ResolvedRepository,
   RereviewOutput,
   ReviewOutput,
@@ -117,6 +118,20 @@ export interface ThreadLimitNotification {
   url: string
 }
 
+interface EditorReviewFinding {
+  body?: string
+  evidence?: string
+  fix: string
+  issue?: string
+  issueNumber?: number
+  line?: number
+  path?: string
+  requirement?: string
+  reviewer: string
+  startLine?: number
+  type: "file" | "inline" | "requirement"
+}
+
 function outputDir(input: MergeRunInput): string {
   return prRunOutputDir({
     config: input.config,
@@ -168,6 +183,7 @@ async function runEditor(
   input: MergeRunInput,
   worktreePath: string,
   cycle: number,
+  reviewFindings: EditorReviewFinding[],
   unresolvedThreads: ReviewThread[],
 ): Promise<EditOutput> {
   const editor = input.repository.agents.editor
@@ -186,6 +202,7 @@ async function runEditor(
     directory: input.directory,
     pr: input.pr,
     repository: input.repository,
+    reviewFindings: JSON.stringify(reviewFindings, null, 2),
     unresolvedThreads: JSON.stringify(unresolvedThreads, null, 2),
     worktreePath,
   })
@@ -346,7 +363,7 @@ async function postRereviewOutput(
     )
   }
 
-  if (output.newFindings.length) {
+  if (output.newFindings.length || output.requirementFindings.length) {
     return postChangesRequested(
       input.exec,
       input.repository,
@@ -355,10 +372,11 @@ async function postRereviewOutput(
       output.newFindings.map((finding) => ({
         fix: "Please address this before merging.",
         issue: finding.body,
-        line: finding.line,
         path: finding.path,
+        ...(finding.line == null ? {} : { line: finding.line }),
         startLine: finding.startLine,
       })),
+      output.requirementFindings,
     )
   }
 
@@ -374,6 +392,62 @@ function parseRereviewOutputWithInlineTargets(
   validateInlineCommentTargets(output.newFindings, targets, "newFindings")
 
   return output
+}
+
+function newFindingToEditorFinding(
+  reviewer: string,
+  finding: NewFinding,
+): EditorReviewFinding {
+  return {
+    body: finding.body,
+    fix: "Please address this before merging.",
+    path: finding.path,
+    reviewer,
+    ...(finding.line == null ? {} : { line: finding.line }),
+    ...(finding.startLine == null ? {} : { startLine: finding.startLine }),
+    type: finding.line == null ? "file" : "inline",
+  }
+}
+
+export function blockingReviewFindings(
+  outputs: Record<string, RereviewOutput | ReviewOutput>,
+): EditorReviewFinding[] {
+  return Object.entries(outputs).flatMap(([reviewer, output]) => {
+    if (output.verdict !== "CHANGES_REQUESTED") return []
+
+    const requirementFindings = output.requirementFindings.map((finding) => ({
+      evidence: finding.evidence,
+      fix: finding.fix,
+      issueNumber: finding.issueNumber,
+      requirement: finding.requirement,
+      reviewer,
+      type: "requirement" as const,
+    }))
+
+    if ("findings" in output) {
+      return [
+        ...output.findings.map((finding) => ({
+          fix: finding.fix,
+          issue: finding.issue,
+          path: finding.path,
+          reviewer,
+          ...(finding.line == null ? {} : { line: finding.line }),
+          ...(finding.startLine == null
+            ? {}
+            : { startLine: finding.startLine }),
+          type: finding.line == null ? ("file" as const) : ("inline" as const),
+        })),
+        ...requirementFindings,
+      ]
+    }
+
+    return [
+      ...output.newFindings.map((finding) =>
+        newFindingToEditorFinding(reviewer, finding),
+      ),
+      ...requirementFindings,
+    ]
+  })
 }
 
 async function runRereview(
@@ -846,16 +920,43 @@ function syntheticReviewThreads(
 
   for (const [reviewer, output] of Object.entries(outputs)) {
     if ("findings" in output) {
-      threads[reviewer] = output.findings.map((finding) => {
+      threads[reviewer] = output.findings.flatMap((finding) => {
+        if (finding.line == null) return []
         const commentId = nextCommentId--
 
-        return {
-          body: `Issue: ${finding.issue}\n\nFix: ${finding.fix}`,
+        return [
+          {
+            body: `Issue: ${finding.issue}\n\nFix: ${finding.fix}`,
+            commentId,
+            comments: [
+              {
+                author: reviewer,
+                body: `Issue: ${finding.issue}\n\nFix: ${finding.fix}`,
+                commentId,
+                createdAt: new Date(0).toISOString(),
+              },
+            ],
+            line: finding.line,
+            path: finding.path,
+            threadId: `dry-run:${reviewer}:${Math.abs(commentId)}`,
+          },
+        ]
+      })
+      continue
+    }
+
+    threads[reviewer] = output.newFindings.flatMap((finding) => {
+      if (finding.line == null) return []
+      const commentId = nextCommentId--
+
+      return [
+        {
+          body: finding.body,
           commentId,
           comments: [
             {
               author: reviewer,
-              body: `Issue: ${finding.issue}\n\nFix: ${finding.fix}`,
+              body: finding.body,
               commentId,
               createdAt: new Date(0).toISOString(),
             },
@@ -863,29 +964,8 @@ function syntheticReviewThreads(
           line: finding.line,
           path: finding.path,
           threadId: `dry-run:${reviewer}:${Math.abs(commentId)}`,
-        }
-      })
-      continue
-    }
-
-    threads[reviewer] = output.newFindings.map((finding) => {
-      const commentId = nextCommentId--
-
-      return {
-        body: finding.body,
-        commentId,
-        comments: [
-          {
-            author: reviewer,
-            body: finding.body,
-            commentId,
-            createdAt: new Date(0).toISOString(),
-          },
-        ],
-        line: finding.line,
-        path: finding.path,
-        threadId: `dry-run:${reviewer}:${Math.abs(commentId)}`,
-      }
+        },
+      ]
     })
   }
 
@@ -1101,8 +1181,18 @@ export async function runMerge(input: MergeRunInput): Promise<MergeRunResult> {
           input.repository.merge.maxThreadResolutionCycles,
         threads: unresolvedThreads,
       })
+      const editorFindings = blockingReviewFindings(reportOutputs)
+      const editableFindings = editableThreads.length
+        ? editorFindings
+        : editorFindings.filter((finding) => finding.type !== "inline")
+      const findingAttemptsExhausted =
+        input.repository.merge.maxThreadResolutionCycles !== 0 &&
+        cycle > input.repository.merge.maxThreadResolutionCycles
 
-      if (!editableThreads.length) {
+      if (
+        !editableThreads.length &&
+        (!editableFindings.length || findingAttemptsExhausted)
+      ) {
         await input.onProgress?.({
           status: "changes_unresolved",
           type: "merge_completed",
@@ -1134,6 +1224,7 @@ export async function runMerge(input: MergeRunInput): Promise<MergeRunResult> {
         abortableInput,
         review.worktreePath,
         cycle,
+        editableFindings,
         editableThreads,
       )
       editorOutputs.push(editorOutput)

--- a/src/orchestrator/report.ts
+++ b/src/orchestrator/report.ts
@@ -60,9 +60,11 @@ function pullRequestLine(input: ReviewReportInput): string {
 
 function formatFinding(finding: Finding): string {
   const line =
-    finding.startLine == null
-      ? `${finding.path}:${finding.line}`
-      : `${finding.path}:${finding.startLine}-${finding.line}`
+    finding.line == null
+      ? finding.path
+      : finding.startLine == null
+        ? `${finding.path}:${finding.line}`
+        : `${finding.path}:${finding.startLine}-${finding.line}`
 
   return `\`${line}\`: ${finding.issue}`
 }
@@ -71,9 +73,11 @@ function formatRereviewFinding(
   finding: RereviewOutput["newFindings"][number],
 ): string {
   const line =
-    finding.startLine == null
-      ? `${finding.path}:${finding.line}`
-      : `${finding.path}:${finding.startLine}-${finding.line}`
+    finding.line == null
+      ? finding.path
+      : finding.startLine == null
+        ? `${finding.path}:${finding.line}`
+        : `${finding.path}:${finding.startLine}-${finding.line}`
 
   return `\`${line}\`: ${finding.body}`
 }

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -2,6 +2,7 @@ import type { PullRequestReview } from "../github/commands"
 import { describe, expect, test } from "vitest"
 import {
   hasPendingThreadReply,
+  reviewOutputFromState,
   resolveReviewMode,
   reviewFreshnessTarget,
 } from "./review"
@@ -150,6 +151,44 @@ describe("review flow", () => {
     )
 
     expect(mode.type).toBe("already_reviewed")
+  })
+
+  test("restores skipped review findings from the posted review body", () => {
+    expect(
+      reviewOutputFromState({
+        author: { login: "bot-a" },
+        body: [
+          "File-level findings:",
+          "- src/orchestrator/merge.ts: Preserve skipped findings.",
+          "  Fix: Pass existing review findings to the editor.",
+          "",
+          "Requirement findings:",
+          "- Missing issue #124 requirement: Include body-only requests.",
+          "  Evidence: The editor prompt omits skipped review findings.",
+          "  Fix: Parse the prior review body before editing.",
+        ].join("\n"),
+        commit: { oid: "head" },
+        state: "CHANGES_REQUESTED",
+        submittedAt: "2026-01-01T00:00:00Z",
+      }),
+    ).toEqual({
+      findings: [
+        {
+          fix: "Pass existing review findings to the editor.",
+          issue: "Preserve skipped findings.",
+          path: "src/orchestrator/merge.ts",
+        },
+      ],
+      requirementFindings: [
+        {
+          evidence: "The editor prompt omits skipped review findings.",
+          fix: "Parse the prior review body before editing.",
+          issueNumber: 124,
+          requirement: "Include body-only requests.",
+        },
+      ],
+      verdict: "CHANGES_REQUESTED",
+    })
   })
 
   test("detects replies after the reviewer latest thread comment", () => {

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -1,8 +1,10 @@
 import type {
   Exec,
+  Finding,
   FindingValidationOutput,
   MagiConfig,
   ModelOptions,
+  RequirementFinding,
   ResolvedRepository,
   RereviewOutput,
   ReviewOutput,
@@ -379,8 +381,82 @@ function parseRereviewOutputWithInlineTargets(
   return output
 }
 
-function reviewOutputFromState(review: PullRequestReview): ReviewOutput {
+function parsePostedFindingLocation(
+  location: string,
+): Pick<Finding, "line" | "path" | "startLine"> {
+  const range = /^(.*):(\d+)-(\d+)$/.exec(location)
+  if (range) {
+    return {
+      line: Number(range[3]),
+      path: range[1] ?? location,
+      startLine: Number(range[2]),
+    }
+  }
+
+  const line = /^(.*):(\d+)$/.exec(location)
+  if (line) return { line: Number(line[2]), path: line[1] ?? location }
+
+  return { path: location }
+}
+
+function reviewFindingsFromBody(
+  body: string | undefined,
+): Pick<ReviewOutput, "findings" | "requirementFindings"> {
+  const findings: Finding[] = []
+  const requirementFindings: RequirementFinding[] = []
+  const lines = (body ?? "").split(/\r?\n/)
+  let section: "finding" | "requirement" | undefined
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+
+    if (line === "Inline findings:" || line === "File-level findings:") {
+      section = "finding"
+      continue
+    }
+    if (line === "Requirement findings:") {
+      section = "requirement"
+      continue
+    }
+
+    if (section === "finding") {
+      const match = /^- (.*): (.+)$/.exec(line ?? "")
+      const fix = /^\s+Fix: (.+)$/.exec(lines[index + 1] ?? "")
+      if (!match || !fix) continue
+
+      findings.push({
+        ...parsePostedFindingLocation(match[1] ?? ""),
+        fix: fix[1] ?? "Please address this before merging.",
+        issue: match[2] ?? "Review finding.",
+      })
+      index += 1
+      continue
+    }
+
+    if (section !== "requirement") continue
+
+    const match = /^- Missing issue #(\d+) requirement: (.+)$/.exec(line ?? "")
+    const evidence = /^\s+Evidence: (.+)$/.exec(lines[index + 1] ?? "")
+    const fix = /^\s+Fix: (.+)$/.exec(lines[index + 2] ?? "")
+    if (!match || !evidence || !fix) continue
+
+    requirementFindings.push({
+      evidence: evidence[1] ?? "See review body.",
+      fix: fix[1] ?? "Please address this before merging.",
+      issueNumber: Number(match[1]),
+      requirement: match[2] ?? "Review requirement.",
+    })
+    index += 2
+  }
+
+  return { findings, requirementFindings }
+}
+
+export function reviewOutputFromState(review: PullRequestReview): ReviewOutput {
   const verdict = reviewStateToVerdict(review.state)
+
+  if (verdict === "CHANGES_REQUESTED")
+    return { ...reviewFindingsFromBody(review.body), verdict }
 
   return verdict === "CLOSE"
     ? {
@@ -1308,7 +1384,17 @@ export async function runReview(
       sessionIds,
       worktreePath,
     })
-    const outputs = validation.outputs
+    const activeOutputs = validation.outputs
+    const skippedOutputs = Object.fromEntries(
+      input.repository.agents.reviewers.flatMap((reviewer) => {
+        const assignment = mode.assignments.get(reviewer.account)
+
+        return assignment?.type === "skip"
+          ? [[reviewer.key, reviewOutputFromState(assignment.review)]]
+          : []
+      }),
+    )
+    const outputs = { ...skippedOutputs, ...activeOutputs }
     const remainingSkippedVerdicts = input.repository.agents.reviewers.flatMap(
       (reviewer) => {
         const assignment = mode.assignments.get(reviewer.account)
@@ -1324,7 +1410,7 @@ export async function runReview(
         ]
       },
     )
-    const activeVerdicts = Object.entries(outputs).map(
+    const activeVerdicts = Object.entries(activeOutputs).map(
       ([reviewer, output]) => ({
         reviewer,
         verdict: output.verdict,
@@ -1347,7 +1433,7 @@ export async function runReview(
       ),
       ...Object.fromEntries(
         await Promise.all(
-          Object.entries(outputs).map(async ([key, output]) => [
+          Object.entries(activeOutputs).map(async ([key, output]) => [
             key,
             input.dryRun
               ? dryRunReviewPost(key, output)

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -476,8 +476,8 @@ async function postRereviewOutput(
     output.newFindings.map((finding) => ({
       fix: "Please address this before merging.",
       issue: finding.body,
-      line: finding.line,
       path: finding.path,
+      ...(finding.line == null ? {} : { line: finding.line }),
       startLine: finding.startLine,
     })),
     output.requirementFindings,

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -315,6 +315,7 @@ describe("prompt composer", () => {
       directory: dir,
       pr: 1,
       repository,
+      reviewFindings: "[]",
       unresolvedThreads: "[]",
       worktreePath: "/tmp/worktree",
     })

--- a/src/prompts/compose.ts
+++ b/src/prompts/compose.ts
@@ -46,6 +46,7 @@ export interface EditPromptInput {
   directory: string
   pr: number
   repository: ResolvedRepository
+  reviewFindings: string
   unresolvedThreads: string
   worktreePath: string
 }
@@ -204,6 +205,7 @@ function editValues(input: EditPromptInput): Record<string, string> {
   return {
     ...repositoryValues(input.repository),
     pr: String(input.pr),
+    reviewFindings: input.reviewFindings,
     unresolvedThreads: input.unresolvedThreads,
     worktreePath: input.worktreePath,
   }

--- a/src/prompts/contracts.ts
+++ b/src/prompts/contracts.ts
@@ -31,9 +31,10 @@ Rules:
 - CHANGES_REQUESTED requires at least one finding or requirementFinding.
 - CLOSE requires a reason and empty findings and requirementFindings arrays.
 - path must be repository-relative.
-- line and startLine must refer to lines inside the PR diff hunk.
-- Omit startLine for single-line findings.
-- Use requirementFindings for missing closing-issue requirements that do not map cleanly to a diff line.
+- line is optional. Include line only when the finding targets a valid line inside the PR diff hunk.
+- startLine is allowed only when line is present and must also refer to a line inside the PR diff hunk.
+- Omit startLine for single-line findings and omit line for file-level or body-only findings.
+- Use requirementFindings only for missing closing-issue requirements; use findings for ordinary file-level issues that do not map cleanly to a diff line.
 </output_contract>`.trim()
 
 export const rereviewOutputContract = `
@@ -54,9 +55,10 @@ Rules:
 - MERGE requires empty followUps, newFindings, and requirementFindings arrays.
 - CHANGES_REQUESTED requires at least one followUp, newFinding, or requirementFinding.
 - CLOSE requires a reason and empty followUps, newFindings, and requirementFindings arrays.
-- line and startLine must refer to lines inside the latest PR diff hunk.
-- Omit startLine for single-line findings.
-- Use requirementFindings for missing closing-issue requirements that do not map cleanly to a diff line.
+- line is optional. Include line only when the newFinding targets a valid line inside the latest PR diff hunk.
+- startLine is allowed only when line is present and must also refer to a line inside the latest PR diff hunk.
+- Omit startLine for single-line findings and omit line for file-level or body-only findings.
+- Use requirementFindings only for missing closing-issue requirements; use newFindings for ordinary file-level issues that do not map cleanly to a diff line.
 </output_contract>`.trim()
 
 export const findingValidationOutputContract = `
@@ -105,7 +107,9 @@ Rules:
 - MERGE requires empty findings and requirementFindings arrays.
 - CHANGES_REQUESTED requires at least one finding or requirementFinding.
 - CLOSE is not allowed in this reconsideration step.
-- Omit startLine for single-line findings.
+- line is optional. Include line only when the finding targets a valid line inside the PR diff hunk.
+- startLine is allowed only when line is present.
+- Omit startLine for single-line findings and omit line for file-level or body-only findings.
 </output_contract>`.trim()
 
 export const rereviewCloseReconsiderationOutputContract = `
@@ -125,7 +129,9 @@ Rules:
 - MERGE requires empty followUps, newFindings, and requirementFindings arrays.
 - CHANGES_REQUESTED requires at least one followUp, newFinding, or requirementFinding.
 - CLOSE is not allowed in this reconsideration step.
-- Omit startLine for single-line findings.
+- line is optional. Include line only when the newFinding targets a valid line inside the latest PR diff hunk.
+- startLine is allowed only when line is present.
+- Omit startLine for single-line findings and omit line for file-level or body-only findings.
 </output_contract>`.trim()
 
 export const editOutputContract = `

--- a/src/prompts/output.test.ts
+++ b/src/prompts/output.test.ts
@@ -57,6 +57,50 @@ describe("review output", () => {
     })
   })
 
+  test("parses file-level findings without a line", () => {
+    expect(
+      parseReviewOutput(
+        JSON.stringify({
+          findings: [
+            {
+              fix: "Pass structured findings to the editor.",
+              issue: "The editor cannot see body-only findings.",
+              path: "src/orchestrator/merge.ts",
+            },
+          ],
+          verdict: "CHANGES_REQUESTED",
+        }),
+      ),
+    ).toMatchObject({
+      findings: [
+        {
+          fix: "Pass structured findings to the editor.",
+          issue: "The editor cannot see body-only findings.",
+          path: "src/orchestrator/merge.ts",
+        },
+      ],
+      verdict: "CHANGES_REQUESTED",
+    })
+  })
+
+  test("rejects startLine without line", () => {
+    expect(() =>
+      parseReviewOutput(
+        JSON.stringify({
+          findings: [
+            {
+              fix: "Use line or omit startLine.",
+              issue: "startLine cannot be posted without a line.",
+              path: "src/app.ts",
+              startLine: 10,
+            },
+          ],
+          verdict: "CHANGES_REQUESTED",
+        }),
+      ),
+    ).toThrow("findings[0].startLine requires line")
+  })
+
   test("rejects merge with requirement findings", () => {
     expect(() =>
       parseReviewOutput(
@@ -121,6 +165,32 @@ describe("review output", () => {
     })
   })
 
+  test("parses file-level rereview findings without a line", () => {
+    expect(
+      parseRereviewOutput(
+        JSON.stringify({
+          followUps: [],
+          newFindings: [
+            {
+              body: "The behavior is still incomplete.",
+              path: "src/orchestrator/merge.ts",
+            },
+          ],
+          resolve: [],
+          verdict: "CHANGES_REQUESTED",
+        }),
+      ),
+    ).toMatchObject({
+      newFindings: [
+        {
+          body: "The behavior is still incomplete.",
+          path: "src/orchestrator/merge.ts",
+        },
+      ],
+      verdict: "CHANGES_REQUESTED",
+    })
+  })
+
   test("parses finding validation votes", () => {
     expect(
       parseFindingValidationOutput(
@@ -148,6 +218,26 @@ describe("review output", () => {
       filesTouched: ["src/app.ts"],
       mode: "EDITED",
       responses: [{ action: "FIXED", body: "Fixed.", commentId: 1 }],
+    })
+  })
+
+  test("allows edited editor output without thread responses", () => {
+    expect(
+      parseEditOutput(
+        JSON.stringify({
+          commitMessage: "fix: handle body-only findings",
+          commitSha: "abcdef1234567890",
+          filesTouched: ["src/app.ts"],
+          mode: "EDITED",
+          responses: [],
+        }),
+      ),
+    ).toEqual({
+      commitMessage: "fix: handle body-only findings",
+      commitSha: "abcdef1234567890",
+      filesTouched: ["src/app.ts"],
+      mode: "EDITED",
+      responses: [],
     })
   })
 

--- a/src/prompts/output.ts
+++ b/src/prompts/output.ts
@@ -107,6 +107,21 @@ function requireNumber(value: unknown, path: string): number {
   return value
 }
 
+function optionalLine(value: unknown, path: string): number | undefined {
+  return value == null ? undefined : requireNumber(value, path)
+}
+
+function optionalStartLine(input: {
+  line: number | undefined
+  path: string
+  value: unknown
+}): number | undefined {
+  if (input.value == null) return undefined
+  if (input.line == null) throw new Error(`${input.path} requires line`)
+
+  return requireNumber(input.value, input.path)
+}
+
 function parseRequirementFindings(
   value: unknown,
 ): ReviewOutput["requirementFindings"] {
@@ -269,20 +284,22 @@ export function parseReviewOutput(text: string): ReviewOutput {
   const findings = requireArray(data.findings, "findings").map(
     (finding, index) => {
       const item = finding as Record<string, unknown>
+      const line = optionalLine(item.line, `findings[${index}].line`)
 
       return {
         fix: requireString(item.fix, `findings[${index}].fix`),
         issue: requireString(item.issue, `findings[${index}].issue`),
-        line: requireNumber(item.line, `findings[${index}].line`),
+        line,
         path: requireString(item.path, `findings[${index}].path`),
         perspective:
           item.perspective == null
             ? undefined
             : requireString(item.perspective, `findings[${index}].perspective`),
-        startLine:
-          item.startLine == null
-            ? undefined
-            : requireNumber(item.startLine, `findings[${index}].startLine`),
+        startLine: optionalStartLine({
+          line,
+          path: `findings[${index}].startLine`,
+          value: item.startLine,
+        }),
       }
     },
   )
@@ -356,15 +373,17 @@ export function parseRereviewOutput(text: string): RereviewOutput {
   const newFindings = requireArray(data.newFindings, "newFindings").map(
     (item, index) => {
       const value = item as Record<string, unknown>
+      const line = optionalLine(value.line, `newFindings[${index}].line`)
 
       return {
         body: requireString(value.body, `newFindings[${index}].body`),
-        line: requireNumber(value.line, `newFindings[${index}].line`),
+        line,
         path: requireString(value.path, `newFindings[${index}].path`),
-        startLine:
-          value.startLine == null
-            ? undefined
-            : requireNumber(value.startLine, `newFindings[${index}].startLine`),
+        startLine: optionalStartLine({
+          line,
+          path: `newFindings[${index}].startLine`,
+          value: value.startLine,
+        }),
       }
     },
   )
@@ -555,7 +574,7 @@ function parseEditOutputWithOptions(
     },
   )
 
-  if (options.requireResponses && !responses.length)
+  if (options.requireResponses && data.mode === "REPLIED" && !responses.length)
     throw new Error("responses must not be empty")
 
   if (data.mode === "EDITED") {

--- a/src/prompts/templates/merge/edit.md
+++ b/src/prompts/templates/merge/edit.md
@@ -1,9 +1,16 @@
 Fix pull request #{pr} for {owner}/{repo}.
 The PR worktree is {worktreePath}.
-Act as the PR author and resolve every unresolved review thread listed below.
+
+Act as the PR author and address every blocking review finding listed below.
+Review findings are the complete set of requested changes. Inline findings target a PR diff line; file-level findings may not have a GitHub thread; requirement findings describe missing closing-issue requirements.
+{reviewFindings}
+
+Unresolved GitHub review threads are conversations that may need replies or resolution.
 {unresolvedThreads}
-For each thread, decide whether you agree with the reviewer.
-If you understand and agree with the requested change, edit the code, stage changes, commit, and reply with action FIXED.
-If the requested change is incorrect or unnecessary and you have a clear reason, do not edit for that thread; reply with action DISAGREE and explain why.
-If you cannot determine whether the request is correct or what change is expected, do not blindly edit; reply with action ASK and ask a concrete question.
+
+For each review finding and thread, decide whether you agree with the reviewer.
+If you understand and agree with the requested change, edit the code, stage changes, commit, and reply with action FIXED for each related thread.
+If a requested change in a thread is incorrect or unnecessary and you have a clear reason, do not edit for that thread; reply with action DISAGREE and explain why.
+If you cannot determine whether a threaded request is correct or what change is expected, do not blindly edit; reply with action ASK and ask a concrete question.
+File-level and requirement findings may not have a thread to reply to, but they are still blocking and must be addressed.
 Do not make changes just because a reviewer requested them. Do not push.

--- a/src/types.ts
+++ b/src/types.ts
@@ -314,9 +314,16 @@ export interface ResolvedRepository extends RepositoryConfig {
 export interface Finding {
   fix: string
   issue: string
-  line: number
+  line?: number
   path: string
   perspective?: string
+  startLine?: number
+}
+
+export interface NewFinding {
+  body: string
+  line?: number
+  path: string
   startLine?: number
 }
 
@@ -336,12 +343,7 @@ export interface ReviewOutput {
 
 export interface RereviewOutput {
   followUps: { commentId: number; body: string }[]
-  newFindings: {
-    path: string
-    line: number
-    startLine?: number
-    body: string
-  }[]
+  newFindings: NewFinding[]
   reason?: string
   requirementFindings: RequirementFinding[]
   resolve: { commentId: number; threadId: string }[]
@@ -356,12 +358,7 @@ export interface CloseReconsiderationOutput {
 
 export interface RereviewCloseReconsiderationOutput {
   followUps: { commentId: number; body: string }[]
-  newFindings: {
-    path: string
-    line: number
-    startLine?: number
-    body: string
-  }[]
+  newFindings: NewFinding[]
   requirementFindings: RequirementFinding[]
   resolve: { commentId: number; threadId: string }[]
   verdict: Exclude<Verdict, "CLOSE">


### PR DESCRIPTION
Closes #121

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Allow review and rereview findings to omit inline diff line targets while preserving inline validation for findings that do specify a line.

## Current behavior (updates)

Review findings required a valid PR diff line, so valid file-level or body-only findings could be rejected or lost before the merge editor saw them.

## New behavior

Findings without a line are accepted as file-level findings, included in review bodies, omitted from inline comments, and passed to the merge editor as structured blocking findings alongside requirement findings and unresolved review threads.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tests: `pnpm test`