### PR TITLE
feat(commands): add synchronous run mode

### DIFF
--- a/.changeset/sync-run-commands.md
+++ b/.changeset/sync-run-commands.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Add synchronous run mode for review, merge, and triage commands.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -45,4 +45,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          opencode run --dir "$GITHUB_WORKSPACE" --command "magi:merge" "${{ github.event.pull_request.number }}"
+          opencode run --dir "$GITHUB_WORKSPACE" --command "magi:merge" "${{ github.event.pull_request.number }} --sync"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -45,4 +45,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          opencode run --dir "$GITHUB_WORKSPACE" --command "magi:triage" "${{ github.event.issue.number }}"
+          opencode run --dir "$GITHUB_WORKSPACE" --command "magi:triage" "${{ github.event.issue.number }} --sync"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,11 +51,19 @@ describe("parsePrs", () => {
       configOverrides: {},
       dryRun: true,
       prs: [7581],
+      sync: false,
     })
     expect(parseRunArguments("7581", true)).toEqual({
       configOverrides: {},
       dryRun: true,
       prs: [7581],
+      sync: false,
+    })
+    expect(parseRunArguments("--sync 7581", false)).toEqual({
+      configOverrides: {},
+      dryRun: false,
+      prs: [7581],
+      sync: true,
     })
   })
 
@@ -75,6 +83,7 @@ describe("parsePrs", () => {
       },
       dryRun: false,
       prs: [7581],
+      sync: false,
     })
   })
 
@@ -97,6 +106,7 @@ describe("parsePrs", () => {
       },
       dryRun: false,
       prs: [7581],
+      sync: false,
     })
   })
 
@@ -147,6 +157,13 @@ describe("parseIssues", () => {
       configOverrides: {},
       dryRun: true,
       issues: [47],
+      sync: false,
+    })
+    expect(parseIssueRunArguments("47 --sync", false)).toEqual({
+      configOverrides: {},
+      dryRun: false,
+      issues: [47],
+      sync: true,
     })
   })
 
@@ -170,6 +187,7 @@ describe("parseIssues", () => {
       },
       dryRun: false,
       issues: [47],
+      sync: false,
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { resolveRepository } from "./config/resolve"
 import { type ModelCatalog, validateConfig } from "./config/validate"
 import { withGitHubApiRetry } from "./github/retry"
 import { mapPool } from "./orchestrator/pool"
-import { MagiRunManager } from "./orchestrator/run-manager"
+import { MagiRunManager, type MagiRunState } from "./orchestrator/run-manager"
 
 const execAsync = promisify(nodeExec)
 const GLOBAL_CONFIG_PATH = join(homedir(), ".config", "opencode", "magi.json")
@@ -43,12 +43,14 @@ interface ParsedRunArguments {
   configOverrides: Record<string, unknown>
   dryRun: boolean
   prs: number[]
+  sync: boolean
 }
 
 interface ParsedIssueRunArguments {
   configOverrides: Record<string, unknown>
   dryRun: boolean
   issues: number[]
+  sync: boolean
 }
 
 type ModelCatalogClient = {
@@ -164,12 +166,17 @@ export function parseRunArguments(
   const tokens = value.split(/[\s,]+/).filter(Boolean)
   const configOverrides: Record<string, unknown> = {}
   const prTokens: string[] = []
+  let sync = false
 
   for (let index = 0; index < tokens.length; index++) {
     const token = tokens[index]!
 
     if (token === "--dry-run") {
       dryRun = true
+      continue
+    }
+    if (token === "--sync") {
+      sync = true
       continue
     }
 
@@ -252,7 +259,7 @@ export function parseRunArguments(
     }
   }
 
-  return { configOverrides, dryRun, prs: parsePrs(prTokens.join(" ")) }
+  return { configOverrides, dryRun, prs: parsePrs(prTokens.join(" ")), sync }
 }
 
 export function parseIssueRunArguments(
@@ -262,12 +269,17 @@ export function parseIssueRunArguments(
   const tokens = value.split(/[\s,]+/).filter(Boolean)
   const configOverrides: Record<string, unknown> = {}
   const issueTokens: string[] = []
+  let sync = false
 
   for (let index = 0; index < tokens.length; index++) {
     const token = tokens[index]!
 
     if (token === "--dry-run") {
       dryRun = true
+      continue
+    }
+    if (token === "--sync") {
+      sync = true
       continue
     }
 
@@ -332,7 +344,12 @@ export function parseIssueRunArguments(
     }
   }
 
-  return { configOverrides, dryRun, issues: parseIssues(issueTokens.join(" ")) }
+  return {
+    configOverrides,
+    dryRun,
+    issues: parseIssues(issueTokens.join(" ")),
+    sync,
+  }
 }
 
 function nextFlagValue(tokens: string[], index: number, flag: string): string {
@@ -342,6 +359,20 @@ function nextFlagValue(tokens: string[], index: number, flag: string): string {
     throw new Error(`${flag} requires a value.`)
 
   return value
+}
+
+async function syncResult(
+  runManager: MagiRunManager,
+  states: MagiRunState[],
+): Promise<string> {
+  const output = await runManager.formatStatesWithReports(states, {
+    verbose: true,
+  })
+  const failed = states.filter((state) => state.status !== "completed")
+
+  if (failed.length) throw new Error(output)
+
+  return output
 }
 
 function parseIntegerFlag(
@@ -656,6 +687,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         args: {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
+          sync: tool.schema.boolean().optional(),
         },
         async execute(args, context) {
           const parsed = parseRunArguments(
@@ -683,6 +715,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           if (!validation.ok) return JSON.stringify(validation, null, 2)
 
           const repository = resolveRepository(config)
+          const sync = parsed.sync || args.sync === true
           const states = await mapPool(
             parsed.prs,
             repository.concurrency.runs,
@@ -694,9 +727,11 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 pr,
                 parentSessionId: context.sessionID,
                 signal: context.abort,
+                sync,
               }),
             { signal: context.abort },
           )
+          if (sync) return syncResult(runManager, states)
 
           return states
             .map(
@@ -714,6 +749,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         args: {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
+          sync: tool.schema.boolean().optional(),
         },
         async execute(args, context) {
           const parsed = parseRunArguments(args.prs, args.dryRun ?? false)
@@ -736,6 +772,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           if (!validation.ok) return JSON.stringify(validation, null, 2)
 
           const repository = resolveRepository(config)
+          const sync = parsed.sync || args.sync === true
           const states = await mapPool(
             parsed.prs,
             repository.concurrency.runs,
@@ -747,9 +784,11 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 pr,
                 parentSessionId: context.sessionID,
                 signal: context.abort,
+                sync,
               }),
             { signal: context.abort },
           )
+          if (sync) return syncResult(runManager, states)
 
           return states
             .map(
@@ -765,6 +804,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
         args: {
           issues: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
+          sync: tool.schema.boolean().optional(),
         },
         async execute(args, context) {
           const parsed = parseIssueRunArguments(
@@ -801,6 +841,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
               null,
               2,
             )
+          const sync = parsed.sync || args.sync === true
           const states = await mapPool(
             parsed.issues,
             repository.triage.concurrency.runs,
@@ -812,9 +853,11 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 parentSessionId: context.sessionID,
                 repository,
                 signal: context.abort,
+                sync,
               }),
             { signal: context.abort },
           )
+          if (sync) return syncResult(runManager, states)
 
           return states
             .map(

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -263,6 +263,41 @@ describe("MagiRunManager notifications", () => {
     }
   })
 
+  test("runs triage synchronously when requested", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-triage-sync-"))
+    const { manager } = managerWithPromptCapture(directory)
+
+    runTriageMock.mockResolvedValueOnce({
+      issue: 115,
+      outputDir: join(directory, "triage"),
+      report: "Triage report",
+      result: { category: "feature", disposition: "accepted" },
+    })
+
+    try {
+      const state = await manager.startTriage({
+        config: { github: { owner: "owner", repo: "repo" } },
+        issue: 115,
+        repository: sampleTriageRepository({
+          clear: ["triage"],
+          close: false,
+          create: false,
+          merge: false,
+          review: false,
+        }),
+        sync: true,
+      })
+
+      expect(state.status).toBe("completed")
+      expect(state.phase).toBe(
+        JSON.stringify({ category: "feature", disposition: "accepted" }),
+      )
+      expect(runTriageMock).toHaveBeenCalledOnce()
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   test("marks synchronous runs failed when execution fails", async () => {
     const directory = await mkdtemp(join(tmpdir(), "magi-sync-fail-"))
     const { manager } = managerWithPromptCapture(directory)

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -7,7 +7,14 @@ import { join } from "node:path"
 import { afterEach, describe, expect, test, vi } from "vitest"
 
 const runReviewMock = vi.hoisted(() => vi.fn())
+const runMergeMock = vi.hoisted(() => vi.fn())
 const runTriageMock = vi.hoisted(() => vi.fn())
+
+vi.mock("./merge", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./merge")>()
+
+  return { ...actual, runMerge: runMergeMock }
+})
 
 vi.mock("./review", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./review")>()
@@ -25,6 +32,7 @@ import { MagiRunManager, redactSecrets } from "./run-manager"
 
 describe("MagiRunManager notifications", () => {
   afterEach(() => {
+    runMergeMock.mockReset()
     runReviewMock.mockReset()
     runTriageMock.mockReset()
     vi.restoreAllMocks()
@@ -194,14 +202,98 @@ describe("MagiRunManager notifications", () => {
     }
   }
 
+  test("runs review synchronously when requested", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-review-sync-"))
+    const { manager } = managerWithPromptCapture(directory)
+
+    runReviewMock.mockResolvedValueOnce({
+      outputs: {
+        security: {
+          findings: [],
+          requirementFindings: [],
+          verdict: "MERGE",
+        },
+      },
+      posted: { security: "approved" },
+      report: "Review report",
+      sessionIds: {},
+      verdict: "MERGE",
+    })
+
+    try {
+      const state = await manager.startReview({
+        config: { github: { owner: "owner", repo: "repo" } },
+        pr: 7557,
+        repository: sampleRepository(),
+        sync: true,
+      })
+
+      expect(state.status).toBe("completed")
+      expect(state.phase).toBe("completed")
+      expect(runReviewMock).toHaveBeenCalledOnce()
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("runs merge synchronously when requested", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-merge-sync-"))
+    const { manager } = managerWithPromptCapture(directory)
+
+    runMergeMock.mockResolvedValueOnce({
+      cycles: 0,
+      pr: 7557,
+      report: "Merge report",
+      status: "approved",
+    })
+
+    try {
+      const state = await manager.startMerge({
+        config: { github: { owner: "owner", repo: "repo" } },
+        pr: 7557,
+        repository: sampleRepository(),
+        sync: true,
+      })
+
+      expect(state.status).toBe("completed")
+      expect(state.phase).toBe("approved")
+      expect(runMergeMock).toHaveBeenCalledOnce()
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("marks synchronous runs failed when execution fails", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-sync-fail-"))
+    const { manager } = managerWithPromptCapture(directory)
+
+    runReviewMock.mockRejectedValueOnce(new Error("review failed"))
+
+    try {
+      const state = await manager.startReview({
+        config: { github: { owner: "owner", repo: "repo" } },
+        pr: 7557,
+        repository: sampleRepository(),
+        sync: true,
+      })
+
+      expect(state.status).toBe("failed")
+      expect(state.error).toBe("review failed")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   async function executeTriageWithAutomation(
     automation: NonNullable<ResolvedRepository["triage"]>["automation"],
+    sync = false,
   ) {
     const directory = await mkdtemp(join(tmpdir(), "magi-triage-follow-up-"))
     const { manager } = managerWithPromptCapture(directory)
     const repository = sampleTriageRepository(automation)
     const state = sampleTriageState(join(directory, "triage"))
     const reviewState = sampleReviewState(join(directory, "review"))
+    reviewState.status = "completed"
     const mergeState: MagiRunState = {
       ...reviewState,
       command: "merge",
@@ -235,6 +327,7 @@ describe("MagiRunManager notifications", () => {
         parentSessionId: "parent-session",
         repository,
         runId: "triage-run",
+        sync,
       })
 
       return { startMerge, startReview }
@@ -277,6 +370,42 @@ describe("MagiRunManager notifications", () => {
         parentSessionId: "parent-session",
         pr: 30,
       }),
+    )
+    expect(startReview).not.toHaveBeenCalled()
+  })
+
+  test("runs triage follow-up review synchronously when requested", async () => {
+    const { startMerge, startReview } = await executeTriageWithAutomation(
+      {
+        clear: ["triage"],
+        close: false,
+        create: true,
+        merge: false,
+        review: true,
+      },
+      true,
+    )
+
+    expect(startReview).toHaveBeenCalledWith(
+      expect.objectContaining({ pr: 30, sync: true }),
+    )
+    expect(startMerge).not.toHaveBeenCalled()
+  })
+
+  test("runs triage follow-up merge synchronously when requested", async () => {
+    const { startMerge, startReview } = await executeTriageWithAutomation(
+      {
+        clear: ["triage"],
+        close: false,
+        create: true,
+        merge: true,
+        review: true,
+      },
+      true,
+    )
+
+    expect(startMerge).toHaveBeenCalledWith(
+      expect.objectContaining({ pr: 30, sync: true }),
     )
     expect(startReview).not.toHaveBeenCalled()
   })

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -151,6 +151,7 @@ const DEFAULT_CLEAR_OPTIONS: MagiClearOptions = {
   session: true,
   worktree: true,
 }
+const SYNC_RUN_TIMEOUT_MS = 600_000
 
 function createRunId(): string {
   return `run-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`
@@ -712,6 +713,7 @@ export class MagiRunManager {
     pr: number
     repository: ResolvedRepository
     signal?: AbortSignal
+    sync?: boolean
   }): Promise<MagiRunState> {
     const runId = createRunId()
     const outputDir = prRunOutputDir({
@@ -760,11 +762,15 @@ export class MagiRunManager {
     const controller = new AbortController()
     this.controllers.set(runId, controller)
 
-    void this.executeReview({
-      ...input,
-      runId,
-      signal: controller.signal,
-    }).catch(async (error) => {
+    const execute = () =>
+      this.executeReview({
+        ...input,
+        runId,
+        signal: controller.signal,
+      })
+    if (input.sync) return this.executeSync(state, controller, execute)
+
+    void execute().catch(async (error) => {
       await this.failRun(runId, error)
     })
 
@@ -778,6 +784,7 @@ export class MagiRunManager {
     pr: number
     repository: ResolvedRepository
     signal?: AbortSignal
+    sync?: boolean
   }): Promise<MagiRunState> {
     const runId = createRunId()
     const outputDir = prRunOutputDir({
@@ -832,11 +839,15 @@ export class MagiRunManager {
     const controller = new AbortController()
     this.controllers.set(runId, controller)
 
-    void this.executeMerge({
-      ...input,
-      runId,
-      signal: controller.signal,
-    }).catch(async (error) => {
+    const execute = () =>
+      this.executeMerge({
+        ...input,
+        runId,
+        signal: controller.signal,
+      })
+    if (input.sync) return this.executeSync(state, controller, execute)
+
+    void execute().catch(async (error) => {
       await this.failRun(runId, error)
     })
 
@@ -850,6 +861,7 @@ export class MagiRunManager {
     parentSessionId?: string
     repository: ResolvedRepository
     signal?: AbortSignal
+    sync?: boolean
   }): Promise<MagiRunState> {
     const runId = createRunId()
     const outputDir = issueRunOutputDir({
@@ -906,11 +918,15 @@ export class MagiRunManager {
     const controller = new AbortController()
     this.controllers.set(runId, controller)
 
-    void this.executeTriage({
-      ...input,
-      runId,
-      signal: controller.signal,
-    }).catch(async (error) => {
+    const execute = () =>
+      this.executeTriage({
+        ...input,
+        runId,
+        signal: controller.signal,
+      })
+    if (input.sync) return this.executeSync(state, controller, execute)
+
+    void execute().catch(async (error) => {
       await this.failRun(runId, error)
     })
 
@@ -1788,6 +1804,46 @@ export class MagiRunManager {
     )
   }
 
+  private async executeSync(
+    state: MagiRunState,
+    controller: AbortController,
+    execute: () => Promise<void>,
+  ): Promise<MagiRunState> {
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeout = setTimeout(() => resolve("timeout"), SYNC_RUN_TIMEOUT_MS)
+    })
+
+    try {
+      const result = await Promise.race([
+        execute().then(() => "completed" as const),
+        timeoutPromise,
+      ])
+      if (result === "timeout") {
+        controller.abort()
+        await this.failRun(
+          state.runId,
+          new Error("Magi sync run timed out after 600 seconds."),
+        )
+      }
+    } catch (error) {
+      controller.abort()
+      await this.failRun(state.runId, error)
+    } finally {
+      if (timeout) clearTimeout(timeout)
+    }
+
+    return (await this.readStateByRunId(state.runId)) ?? state
+  }
+
+  private assertSuccessfulSyncFollowUp(state: MagiRunState): void {
+    if (state.status === "completed") return
+
+    throw new Error(
+      `Synchronous follow-up ${state.command} run ${state.runId} finished with status ${state.status}.`,
+    )
+  }
+
   private async executeReview(input: {
     config: MagiConfig
     dryRun?: boolean
@@ -1925,6 +1981,7 @@ export class MagiRunManager {
     repository: ResolvedRepository
     runId: string
     signal?: AbortSignal
+    sync?: boolean
   }): Promise<void> {
     const state = this.active.get(input.runId)
     if (state) {
@@ -1982,23 +2039,27 @@ export class MagiRunManager {
       : undefined
     const triageAutomation = input.repository.triage?.automation
     if (followUpPr != null && triageAutomation?.merge) {
-      await this.startMerge({
+      const followUp = await this.startMerge({
         config: input.config,
         dryRun: input.dryRun,
         parentSessionId: input.parentSessionId,
         pr: followUpPr,
         repository: input.repository,
         signal: input.signal,
+        sync: input.sync,
       })
+      if (input.sync) this.assertSuccessfulSyncFollowUp(followUp)
     } else if (followUpPr != null && triageAutomation?.review) {
-      await this.startReview({
+      const followUp = await this.startReview({
         config: input.config,
         dryRun: input.dryRun,
         parentSessionId: input.parentSessionId,
         pr: followUpPr,
         repository: input.repository,
         signal: input.signal,
+        sync: input.sync,
       })
+      if (input.sync) this.assertSuccessfulSyncFollowUp(followUp)
     }
     this.active.delete(input.runId)
     this.controllers.delete(input.runId)


### PR DESCRIPTION
Closes #145

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add `--sync` support to `/magi:review`, `/magi:merge`, and `/magi:triage` so CI can wait for actual run completion instead of only confirming background run startup.

## Current behavior (updates)

Run commands start Magi work in the background and return immediately. GitHub Actions can pass while triage/review/merge work is still running or blocked.

## New behavior

`--sync` runs execute to completion with a bounded internal timeout, return final status/report output, and fail tool execution for non-completed states. Triage sync also waits for generated PR follow-up review or merge automation when configured.

## Is this a breaking change (Yes/No):

No

## Additional Information

Targeted tests: `pnpm vitest run src/index.test.ts src/orchestrator/run-manager.test.ts`