### PR TITLE
test(orchestrator): consolidate repetitive cases

### DIFF
--- a/src/orchestrator/ci.test.ts
+++ b/src/orchestrator/ci.test.ts
@@ -44,6 +44,55 @@ function reviewer(
   }
 }
 
+function check(
+  overrides: Partial<{
+    bucket: string
+    link: string
+    name: string
+    state: string
+    workflow: string
+  }> = {},
+) {
+  return {
+    bucket: "fail",
+    link: "https://github.com/owner/repo/actions/runs/1/job/123",
+    name: "Test",
+    state: "FAILURE",
+    workflow: "CI",
+    ...overrides,
+  }
+}
+
+function classifierClient(input: {
+  classification: "SCOPE_IN" | "SCOPE_OUT"
+  reason: string
+}) {
+  return {
+    session: {
+      create: async () => ({ id: "session" }),
+      prompt: async () => ({
+        info: {
+          text: JSON.stringify({
+            checks: [
+              {
+                classification: input.classification,
+                name: "Test",
+                reason: input.reason,
+              },
+            ],
+          }),
+        },
+      }),
+    },
+  }
+}
+
+function expectNoRunRerun(commands: string[]) {
+  expect(commands.some((command) => command.includes("gh run rerun"))).toBe(
+    false,
+  )
+}
+
 describe("check handling", () => {
   test("extracts structured evidence from repeated failure logs", () => {
     const evidence = extractFailureEvidence(
@@ -127,35 +176,13 @@ describe("check handling", () => {
     let watches = 0
     let jsonCalls = 0
     const commands: string[] = []
-    const failed = [
-      {
-        bucket: "fail",
-        link: "https://github.com/owner/repo/actions/runs/1/job/123",
-        name: "Test",
-        state: "FAILURE",
-        workflow: "CI",
-      },
-    ]
+    const failed = [check()]
 
     const result = await waitForChecksWithClassification({
-      client: {
-        session: {
-          create: async () => ({ id: "session" }),
-          prompt: async () => ({
-            info: {
-              text: JSON.stringify({
-                checks: [
-                  {
-                    classification: "SCOPE_OUT",
-                    name: "Test",
-                    reason: "Flaky browser test.",
-                  },
-                ],
-              }),
-            },
-          }),
-        },
-      },
+      client: classifierClient({
+        classification: "SCOPE_OUT",
+        reason: "Flaky browser test.",
+      }),
       directory: ".",
       exec: async (command) => {
         commands.push(command)
@@ -198,35 +225,13 @@ describe("check handling", () => {
 
   test("does not rerun scope-out jobs during dry runs", async () => {
     const commands: string[] = []
-    const failed = [
-      {
-        bucket: "fail",
-        link: "https://github.com/owner/repo/actions/runs/1/job/123",
-        name: "Test",
-        state: "FAILURE",
-        workflow: "CI",
-      },
-    ]
+    const failed = [check()]
 
     const result = await waitForChecksWithClassification({
-      client: {
-        session: {
-          create: async () => ({ id: "session" }),
-          prompt: async () => ({
-            info: {
-              text: JSON.stringify({
-                checks: [
-                  {
-                    classification: "SCOPE_OUT",
-                    name: "Test",
-                    reason: "Flaky browser test.",
-                  },
-                ],
-              }),
-            },
-          }),
-        },
-      },
+      client: classifierClient({
+        classification: "SCOPE_OUT",
+        reason: "Flaky browser test.",
+      }),
       directory: ".",
       dryRun: true,
       exec: async (command) => {
@@ -249,9 +254,7 @@ describe("check handling", () => {
     expect(result?.report.dryRunRerun).toMatchObject([
       { check: failed[0], classification: "SCOPE_OUT" },
     ])
-    expect(commands.some((command) => command.includes("gh run rerun"))).toBe(
-      false,
-    )
+    expectNoRunRerun(commands)
   })
 
   test("does not report failed CI investigation while checks are pending", async () => {
@@ -302,35 +305,13 @@ describe("check handling", () => {
 
   test("classifies existing failures without waiting when wait is false", async () => {
     const commands: string[] = []
-    const failed = [
-      {
-        bucket: "fail",
-        link: "https://github.com/owner/repo/actions/runs/1/job/123",
-        name: "Test",
-        state: "FAILURE",
-        workflow: "CI",
-      },
-    ]
+    const failed = [check()]
 
     const result = await waitForChecksWithClassification({
-      client: {
-        session: {
-          create: async () => ({ id: "session" }),
-          prompt: async () => ({
-            info: {
-              text: JSON.stringify({
-                checks: [
-                  {
-                    classification: "SCOPE_IN",
-                    name: "Test",
-                    reason: "Type error in changed package.",
-                  },
-                ],
-              }),
-            },
-          }),
-        },
-      },
+      client: classifierClient({
+        classification: "SCOPE_IN",
+        reason: "Type error in changed package.",
+      }),
       directory: ".",
       exec: async (command) => {
         commands.push(command)
@@ -534,15 +515,7 @@ describe("check handling", () => {
     let jsonCalls = 0
     let promptCount = 0
     const commands: string[] = []
-    const cancelled = [
-      {
-        bucket: "cancel",
-        link: "https://github.com/owner/repo/actions/runs/1/job/123",
-        name: "Test",
-        state: "CANCELLED",
-        workflow: "CI",
-      },
-    ]
+    const cancelled = [check({ bucket: "cancel", state: "CANCELLED" })]
 
     const result = await waitForChecksWithClassification({
       client: {
@@ -592,13 +565,13 @@ describe("check handling", () => {
   test("leaves non-rerunnable cancelled checks unresolved", async () => {
     const commands: string[] = []
     const cancelled = [
-      {
+      check({
         bucket: "cancel",
         link: "https://example.com/check",
         name: "External Check",
         state: "CANCELLED",
         workflow: "",
-      },
+      }),
     ]
 
     const result = await waitForChecksWithClassification({
@@ -628,42 +601,18 @@ describe("check handling", () => {
     expect(result?.report.scopeOutsideUnresolved).toMatchObject([
       { check: cancelled[0], classification: "SCOPE_OUT" },
     ])
-    expect(commands.some((command) => command.includes("gh run rerun"))).toBe(
-      false,
-    )
+    expectNoRunRerun(commands)
   })
 
   test("returns scope-in failure context without rerunning", async () => {
     const commands: string[] = []
-    const failed = [
-      {
-        bucket: "fail",
-        link: "https://github.com/owner/repo/actions/runs/1/job/123",
-        name: "Test",
-        state: "FAILURE",
-        workflow: "CI",
-      },
-    ]
+    const failed = [check()]
 
     const result = await waitForChecksWithClassification({
-      client: {
-        session: {
-          create: async () => ({ id: "session" }),
-          prompt: async () => ({
-            info: {
-              text: JSON.stringify({
-                checks: [
-                  {
-                    classification: "SCOPE_IN",
-                    name: "Test",
-                    reason: "Type error in changed package.",
-                  },
-                ],
-              }),
-            },
-          }),
-        },
-      },
+      client: classifierClient({
+        classification: "SCOPE_IN",
+        reason: "Type error in changed package.",
+      }),
       directory: ".",
       exec: async (command) => {
         commands.push(command)
@@ -689,9 +638,7 @@ describe("check handling", () => {
       { check: failed[0], classification: "SCOPE_IN" },
     ])
     expect(result?.ciFailureContext).toContain("Type error")
-    expect(commands.some((command) => command.includes("gh run rerun"))).toBe(
-      false,
-    )
+    expectNoRunRerun(commands)
   })
 
   test("classifies CI scope by reviewer majority", async () => {

--- a/src/orchestrator/inline-comments.test.ts
+++ b/src/orchestrator/inline-comments.test.ts
@@ -38,37 +38,30 @@ describe("inline comment targets", () => {
     ).not.toThrow()
   })
 
-  test("rejects wildcard paths that are not concrete PR diff files", () => {
-    const targets = parseRightSideDiffTargets(diff)
+  for (const { context, expected, targets: comments, title } of [
+    {
+      expected: "path is not in the PR diff",
+      targets: [{ line: 1, path: ".changeset/*.md" }],
+      title: "rejects wildcard paths that are not concrete PR diff files",
+    },
+    {
+      expected: "line is not in a right-side PR diff hunk",
+      targets: [{ line: 100, path: "src/app.ts" }],
+      title: "rejects changed files when the line is outside right-side hunks",
+    },
+    {
+      context: "newFindings",
+      expected: "newFindings[0] targets src/app.ts:12",
+      targets: [{ line: 12, path: "src/app.ts", startLine: 10 }],
+      title: "rejects multi-line comments that span outside right-side hunks",
+    },
+  ]) {
+    test(title, () => {
+      const diffTargets = parseRightSideDiffTargets(diff)
 
-    expect(() =>
-      validateInlineCommentTargets(
-        [{ line: 1, path: ".changeset/*.md" }],
-        targets,
-      ),
-    ).toThrow("path is not in the PR diff")
-  })
-
-  test("rejects changed files when the line is outside right-side hunks", () => {
-    const targets = parseRightSideDiffTargets(diff)
-
-    expect(() =>
-      validateInlineCommentTargets(
-        [{ line: 100, path: "src/app.ts" }],
-        targets,
-      ),
-    ).toThrow("line is not in a right-side PR diff hunk")
-  })
-
-  test("rejects multi-line comments that span outside right-side hunks", () => {
-    const targets = parseRightSideDiffTargets(diff)
-
-    expect(() =>
-      validateInlineCommentTargets(
-        [{ line: 12, path: "src/app.ts", startLine: 10 }],
-        targets,
-        "newFindings",
-      ),
-    ).toThrow("newFindings[0] targets src/app.ts:12")
-  })
+      expect(() =>
+        validateInlineCommentTargets(comments, diffTargets, context),
+      ).toThrow(expected)
+    })
+  }
 })

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -17,21 +17,74 @@ function review(account: string, commit: string, submittedAt: string) {
   } satisfies PullRequestReview
 }
 
-describe("review flow", () => {
-  test("uses initial review when no configured account reviewed", () => {
-    const mode = resolveReviewMode([], accounts, {
-      headSha: "head",
-      type: "head",
-    })
+function expectActiveAssignments(
+  mode: ReturnType<typeof resolveReviewMode>,
+  assignments: string[],
+) {
+  expect(mode.type).toBe("active")
+  if (mode.type !== "active") throw new Error("expected active mode")
+  expect([...mode.assignments.values()].map((item) => item.type)).toEqual(
+    assignments,
+  )
+}
 
-    expect(mode.type).toBe("active")
-    if (mode.type !== "active") throw new Error("expected active mode")
-    expect([...mode.assignments.values()].map((item) => item.type)).toEqual([
-      "initial",
-      "initial",
-      "initial",
-    ])
-  })
+describe("review flow", () => {
+  for (const {
+    expectedAssignments,
+    pendingThreadReplyAccounts,
+    reviews,
+    title,
+  } of [
+    {
+      expectedAssignments: ["initial", "initial", "initial"],
+      reviews: [],
+      title: "uses initial review when no configured account reviewed",
+    },
+    {
+      expectedAssignments: ["skip", "rereview", "skip"],
+      pendingThreadReplyAccounts: new Set(["bot-b"]),
+      reviews: [
+        review("bot-a", "head", "2026-01-01T00:00:00Z"),
+        review("bot-b", "head", "2026-01-01T00:00:01Z"),
+        review("bot-c", "head", "2026-01-01T00:00:02Z"),
+      ],
+      title:
+        "uses rereview when a reviewed head account has a pending thread reply",
+    },
+    {
+      expectedAssignments: ["rereview", "rereview", "rereview"],
+      reviews: [
+        review("bot-a", "old", "2026-01-01T00:00:00Z"),
+        review("bot-b", "old", "2026-01-01T00:00:01Z"),
+        review("bot-c", "old", "2026-01-01T00:00:02Z"),
+      ],
+      title: "uses rereview when configured accounts reviewed an older commit",
+    },
+    {
+      expectedAssignments: ["skip", "initial", "initial"],
+      reviews: [review("bot-a", "head", "2026-01-01T00:00:00Z")],
+      title: "skips reviewed head accounts and reviews missing accounts",
+    },
+    {
+      expectedAssignments: ["skip", "rereview", "initial"],
+      reviews: [
+        review("bot-a", "head", "2026-01-01T00:00:00Z"),
+        review("bot-b", "old", "2026-01-01T00:00:01Z"),
+      ],
+      title: "mixes skip, rereview, and initial assignments",
+    },
+  ]) {
+    test(title, () => {
+      const mode = resolveReviewMode(
+        reviews,
+        accounts,
+        { headSha: "head", type: "head" },
+        pendingThreadReplyAccounts,
+      )
+
+      expectActiveAssignments(mode, expectedAssignments)
+    })
+  }
 
   test("aborts when all configured accounts already reviewed head", () => {
     expect(
@@ -45,82 +98,6 @@ describe("review flow", () => {
         { headSha: "head", type: "head" },
       ),
     ).toMatchObject({ type: "already_reviewed" })
-  })
-
-  test("uses rereview when a reviewed head account has a pending thread reply", () => {
-    const mode = resolveReviewMode(
-      [
-        review("bot-a", "head", "2026-01-01T00:00:00Z"),
-        review("bot-b", "head", "2026-01-01T00:00:01Z"),
-        review("bot-c", "head", "2026-01-01T00:00:02Z"),
-      ],
-      accounts,
-      { headSha: "head", type: "head" },
-      new Set(["bot-b"]),
-    )
-
-    expect(mode.type).toBe("active")
-    if (mode.type !== "active") throw new Error("expected active mode")
-    expect([...mode.assignments.values()].map((item) => item.type)).toEqual([
-      "skip",
-      "rereview",
-      "skip",
-    ])
-  })
-
-  test("uses rereview when configured accounts reviewed an older commit", () => {
-    const mode = resolveReviewMode(
-      [
-        review("bot-a", "old", "2026-01-01T00:00:00Z"),
-        review("bot-b", "old", "2026-01-01T00:00:01Z"),
-        review("bot-c", "old", "2026-01-01T00:00:02Z"),
-      ],
-      accounts,
-      { headSha: "head", type: "head" },
-    )
-
-    expect(mode.type).toBe("active")
-    if (mode.type !== "active") throw new Error("expected active mode")
-    expect([...mode.assignments.values()].map((item) => item.type)).toEqual([
-      "rereview",
-      "rereview",
-      "rereview",
-    ])
-  })
-
-  test("skips reviewed head accounts and reviews missing accounts", () => {
-    const mode = resolveReviewMode(
-      [review("bot-a", "head", "2026-01-01T00:00:00Z")],
-      accounts,
-      { headSha: "head", type: "head" },
-    )
-
-    expect(mode.type).toBe("active")
-    if (mode.type !== "active") throw new Error("expected active mode")
-    expect([...mode.assignments.values()].map((item) => item.type)).toEqual([
-      "skip",
-      "initial",
-      "initial",
-    ])
-  })
-
-  test("mixes skip, rereview, and initial assignments", () => {
-    const mode = resolveReviewMode(
-      [
-        review("bot-a", "head", "2026-01-01T00:00:00Z"),
-        review("bot-b", "old", "2026-01-01T00:00:01Z"),
-      ],
-      accounts,
-      { headSha: "head", type: "head" },
-    )
-
-    expect(mode.type).toBe("active")
-    if (mode.type !== "active") throw new Error("expected active mode")
-    expect([...mode.assignments.values()].map((item) => item.type)).toEqual([
-      "skip",
-      "rereview",
-      "initial",
-    ])
   })
 
   test("uses latest non-merge commit time for review freshness", () => {

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -8,7 +8,7 @@ import type {
   IssueMeta,
   RelatedPullRequest,
 } from "../github/commands"
-import type { Exec, ResolvedRepository } from "../types"
+import type { Exec, ResolvedRepository, TriageDuplicateOutput } from "../types"
 import type { ModelClient } from "./model"
 import {
   chooseDuplicateOutput,
@@ -439,51 +439,33 @@ describe("triage orchestration", () => {
     })
   })
 
-  test("skips category classification when issue type is Bug", async () => {
-    const result = await runScenario({
-      issue: issue({ type: "Bug" }),
-      outputs: [
-        vote("YES"),
-        vote("YES"),
-        vote("YES"),
-        action("COMMENT"),
-        "Bug accepted comment",
-      ],
+  for (const { category, type } of [
+    { category: "bug", type: "Bug" },
+    { category: "feature", type: "Feature" },
+  ]) {
+    test(`skips category classification when issue type is ${type}`, async () => {
+      const result = await runScenario({
+        issue: issue({ type }),
+        outputs: [
+          vote("YES"),
+          vote("YES"),
+          vote("YES"),
+          action("COMMENT"),
+          `${type} accepted comment`,
+        ],
+      })
+
+      expect(result.result.result).toEqual(decision(category, "accepted"))
+      expect(
+        result.sessionTitles.filter((title) =>
+          title.includes("triage acceptance"),
+        ),
+      ).toHaveLength(3)
+      expect(
+        result.sessionTitles.some((title) => title.includes("triage category")),
+      ).toBe(false)
     })
-
-    expect(result.result.result).toEqual(decision("bug", "accepted"))
-    expect(
-      result.sessionTitles.filter((title) =>
-        title.includes("triage acceptance"),
-      ),
-    ).toHaveLength(3)
-    expect(
-      result.sessionTitles.some((title) => title.includes("triage category")),
-    ).toBe(false)
-  })
-
-  test("skips category classification when issue type is Feature", async () => {
-    const result = await runScenario({
-      issue: issue({ type: "Feature" }),
-      outputs: [
-        vote("YES"),
-        vote("YES"),
-        vote("YES"),
-        action("COMMENT"),
-        "Feature accepted comment",
-      ],
-    })
-
-    expect(result.result.result).toEqual(decision("feature", "accepted"))
-    expect(
-      result.sessionTitles.filter((title) =>
-        title.includes("triage acceptance"),
-      ),
-    ).toHaveLength(3)
-    expect(
-      result.sessionTitles.some((title) => title.includes("triage category")),
-    ).toBe(false)
-  })
+  }
 
   test("runs category classification when issue type and category labels are absent", async () => {
     const result = await runScenario({
@@ -1028,44 +1010,48 @@ describe("triage orchestration", () => {
     ).toHaveLength(3)
   })
 
-  test("requires majority support for the same duplicate target", () => {
-    const result = chooseDuplicateOutput({
+  for (const { candidateNumbers, expectedDuplicateOf, outputs, title } of [
+    {
       candidateNumbers: [101, 202],
       outputs: [
         { duplicateOf: 101, reason: "same failure", vote: "DUPLICATE" },
         { duplicateOf: 202, reason: "same request", vote: "DUPLICATE" },
         { reason: "not the same", vote: "NOT_DUPLICATE" },
       ],
-    })
-
-    expect(result).toBeUndefined()
-  })
-
-  test("selects a duplicate target with majority support", () => {
-    const result = chooseDuplicateOutput({
+      title: "requires majority support for the same duplicate target",
+    },
+    {
       candidateNumbers: [101, 202],
+      expectedDuplicateOf: 101,
       outputs: [
         { duplicateOf: 101, reason: "same failure", vote: "DUPLICATE" },
         { duplicateOf: 101, reason: "same root cause", vote: "DUPLICATE" },
         { duplicateOf: 202, reason: "similar request", vote: "DUPLICATE" },
       ],
-    })
-
-    expect(result?.duplicateOf).toBe(101)
-  })
-
-  test("ignores duplicate targets that were not provided as candidates", () => {
-    const result = chooseDuplicateOutput({
+      title: "selects a duplicate target with majority support",
+    },
+    {
       candidateNumbers: [101],
       outputs: [
         { duplicateOf: 999, reason: "invalid target", vote: "DUPLICATE" },
         { duplicateOf: 999, reason: "invalid target", vote: "DUPLICATE" },
         { reason: "not the same", vote: "NOT_DUPLICATE" },
       ],
-    })
+      title: "ignores duplicate targets that were not provided as candidates",
+    },
+  ] satisfies {
+    candidateNumbers: number[]
+    expectedDuplicateOf?: number
+    outputs: TriageDuplicateOutput[]
+    title: string
+  }[]) {
+    test(title, () => {
+      const result = chooseDuplicateOutput({ candidateNumbers, outputs })
 
-    expect(result).toBeUndefined()
-  })
+      if (expectedDuplicateOf == null) expect(result).toBeUndefined()
+      else expect(result?.duplicateOf).toBe(expectedDuplicateOf)
+    })
+  }
 
   test("allows reconsideration mentions by actor or role", () => {
     expect(


### PR DESCRIPTION
Closes #133

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Consolidates repetitive orchestrator test cases with focused tables and helpers while preserving existing behavioral coverage.

## Current behavior (updates)

Several orchestrator tests repeated full test bodies for similar triage, inline comment, review mode, and CI rerun assertions.

## New behavior

Repeated cases are table-driven or use small shared helpers for clearer coverage without removing safety-critical negative tests.

## Is this a breaking change (Yes/No):

No

## Additional Information

Targeted tests passed: `pnpm test src/orchestrator/triage.test.ts src/orchestrator/inline-comments.test.ts src/orchestrator/review.test.ts src/orchestrator/ci.test.ts`.