### PR TITLE
test(tests): remove redundant negative assertions

### DIFF
--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -25,8 +25,5 @@ describe("Magi slash commands", () => {
     expect(MAGI_COMMANDS["magi:triage"].template).toBe(
       "Call the `magi_triage` tool.\nIssue: $ARGUMENTS",
     )
-    expect(MAGI_COMMANDS["magi:review"].template).not.toContain("If")
-    expect(MAGI_COMMANDS["magi:review"].template).not.toContain("with")
-    expect(MAGI_COMMANDS["magi:review"].template).not.toContain("``")
   })
 })

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -394,8 +394,6 @@ describe("GitHub command helpers", () => {
     expect(commands[2]).toContain("enqueuePullRequest")
     expect(commands[2]).toContain("pullRequestId='PR_node_id'")
     expect(commands[2]).toContain("expectedHeadOid='head-sha'")
-    expect(commands[2]).not.toContain("gh pr merge")
-    expect(commands[2]).not.toContain("--delete-branch")
     expect(options[1]?.env?.GH_TOKEN).toBe("token")
     expect(options[2]?.env?.GH_TOKEN).toBe("token")
   })
@@ -530,7 +528,6 @@ describe("GitHub command helpers", () => {
       "https://github.com/owner/repo/pull/7557#pullrequestreview-1",
     )
     expect(commands[1]).toContain("repos/owner/repo/pulls/7557/reviews")
-    expect(commands[1]).not.toContain("repos/owner/repo/issues/7557/comments")
     expect(commands[1]).not.toContain("GH_TOKEN")
     expect(options[1]?.env?.GH_TOKEN).toBe("token")
     expect(payload).toEqual({
@@ -649,7 +646,6 @@ describe("GitHub command helpers", () => {
     )
 
     expect(graphqlCommand).toContain("pullRequest(number: $pr)")
-    expect(graphqlCommand).not.toContain("issue(number:")
     expectBalancedBraces(extractGraphqlQuery(graphqlCommand))
     expect(result).toEqual([
       {

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -532,7 +532,6 @@ describe("triage orchestration", () => {
     )
     expect(visibleComment).not.toContain("bug")
     expect(visibleComment).not.toContain("feature")
-    expect(visibleComment).not.toContain("Magi")
   })
 
   test("blocks unsafe issues before model classification", async () => {
@@ -732,7 +731,6 @@ describe("triage orchestration", () => {
     expect(assignIndex).toBeGreaterThan(-1)
     expect(assignIndex).toBeLessThan(worktreeIndex)
     expect(assignIndex).toBeLessThan(prIndex)
-    expect(result.commands[prIndex]).not.toContain("--add-assignee")
     expect(result.commands[prIndex]).toContain(
       "--title 'fix(triage): use creator PR metadata'",
     )

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -125,7 +125,6 @@ describe("prompt composer", () => {
     expect(prompt).toContain(
       "<pull_request_context>\nnumber: 1\n</pull_request_context>",
     )
-    expect(prompt).not.toContain("Review pull request #1")
     expect(prompt.indexOf("Custom review for #1")).toBeLessThan(
       prompt.indexOf("<pull_request_context>"),
     )
@@ -290,7 +289,6 @@ describe("prompt composer", () => {
     expect(rereviewCloseReconsiderationPrompt).not.toContain("<persona>")
     expect(rereviewCloseReconsiderationPrompt).not.toContain("/tmp/worktree")
     expect(rereviewCloseReconsiderationPrompt).not.toContain("git -C")
-    expect(rereviewCloseReconsiderationPrompt).not.toContain("[]")
 
     const firstSessionRereviewCloseReconsiderationPrompt =
       await composeRereviewCloseReconsiderationPrompt({
@@ -382,7 +380,6 @@ describe("prompt composer", () => {
 
     expect(prompt).toContain("Treat Vercel deploy failures as SCOPE_OUT.")
     expect(prompt).toContain('"evidence"')
-    expect(prompt).not.toContain('"log"')
     expect(prompt.indexOf("Treat Vercel")).toBeLessThan(
       prompt.indexOf("<output_contract>"),
     )

--- a/src/prompts/contracts.test.ts
+++ b/src/prompts/contracts.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, test } from "vitest"
 import { repairPrompt } from "./contracts"
 
 describe("repairPrompt", () => {
-  test("resends the output contract without previous output", () => {
-    const previousOutput = "Let me analyze the PR diff. ```json"
+  test("resends the output contract", () => {
     const prompt = repairPrompt("review")
 
     expect(prompt).toContain(
@@ -16,7 +15,5 @@ describe("repairPrompt", () => {
     expect(prompt).toContain(
       "Do not include analysis, explanation, apologies, markdown, or any text before or after the JSON object.",
     )
-    expect(prompt).not.toContain("Previous output")
-    expect(prompt).not.toContain(previousOutput)
   })
 })


### PR DESCRIPTION
Closes #128

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Remove redundant negative test assertions that only checked legacy wording or old implementation details already covered by positive assertions.

## Current behavior (updates)

Several tests included `.not` assertions for obsolete prompt strings, command fragments, or old endpoints in addition to positive assertions for the intended behavior.

## New behavior

The tests now keep the positive behavioral assertions and retain negative assertions that protect explicit behavior contracts such as security-sensitive token handling and filtering.

## Is this a breaking change (Yes/No):

No

## Additional Information

Targeted tests passed: `pnpm vitest run src/prompts/compose.test.ts src/prompts/contracts.test.ts src/commands.test.ts src/github/commands.test.ts src/orchestrator/triage.test.ts`.