### PR TITLE
feat(config): support reusable agent refs

### DIFF
--- a/.changeset/curvy-suns-melt.md
+++ b/.changeset/curvy-suns-melt.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Add reusable agents.refs presets for Magi agent configuration.

--- a/schema.json
+++ b/schema.json
@@ -9,7 +9,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "permissions": { "$ref": "#/$defs/permissions" }
+        "permissions": { "$ref": "#/$defs/permissions" },
+        "refs": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/agentRef" }
+        }
       }
     },
     "clear": {
@@ -51,11 +55,33 @@
     "triage": { "$ref": "#/$defs/triage" }
   },
   "$defs": {
-    "reviewer": {
+    "agentRef": {
       "type": "object",
-      "required": ["model", "account"],
       "additionalProperties": false,
       "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "model": { "type": "string", "minLength": 1 },
+        "options": { "type": "object", "additionalProperties": true },
+        "account": { "type": "string", "minLength": 1 },
+        "author": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "email": { "type": "string", "minLength": 1 }
+          }
+        },
+        "permissions": { "$ref": "#/$defs/permissions" },
+        "persona": { "type": "string" }
+      }
+    },
+    "reviewer": {
+      "type": "object",
+      "if": { "not": { "required": ["ref"] } },
+      "then": { "required": ["model", "account"] },
+      "additionalProperties": false,
+      "properties": {
+        "ref": { "type": "string", "minLength": 1 },
         "id": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
         "model": { "type": "string", "minLength": 1 },
         "options": { "type": "object", "additionalProperties": true },
@@ -66,9 +92,11 @@
     },
     "editor": {
       "type": "object",
-      "required": ["model", "account", "author"],
+      "if": { "not": { "required": ["ref"] } },
+      "then": { "required": ["model", "account", "author"] },
       "additionalProperties": false,
       "properties": {
+        "ref": { "type": "string", "minLength": 1 },
         "model": { "type": "string", "minLength": 1 },
         "options": { "type": "object", "additionalProperties": true },
         "account": { "type": "string", "minLength": 1 },
@@ -87,9 +115,11 @@
     },
     "triageAgent": {
       "type": "object",
-      "required": ["model"],
+      "if": { "not": { "required": ["ref"] } },
+      "then": { "required": ["model"] },
       "additionalProperties": false,
       "properties": {
+        "ref": { "type": "string", "minLength": 1 },
         "id": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
         "model": { "type": "string", "minLength": 1 },
         "options": { "type": "object", "additionalProperties": true },
@@ -99,9 +129,11 @@
     },
     "triageCreator": {
       "type": "object",
-      "required": ["model", "author"],
+      "if": { "not": { "required": ["ref"] } },
+      "then": { "required": ["model", "author"] },
       "additionalProperties": false,
       "properties": {
+        "ref": { "type": "string", "minLength": 1 },
         "account": { "type": "string", "minLength": 1 },
         "model": { "type": "string", "minLength": 1 },
         "options": { "type": "object", "additionalProperties": true },

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, test } from "vitest"
+import { resolveRepository } from "./resolve"
 import { validateConfig } from "./validate"
 
 const config: MagiConfig = {
@@ -39,6 +40,156 @@ describe("validateConfig", () => {
 
     expect(result.ok).toBe(true)
     expect(result.errors).toEqual([])
+  })
+
+  test("expands agent refs before validation and resolution", async () => {
+    const refConfig = {
+      agents: {
+        refs: {
+          shared: {
+            model: "openai/gpt",
+            options: { reasoningEffort: "high" },
+            persona: "Shared persona",
+          },
+          editor: {
+            model: "openai/gpt",
+            account: "editor-bot",
+            author: { email: "editor@example.com", name: "Editor Bot" },
+          },
+        },
+      },
+      github: { owner: "owner", repo: "repo" },
+      review: {
+        agents: [
+          { ref: "shared", id: "alpha", account: "bot-a" },
+          {
+            ref: "shared",
+            id: "beta",
+            account: "bot-b",
+            options: { reasoningEffort: "low" },
+          },
+          { ref: "shared", id: "gamma", account: "bot-c" },
+        ],
+      },
+      merge: {
+        editor: { ref: "editor", persona: "Edit carefully" },
+      },
+      triage: {
+        account: "triage-bot",
+        agents: [
+          { ref: "shared", id: "first" },
+          { ref: "shared", id: "second" },
+          { ref: "shared", id: "third" },
+        ],
+        creator: { ref: "editor", account: "creator-bot" },
+      },
+    } as unknown as MagiConfig
+
+    const result = await validateConfig(refConfig, {
+      requireTriage: true,
+    })
+    const repository = resolveRepository(refConfig)
+
+    expect(result).toMatchObject({ errors: [], ok: true })
+    expect(refConfig.agents?.refs).toBeUndefined()
+    expect(refConfig.review?.agents?.[0]).toEqual({
+      account: "bot-a",
+      id: "alpha",
+      model: "openai/gpt",
+      options: { reasoningEffort: "high" },
+      persona: "Shared persona",
+    })
+    expect(refConfig.review?.agents?.[1].options).toEqual({
+      reasoningEffort: "low",
+    })
+    expect(refConfig.review?.agents?.[0]).not.toHaveProperty("ref")
+    expect(repository.agents.reviewers[0]).toMatchObject({
+      account: "bot-a",
+      key: "alpha",
+      model: "openai/gpt",
+    })
+    expect(repository.agents.editor).toMatchObject({
+      account: "editor-bot",
+      model: "openai/gpt",
+      persona: "Edit carefully",
+    })
+    expect(repository.agents.triageCreator).toMatchObject({
+      account: "creator-bot",
+      model: "openai/gpt",
+    })
+  })
+
+  test("reports clear errors for invalid agent ref uses", async () => {
+    const refConfig = {
+      agents: { refs: { shared: { model: "openai/gpt" } } },
+      github: { owner: "owner", repo: "repo" },
+      review: {
+        agents: [
+          { ref: "missing", account: "bot-a" },
+          { ref: 1, account: "bot-b" },
+          { ref: "shared", account: "bot-c" },
+        ],
+      },
+    } as unknown as MagiConfig
+
+    const result = await validateConfig(refConfig)
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain(
+      "review.agents[0].ref references unknown agents.refs preset: missing",
+    )
+    expect(result.errors).toContain("review.agents[1].ref must be a string")
+    expect(refConfig.agents?.refs).toBeUndefined()
+    expect(refConfig.review?.agents?.[0]).not.toHaveProperty("ref")
+  })
+
+  test("does not validate unused agent refs", async () => {
+    const refConfig = {
+      agents: {
+        refs: {
+          unused: { author: "invalid", unknown: true },
+        },
+      },
+      github: { owner: "owner", repo: "repo" },
+      review: {
+        agents: [
+          { model: "openai/gpt", account: "bot-a" },
+          { model: "openai/gpt", account: "bot-b" },
+          { model: "openai/gpt", account: "bot-c" },
+        ],
+      },
+    } as unknown as MagiConfig
+
+    const result = await validateConfig(refConfig)
+
+    expect(result).toMatchObject({ errors: [], ok: true })
+    expect(refConfig.agents?.refs).toBeUndefined()
+  })
+
+  test("applies role-specific validation after agent ref expansion", async () => {
+    const refConfig = {
+      agents: {
+        refs: {
+          creator: {
+            model: "openai/gpt",
+            author: { email: "creator@example.com", name: "Creator Bot" },
+          },
+        },
+      },
+      github: { owner: "owner", repo: "repo" },
+      review: {
+        agents: [
+          { ref: "creator", account: "bot-a" },
+          { model: "openai/gpt", account: "bot-b" },
+          { model: "openai/gpt", account: "bot-c" },
+        ],
+      },
+    } as unknown as MagiConfig
+
+    const result = await validateConfig(refConfig)
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain("review.agents[0].author is not supported")
   })
 
   test("allows missing editor unless merge validation requires it", async () => {

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -182,6 +182,8 @@ const TRIAGE_PROMPT_KEYS = new Set([
   "reconsider",
 ])
 
+type AgentRefUse = Record<string, unknown> & { ref?: unknown }
+
 function githubHost(config: MagiConfig): string {
   return config.github?.host ?? "github.com"
 }
@@ -194,6 +196,104 @@ function ghHostOption(config: MagiConfig): string {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function expandAgentRefUse(
+  value: unknown,
+  path: string,
+  refs: Record<string, unknown> | undefined,
+  refsInvalid: boolean,
+  errors: string[],
+): unknown {
+  if (!isPlainObject(value) || !Object.hasOwn(value, "ref")) return value
+
+  const use = { ...(value as AgentRefUse) }
+  const ref = use.ref
+  delete use.ref
+
+  if (typeof ref !== "string") {
+    errors.push(`${path}.ref must be a string`)
+    return use
+  }
+
+  if (refsInvalid) {
+    errors.push(`agents.refs must be an object to resolve ${path}.ref`)
+    return use
+  }
+
+  const preset = refs?.[ref]
+  if (preset == null) {
+    errors.push(`${path}.ref references unknown agents.refs preset: ${ref}`)
+    return use
+  }
+
+  if (!isPlainObject(preset)) {
+    errors.push(
+      `agents.refs.${ref} must be an object when referenced by ${path}.ref`,
+    )
+    return use
+  }
+
+  const presetFields = { ...(preset as AgentRefUse) }
+  delete presetFields.ref
+
+  return { ...presetFields, ...use }
+}
+
+function expandAgentRefs(config: MagiConfig, errors: string[]): void {
+  if (!config || typeof config !== "object") return
+
+  const magiConfig = config as MagiConfig
+  const agents = magiConfig.agents
+  const refsValue = isPlainObject(agents) ? agents.refs : undefined
+  const refsInvalid = refsValue != null && !isPlainObject(refsValue)
+  const refs = isPlainObject(refsValue) ? refsValue : undefined
+
+  if (Array.isArray(magiConfig.review?.agents)) {
+    magiConfig.review.agents = magiConfig.review.agents.map((agent, index) =>
+      expandAgentRefUse(
+        agent,
+        `review.agents[${index}]`,
+        refs,
+        refsInvalid,
+        errors,
+      ),
+    ) as ReviewerConfig[]
+  }
+
+  if (isPlainObject(magiConfig.merge?.editor)) {
+    magiConfig.merge.editor = expandAgentRefUse(
+      magiConfig.merge.editor,
+      "merge.editor",
+      refs,
+      refsInvalid,
+      errors,
+    ) as EditorConfig
+  }
+
+  if (Array.isArray(magiConfig.triage?.agents)) {
+    magiConfig.triage.agents = magiConfig.triage.agents.map((agent, index) =>
+      expandAgentRefUse(
+        agent,
+        `triage.agents[${index}]`,
+        refs,
+        refsInvalid,
+        errors,
+      ),
+    ) as TriageAgentConfig[]
+  }
+
+  if (isPlainObject(magiConfig.triage?.creator)) {
+    magiConfig.triage.creator = expandAgentRefUse(
+      magiConfig.triage.creator,
+      "triage.creator",
+      refs,
+      refsInvalid,
+      errors,
+    ) as TriageCreatorConfig
+  }
+
+  if (isPlainObject(magiConfig.agents)) delete magiConfig.agents.refs
 }
 
 function validateKnownKeys(
@@ -1165,6 +1265,8 @@ export async function validateConfig(
 
   if (!config || typeof config !== "object")
     errors.push("config must be an object")
+
+  expandAgentRefs(config, errors)
 
   if (config && typeof config === "object") validateJsonSchema(config, errors)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface ReviewerConfig {
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
+  ref?: string
 }
 
 export interface EditorConfig {
@@ -37,6 +38,7 @@ export interface EditorConfig {
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
+  ref?: string
 }
 
 export interface TriageAgentConfig {
@@ -45,6 +47,7 @@ export interface TriageAgentConfig {
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
+  ref?: string
 }
 
 export interface TriageCreatorConfig {
@@ -57,10 +60,25 @@ export interface TriageCreatorConfig {
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
+  ref?: string
+}
+
+export interface AgentRefConfig {
+  account?: string
+  author?: {
+    email?: string
+    name?: string
+  }
+  id?: string
+  model?: string
+  options?: ModelOptions
+  permissions?: PermissionConfig
+  persona?: string
 }
 
 export interface AgentsConfig {
   permissions?: PermissionConfig
+  refs?: Record<string, AgentRefConfig>
 }
 
 export interface GitHubRepoConfig {


### PR DESCRIPTION
Closes #127

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add reusable `agents.refs` presets that can be expanded into review agents, merge editors, triage agents, and triage creators before normal config validation.

## Current behavior (updates)

Agent fields such as `model`, `options`, `persona`, `account`, and `author` must be repeated in each role-specific config entry.

## New behavior

Config validation now expands role entries with `ref` from `agents.refs`, applies inline field overrides, removes `ref` and `agents.refs` from the effective config, and then runs existing schema and role-specific validation. Unknown or non-string refs report clear validation errors, and unused presets are not validated.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/config/validate.test.ts src/config/resolve.test.ts src/config/load.test.ts`.