### PR TITLE
docs(config): document agent refs presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,26 +61,33 @@ Add the following content to the configuration file.
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
+  "agents": {
+    "refs": {
+      "account-1": {
+        "model": "openai/gpt-5.5",
+        "account": "account-1"
+      },
+      "account-2": {
+        "model": "anthropic/claude-opus-4-7",
+        "account": "account-2"
+      },
+      "account-3": {
+        "model": "opencode/kimi-k2-6",
+        "account": "account-3"
+      }
+    }
+  },
   "review": {
     "agents": [
-      {
-        "account": "your-account-1",
-        "model": "openai/gpt-5.5"
-      },
-      {
-        "account": "your-account-2",
-        "model": "anthropic/claude-opus-4-7"
-      },
-      {
-        "account": "your-account-3",
-        "model": "opencode/kimi-k2-6"
-      }
+      { "ref": "account-1" },
+      { "ref": "account-2" },
+      { "ref": "account-3" }
     ]
   }
 }
 ```
 
-`review.agents[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique.
+After refs are expanded, `review.agents[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique.
 
 #### Set project config
 
@@ -101,53 +108,54 @@ Add the following content to the configuration file.
     "owner": "your-owner",
     "repo": "your-repo"
   },
-  "review": {
-    "agents": [
-      {
-        "account": "your-account-1",
-        "model": "openai/gpt-5.5"
+  "agents": {
+    "refs": {
+      "account-1": {
+        "model": "openai/gpt-5.5",
+        "account": "account-1"
       },
-      {
-        "account": "your-account-2",
-        "model": "anthropic/claude-opus-4-7"
+      "account-2": {
+        "model": "anthropic/claude-opus-4-7",
+        "account": "account-2"
       },
-      {
-        "account": "your-account-3",
-        "model": "opencode/kimi-k2-6"
-      }
-    ]
-  },
-  "merge": {
-    "editor": {
-      "account": "your-editor-account",
-      "model": "openai/gpt-5.5",
-      "author": {
-        "name": "your-account",
-        "email": "your-email@example.com"
+      "account-3": {
+        "model": "opencode/kimi-k2-6",
+        "account": "account-3"
+      },
+      "account-4": {
+        "model": "openai/gpt-5.5",
+        "account": "account-4",
+        "author": {
+          "name": "account-4",
+          "email": "your-email@example.com"
+        }
       }
     }
   },
-  "triage": {
-    "account": "your-triage-account",
+  "review": {
     "agents": [
-      {
-        "id": "general",
-        "model": "openai/gpt-5.5"
-      },
-      {
-        "id": "maintenance",
-        "model": "anthropic/claude-opus-4-7"
-      },
-      {
-        "id": "product",
-        "model": "opencode/kimi-k2-6"
-      }
+      { "ref": "account-1" },
+      { "ref": "account-2" },
+      { "ref": "account-3" }
+    ]
+  },
+  "merge": {
+    "editor": { "ref": "account-4" }
+  },
+  "triage": {
+    "account": "account-5",
+    "agents": [
+      { "ref": "account-1" },
+      { "ref": "account-2" },
+      { "ref": "account-3" }
     ]
   }
 }
 ```
 
-`review.agents[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique. `merge.editor.account` is used by `/magi:merge` to push fixes, close PRs, and merge PRs.
+Entries with `ref` are expanded from `agents.refs`. Fields set alongside `ref` override fields from the preset.
+
+After refs are expanded, `review.agents[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique. `merge.editor.account` is used by `/magi:merge` to push fixes, close PRs, and merge PRs.
 
 #### Validate config
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,26 +25,27 @@ If at least one config exists, Magi validates the merged effective config and re
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
+  "agents": {
+    "refs": {
+      "account-1": {
+        "model": "openai/gpt-5.5",
+        "account": "account-1"
+      },
+      "account-2": {
+        "model": "anthropic/claude-opus-4-7",
+        "account": "account-2"
+      },
+      "account-3": {
+        "model": "opencode/kimi-k2-6",
+        "account": "account-3"
+      }
+    }
+  },
   "review": {
     "agents": [
-      {
-        "id": "general",
-        "model": "openai/gpt-5.5",
-        "account": "your-account-1"
-      },
-      {
-        "id": "security",
-        "model": "anthropic/claude-opus-4-7",
-        "account": "your-account-2",
-        "persona": "Focus on security vulnerabilities."
-      },
-      {
-        "id": "compat",
-        "model": "opencode/kimi-k2-6",
-        "options": { "reasoningEffort": "high" },
-        "account": "your-account-3",
-        "persona": "Focus on backward compatibility."
-      }
+      { "ref": "account-1" },
+      { "ref": "account-2" },
+      { "ref": "account-3" }
     ]
   }
 }
@@ -56,54 +57,55 @@ If at least one config exists, Magi validates the merged effective config and re
 {
   "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
   "github": {
-    "host": "github.com",
-    "owner": "yamada-ui",
-    "repo": "yamada-ui"
+    "owner": "your-owner",
+    "repo": "your-repo"
   },
-  "language": "ja",
-  "review": {
-    "merge": {
-      "queue": true
-    },
-    "prompts": {
-      "reviewGuidelines": ".agents/references/review-guidelines.md"
+  "agents": {
+    "refs": {
+      "account-1": {
+        "model": "openai/gpt-5.5",
+        "account": "account-1"
+      },
+      "account-2": {
+        "model": "anthropic/claude-opus-4-7",
+        "account": "account-2"
+      },
+      "account-3": {
+        "model": "opencode/kimi-k2-6",
+        "account": "account-3"
+      },
+      "account-4": {
+        "model": "openai/gpt-5.5",
+        "account": "account-4",
+        "author": {
+          "name": "account-4",
+          "email": "your-email@example.com"
+        }
+      }
     }
+  },
+  "review": {
+    "agents": [
+      { "ref": "account-1" },
+      { "ref": "account-2" },
+      { "ref": "account-3" }
+    ]
   },
   "merge": {
-    "editor": {
-      "model": "openai/gpt-5.5",
-      "account": "your-editor-account",
-      "author": {
-        "name": "your-account",
-        "email": "your-email@example.com"
-      }
-    },
-    "prompts": {
-      "editGuidelines": ".agents/references/edit-guidelines.md"
-    }
+    "editor": { "ref": "account-4" }
   },
   "triage": {
-    "account": "your-triage-account",
+    "account": "account-5",
     "agents": [
-      {
-        "id": "general",
-        "model": "openai/gpt-5.5"
-      },
-      {
-        "id": "maintenance",
-        "model": "anthropic/claude-opus-4-7"
-      },
-      {
-        "id": "product",
-        "model": "opencode/kimi-k2-6"
-      }
-    ],
-    "prompts": {
-      "createGuidelines": ".agents/references/create-guidelines.md"
-    }
+      { "ref": "account-1" },
+      { "ref": "account-2" },
+      { "ref": "account-3" }
+    ]
   }
 }
 ```
+
+Entries with `ref` are expanded from `agents.refs`. Fields set alongside `ref` override fields from the preset.
 
 ## Reference
 
@@ -116,6 +118,7 @@ If at least one config exists, Magi validates the merged effective config and re
 | `github.apiRetryAttempts`              | Project | No                               | `3`                                                  | Number of retry attempts for GitHub CLI API calls that fail with rate limit errors.                                  |
 | `language`                             | Both    | No                               | -                                                    | Default language hint for generated reviews and comments.                                                            |
 | `agents`                               | Both    | No                               | -                                                    | Common agent configuration.                                                                                          |
+| `agents.refs`                          | Both    | No                               | -                                                    | Reusable agent presets. Agent entries with `ref` are expanded from these presets before validation.                  |
 | `agents.permissions`                   | Both    | No                               | [json](/src/permissions/common.json)                 | Common OpenCode permission rules applied before per-agent `permissions`.                                             |
 | `output`                               | Both    | No                               | -                                                    | Output parsing and repair configuration.                                                                             |
 | `output.repairAttempts`                | Both    | No                               | `3`                                                  | Number of times to ask a model to repair invalid structured output.                                                  |


### PR DESCRIPTION
Closes #144

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates README and config docs to demonstrate reusable `agents.refs` presets for global and project configuration examples.

## Current behavior (updates)

The examples repeated inline agent configuration and used older placeholder account values.

## New behavior

The examples define shared `account-1` through `account-4` presets and reference them from review, merge, and triage configuration. The docs also explain that referenced agent fields are expanded from `agents.refs` and local fields override preset fields.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change. Tests were not run. Local commit hooks reported `lefthook` was not available in PATH.