### PR TITLE
fix(merge): restore headerless requirement findings

### DIFF
--- a/.changeset/fix-merge-headerless-requirement-findings.md
+++ b/.changeset/fix-merge-headerless-requirement-findings.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Restore skipped merge review requirement findings even when the prior review body omitted the requirement section heading.

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -168,6 +168,33 @@ describe("review flow", () => {
     })
   })
 
+  test("restores skipped requirement findings without a section heading", () => {
+    expect(
+      reviewOutputFromState({
+        author: { login: "bot-a" },
+        body: [
+          "- Missing issue #128 requirement: Do not bundle broader changes.",
+          "  Evidence: The PR includes unrelated test rewrites.",
+          "  Fix: Split the unrelated changes into a separate PR.",
+        ].join("\n"),
+        commit: { oid: "head" },
+        state: "CHANGES_REQUESTED",
+        submittedAt: "2026-01-01T00:00:00Z",
+      }),
+    ).toEqual({
+      findings: [],
+      requirementFindings: [
+        {
+          evidence: "The PR includes unrelated test rewrites.",
+          fix: "Split the unrelated changes into a separate PR.",
+          issueNumber: 128,
+          requirement: "Do not bundle broader changes.",
+        },
+      ],
+      verdict: "CHANGES_REQUESTED",
+    })
+  })
+
   test("detects replies after the reviewer latest thread comment", () => {
     expect(
       hasPendingThreadReply(

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -405,7 +405,7 @@ function reviewFindingsFromBody(
   const findings: Finding[] = []
   const requirementFindings: RequirementFinding[] = []
   const lines = (body ?? "").split(/\r?\n/)
-  let section: "finding" | "requirement" | undefined
+  let section: "finding" | undefined
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]
@@ -415,7 +415,23 @@ function reviewFindingsFromBody(
       continue
     }
     if (line === "Requirement findings:") {
-      section = "requirement"
+      section = undefined
+      continue
+    }
+
+    const requirementMatch = /^- Missing issue #(\d+) requirement: (.+)$/.exec(
+      line ?? "",
+    )
+    const evidence = /^\s+Evidence: (.+)$/.exec(lines[index + 1] ?? "")
+    const requirementFix = /^\s+Fix: (.+)$/.exec(lines[index + 2] ?? "")
+    if (requirementMatch && evidence && requirementFix) {
+      requirementFindings.push({
+        evidence: evidence[1] ?? "See review body.",
+        fix: requirementFix[1] ?? "Please address this before merging.",
+        issueNumber: Number(requirementMatch[1]),
+        requirement: requirementMatch[2] ?? "Review requirement.",
+      })
+      index += 2
       continue
     }
 
@@ -432,21 +448,6 @@ function reviewFindingsFromBody(
       index += 1
       continue
     }
-
-    if (section !== "requirement") continue
-
-    const match = /^- Missing issue #(\d+) requirement: (.+)$/.exec(line ?? "")
-    const evidence = /^\s+Evidence: (.+)$/.exec(lines[index + 1] ?? "")
-    const fix = /^\s+Fix: (.+)$/.exec(lines[index + 2] ?? "")
-    if (!match || !evidence || !fix) continue
-
-    requirementFindings.push({
-      evidence: evidence[1] ?? "See review body.",
-      fix: fix[1] ?? "Please address this before merging.",
-      issueNumber: Number(match[1]),
-      requirement: match[2] ?? "Review requirement.",
-    })
-    index += 2
   }
 
   return { findings, requirementFindings }


### PR DESCRIPTION
Closes #141

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Restores skipped CHANGES_REQUESTED review requirement findings from prior review bodies even when the `Requirement findings:` heading is absent.

## Current behavior (updates)

`/magi:merge` could reconstruct no editable findings from a current skipped review whose body contained only a requirement finding without the section heading, causing `changes_unresolved` before the editor runs.

## New behavior

Requirement finding bullet triplets are recognized anywhere in the review body, so blocking findings are passed to the editor. Added regression coverage and a patch changeset.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm exec vitest run src/orchestrator/review.test.ts src/orchestrator/merge.test.ts`.