### PR TITLE
docs(commands): expand config key references

### DIFF
--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -36,7 +36,7 @@ During a single merge flow, Magi reuses reviewer OpenCode sessions from the init
 
 ## Flow
 
-1. Stop before agent execution when `review.safety.*` gates block the PR.
+1. Stop before agent execution when `review.safety.requiredLabels`, `review.safety.blockedPaths`, `review.safety.maxChangedFiles`, or `review.safety.allowAuthors` blocks the PR.
 2. Run the full [`/magi:review`](review.md) flow.
 3. If every configured reviewer already reviewed the current effective head, reuse those existing verdicts instead of aborting.
 4. If the review decision is `CLOSE`, close the PR when `merge.automation.close` is enabled and stop. Dry runs stop before closing.
@@ -107,9 +107,14 @@ Important settings for `/magi:merge`:
 | `merge.maxThreadResolutionCycles` | Maximum fix/reply attempts per unresolved review thread.           |
 | `review.merge.queue`              | Enqueue the PR through GitHub GraphQL and poll queue completion.   |
 | `review.merge.method`             | Merge method: `merge`, `squash`, or `rebase`.                      |
-| `merge.prompts.edit*`             | Editor prompt templates and guidelines.                            |
+| `merge.prompts.edit`              | Editor prompt template.                                            |
+| `merge.prompts.editGuidelines`    | Shared edit guidance file.                                         |
+| `merge.prompts.ciClassification`  | Post-edit failed-check classification prompt template.             |
 | `review.prompts.rereview`         | Re-review prompt template.                                         |
-| `review.safety.*`                 | Optional gates that block merge before agents run.                 |
+| `review.safety.requiredLabels`    | Required PR labels before merge flow.                              |
+| `review.safety.blockedPaths`      | Changed-file glob patterns that block merge flow.                  |
+| `review.safety.maxChangedFiles`   | Maximum changed file count before merge flow is blocked.           |
+| `review.safety.allowAuthors`      | Allowed PR authors when configured.                                |
 
 See [Config](/docs/config.md) for the complete configuration reference.
 

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -36,7 +36,7 @@ It skips reviewer accounts that already reviewed the current effective head. If 
 
 1. Fetch PR metadata with `gh pr view`.
 2. Abort if the PR is a draft.
-3. Stop before agent execution when `review.safety.*` gates block the PR.
+3. Stop before agent execution when `review.safety.requiredLabels`, `review.safety.blockedPaths`, `review.safety.maxChangedFiles`, or `review.safety.allowAuthors` blocks the PR.
 4. Fetch existing PR reviews for configured `review.agents[].account` values.
 5. Determine review freshness against the latest non-merge PR commit.
 6. Skip current reviewers, use re-review mode for stale reviewers, and use initial review mode for reviewers with no prior review.
@@ -84,20 +84,28 @@ Review artifacts are written to the run output directory:
 
 Important settings for `/magi:review`:
 
-| Setting                         | Purpose                                                       |
-| ------------------------------- | ------------------------------------------------------------- |
-| `review.agents`                 | Reviewer agents, models, personas, permissions, and accounts. |
-| `review.checks.wait`            | Wait for PR checks before review.                             |
-| `review.checks.exclude`         | Ignore matching failed checks.                                |
-| `review.checks.retryFailedJobs` | Retry scope-outside GitHub Actions jobs.                      |
-| `review.concurrency.reviewers`  | Maximum reviewer agents running at once.                      |
-| `review.concurrency.runs`       | Maximum PR runs processed at once.                            |
-| `github.apiRetryAttempts`       | Retry count for GitHub CLI API rate limit errors.             |
-| `review.output`                 | PR run output directory.                                      |
-| `output.repairAttempts`         | Model output repair attempts.                                 |
-| `review.prompts.*`              | Review prompt templates and guidelines.                       |
-| `review.safety.*`               | Optional gates that block review before agents run.           |
-| `review.worktree`               | Temporary PR worktree base directory.                         |
+| Setting                               | Purpose                                                       |
+| ------------------------------------- | ------------------------------------------------------------- |
+| `review.agents`                       | Reviewer agents, models, personas, permissions, and accounts. |
+| `review.checks.wait`                  | Wait for PR checks before review.                             |
+| `review.checks.exclude`               | Ignore matching failed checks.                                |
+| `review.checks.retryFailedJobs`       | Retry scope-outside GitHub Actions jobs.                      |
+| `review.concurrency.reviewers`        | Maximum reviewer agents running at once.                      |
+| `review.concurrency.runs`             | Maximum PR runs processed at once.                            |
+| `github.apiRetryAttempts`             | Retry count for GitHub CLI API rate limit errors.             |
+| `review.output`                       | PR run output directory.                                      |
+| `output.repairAttempts`               | Model output repair attempts.                                 |
+| `review.prompts.review`               | Initial review prompt template.                               |
+| `review.prompts.rereview`             | Re-review prompt template.                                    |
+| `review.prompts.reviewGuidelines`     | Shared review guidance file.                                  |
+| `review.prompts.ciClassification`     | Failed-check classification prompt template.                  |
+| `review.prompts.findingValidation`    | Finding validation prompt template.                           |
+| `review.prompts.closeReconsideration` | Close reconsideration prompt template.                        |
+| `review.safety.requiredLabels`        | Required PR labels before review.                             |
+| `review.safety.blockedPaths`          | Changed-file glob patterns that block review.                 |
+| `review.safety.maxChangedFiles`       | Maximum changed file count before review is blocked.          |
+| `review.safety.allowAuthors`          | Allowed PR authors when configured.                           |
+| `review.worktree`                     | Temporary PR worktree base directory.                         |
 
 See [Config](/docs/config.md) for the complete configuration reference.
 

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -81,22 +81,36 @@ Triage artifacts are written to the issue run output directory:
 
 Important settings:
 
-| Setting                    | Purpose                                                                                               |
-| -------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `triage.account`           | GitHub account used for triage comments and mutations.                                                |
-| `triage.agents`            | Dedicated issue triage voting agents.                                                                 |
-| `triage.creator`           | Agent used for implementation PR creation when enabled.                                               |
-| `triage.categories`        | Category IDs and label/type rules that can skip Category Vote. Type rules require GitHub issue types. |
-| `triage.automation.close`  | Enables closing rejected or duplicate issues.                                                         |
-| `triage.automation.create` | Enables implementation PR creation for accepted issues.                                               |
-| `triage.automation.review` | Starts `/magi:review` after implementation PR creation. Requires `triage.automation.create`.          |
-| `triage.automation.merge`  | Starts `/magi:merge` after implementation PR creation. Requires `triage.automation.create`.           |
-| `triage.automation.clear`  | Labels removed for non-ASK results.                                                                   |
-| `triage.safety.*`          | Gates for initial triage and reconsideration.                                                         |
-| `triage.prompts.*`         | Triage prompt templates and PR creation guidelines.                                                   |
-| `triage.concurrency.runs`  | Maximum issues processed concurrently.                                                                |
-| `triage.output`            | Issue triage artifact directory.                                                                      |
-| `triage.worktree`          | Worktree directory for validation and PR creation.                                                    |
+| Setting                                | Purpose                                                                                               |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `triage.account`                       | GitHub account used for triage comments and mutations.                                                |
+| `triage.agents`                        | Dedicated issue triage voting agents.                                                                 |
+| `triage.creator`                       | Agent used for implementation PR creation when enabled.                                               |
+| `triage.categories`                    | Category IDs and label/type rules that can skip Category Vote. Type rules require GitHub issue types. |
+| `triage.automation.close`              | Enables closing rejected or duplicate issues.                                                         |
+| `triage.automation.create`             | Enables implementation PR creation for accepted issues.                                               |
+| `triage.automation.review`             | Starts `/magi:review` after implementation PR creation. Requires `triage.automation.create`.          |
+| `triage.automation.merge`              | Starts `/magi:merge` after implementation PR creation. Requires `triage.automation.create`.           |
+| `triage.automation.clear`              | Labels removed for non-ASK results.                                                                   |
+| `triage.safety.requiredLabels`         | Labels required before initial triage runs.                                                           |
+| `triage.safety.blockedLabels`          | Labels that prevent triage from running.                                                              |
+| `triage.safety.allowAuthors`           | Allowed issue authors when configured.                                                                |
+| `triage.safety.allowMentionActors`     | GitHub logins allowed to trigger reconsideration.                                                     |
+| `triage.safety.allowMentionRoles`      | GitHub author associations allowed to trigger reconsideration.                                        |
+| `triage.prompts.existingPr`            | Related-PR voting prompt template.                                                                    |
+| `triage.prompts.duplicate`             | Duplicate issue voting prompt template.                                                               |
+| `triage.prompts.category`              | Category voting prompt template.                                                                      |
+| `triage.prompts.acceptance`            | Acceptance voting prompt template.                                                                    |
+| `triage.prompts.action`                | Final action planning prompt template.                                                                |
+| `triage.prompts.question`              | Clarification question prompt template.                                                               |
+| `triage.prompts.comment`               | Triage result comment prompt template.                                                                |
+| `triage.prompts.commentClassification` | Mention reply classification prompt template.                                                         |
+| `triage.prompts.reconsider`            | Reconsideration prompt template.                                                                      |
+| `triage.prompts.create`                | Implementation PR creation prompt template.                                                           |
+| `triage.prompts.createGuidelines`      | Shared PR creation guidance file.                                                                     |
+| `triage.concurrency.runs`              | Maximum issues processed concurrently.                                                                |
+| `triage.output`                        | Issue triage artifact directory.                                                                      |
+| `triage.worktree`                      | Worktree directory for validation and PR creation.                                                    |
 
 See [Config](/docs/config.md) for the complete reference.
 


### PR DESCRIPTION
Closes #123

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Expands wildcard configuration references in the review, merge, and triage command documentation to list the concrete config keys documented in `docs/config.md`.

## Current behavior (updates)

Command docs used wildcard entries such as `review.prompts.*`, `merge.prompts.edit*`, `triage.prompts.*`, and safety wildcard references.

## New behavior

Command docs now list the concrete prompt and safety keys for review, merge, and triage configuration.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change; no runtime tests were run.