### PR TITLE
fix(github): sanitize duplicate issue search query

### DIFF
--- a/.changeset/fix-triage-duplicate-search.md
+++ b/.changeset/fix-triage-duplicate-search.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Sanitize duplicate issue search queries before passing issue titles to GitHub CLI.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -205,9 +205,37 @@ describe("GitHub command helpers", () => {
     )
 
     expect(commands).toEqual([
-      "gh search issues --repo 'owner/repo' --json number,title,url,state,body --limit 5 -- 'Align docs/config.md triage.prompts entries with review and merge prompts'",
+      "gh search issues --repo 'owner/repo' --json number,title,url,state,body --limit 5 -- 'Align docs config md triage prompts entries with review and merge prompts'",
     ])
     expect(result.map((item) => item.number)).toEqual([43])
+  })
+
+  test("sanitizes duplicate issue search queries with slash-prefixed command titles", async () => {
+    const commands: string[] = []
+
+    const result = await searchDuplicateIssues(
+      async (command) => {
+        commands.push(command)
+
+        return "[]"
+      },
+      repository,
+      {
+        author: "author",
+        body: "body",
+        labels: [],
+        number: 141,
+        state: "OPEN",
+        title:
+          "/magi:merge skips editor when existing CHANGES_REQUESTED review has only body-level requirement findings",
+        url: "https://github.com/owner/repo/issues/141",
+      },
+    )
+
+    expect(commands).toEqual([
+      "gh search issues --repo 'owner/repo' --json number,title,url,state,body --limit 5 -- 'magi merge skips editor when existing CHANGES_REQUESTED review has only body level requirement findings'",
+    ])
+    expect(result).toEqual([])
   })
 
   test("normalizes searched related pull request states", async () => {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -692,6 +692,15 @@ function duplicateReferences(text: string): number[] {
   return [...refs]
 }
 
+function issueTitleSearchQuery(title: string, fallback: string): string {
+  return (
+    title
+      .replaceAll(/[^\p{L}\p{N}_]+/gu, " ")
+      .replaceAll(/\s+/g, " ")
+      .trim() || fallback
+  )
+}
+
 async function fetchIssueCandidate(
   exec: Exec,
   repository: ResolvedRepository,
@@ -720,7 +729,7 @@ export async function searchDuplicateIssues(
   issue: IssueMeta,
   limit = 5,
 ): Promise<DuplicateIssueCandidate[]> {
-  const query = issue.title
+  const query = issueTitleSearchQuery(issue.title, String(issue.number))
   const explicitCandidates = await Promise.all(
     duplicateReferences(issue.body)
       .filter((number) => number !== issue.number)


### PR DESCRIPTION
Closes #147

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Sanitizes duplicate issue title search terms before passing them to `gh search issues`.

## Current behavior (updates)

Slash-prefixed command text in issue titles can make GitHub CLI build an invalid issue search query.

## New behavior

Duplicate issue search strips punctuation from title terms and falls back to the issue number if no searchable terms remain.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/github/commands.test.ts`.