### PR TITLE
fix(review): skip pull request issue references

### DIFF
--- a/.changeset/fix-review-pr-references.md
+++ b/.changeset/fix-review-pr-references.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Skip pull request references when building review issue context.

--- a/src/orchestrator/review-context.test.ts
+++ b/src/orchestrator/review-context.test.ts
@@ -150,6 +150,145 @@ describe("review context", () => {
     expect(snapshot.closingIssues[0].commentsOmitted).toBe(5)
   })
 
+  test("skips pull request references when building issue context", async () => {
+    const commands: string[] = []
+    const referencedPullRequests = new Set([124, 125, 126, 127, 128])
+
+    const snapshot = await buildReviewContextSnapshot({
+      exec: async (command) => {
+        commands.push(command)
+
+        if (command.includes("closingIssuesReferences")) {
+          return JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: { closingIssuesReferences: { nodes: [] } },
+              },
+            },
+          })
+        }
+        if (command.includes("reviewThreads")) {
+          return JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    nodes: [
+                      {
+                        comments: {
+                          nodes: [
+                            {
+                              author: { login: "reviewer" },
+                              body: "This depends on #127",
+                              createdAt: "2026-01-01T00:00:00Z",
+                              databaseId: 2,
+                              line: 10,
+                              path: "src/app.ts",
+                            },
+                          ],
+                          totalCount: 1,
+                        },
+                        id: "thread-id",
+                        isResolved: false,
+                      },
+                    ],
+                    totalCount: 1,
+                  },
+                },
+              },
+            },
+          })
+        }
+        if (command.includes("files(first:")) {
+          return JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  author: { login: "author" },
+                  changedFiles: 1,
+                  files: {
+                    nodes: [{ path: "src/app.ts" }],
+                    pageInfo: { hasNextPage: false },
+                  },
+                  labels: { nodes: [] },
+                },
+              },
+            },
+          })
+        }
+        if (command.includes("pullRequest(number: $pr) { comments")) {
+          return JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  comments: {
+                    nodes: [
+                      {
+                        author: { login: "commenter" },
+                        body: "Also after #126",
+                        createdAt: "2026-01-01T00:00:00Z",
+                        databaseId: 1,
+                        url: "https://github.com/owner/repo/pull/52#issuecomment-1",
+                      },
+                    ],
+                    totalCount: 1,
+                  },
+                },
+              },
+            },
+          })
+        }
+        if (command.includes("issue(number: $issue) { comments")) {
+          throw new Error(`unexpected issue comment fetch: ${command}`)
+        }
+        if (command.includes("issue(number: $issue) { number title body")) {
+          throw Object.assign(new Error("Command failed"), {
+            stderr: "gh: Could not resolve to an Issue.",
+          })
+        }
+        if (command.startsWith("gh issue view ")) {
+          const number = Number(command.match(/gh issue view (\d+)/)?.[1])
+
+          if (!referencedPullRequests.has(number)) {
+            throw new Error(`unexpected issue view: ${command}`)
+          }
+
+          return JSON.stringify({
+            author: { login: "pr-author" },
+            body: "Pull request body",
+            labels: [],
+            number,
+            state: "MERGED",
+            title: `Pull request ${number}`,
+            url: `https://github.com/owner/repo/pull/${number}`,
+          })
+        }
+
+        throw new Error(`unexpected command: ${command}`)
+      },
+      pr: {
+        author: { login: "author" },
+        baseRefName: "main",
+        baseRefOid: "base",
+        body: "Related #125\nFixes #128",
+        headRefName: "feature",
+        headRefOid: "head",
+        isDraft: false,
+        number: 52,
+        state: "OPEN",
+        title: "After #124",
+        url: "https://github.com/owner/repo/pull/52",
+      },
+      repository,
+    })
+
+    expect(snapshot.closingIssues).toEqual([])
+    expect(snapshot.referencedIssues).toEqual([])
+    expect(
+      commands.filter((command) => command.startsWith("gh issue view ")),
+    ).toHaveLength(5)
+  })
+
   test("detects closing and referenced issue relationships", () => {
     const relationships = collectIssueRelationships({
       closingIssues: [

--- a/src/orchestrator/review-context.ts
+++ b/src/orchestrator/review-context.ts
@@ -120,6 +120,34 @@ function quoteEvidence(value: string): string {
   return compact.length > 120 ? `${compact.slice(0, 117)}...` : compact
 }
 
+function errorText(error: unknown): string {
+  if (!error || typeof error !== "object") return String(error)
+
+  const value = error as {
+    message?: unknown
+    stderr?: unknown
+    stdout?: unknown
+  }
+
+  return [value.message, value.stderr, value.stdout]
+    .filter((item): item is string => typeof item === "string")
+    .join("\n")
+}
+
+function isIssueLookupFailure(error: unknown): boolean {
+  const text = errorText(error)
+
+  return (
+    /could not resolve to an issue/i.test(text) ||
+    /could not fetch issue #\d+/i.test(text) ||
+    /not an issue/i.test(text)
+  )
+}
+
+function isIssueUrl(url: string): boolean {
+  return /\/issues\/\d+(?:$|[/?#])/i.test(url)
+}
+
 function issueReferencePattern(repository: ResolvedRepository): RegExp {
   const host = escapeRegExp(repository.github.host || "github.com")
   const owner = escapeRegExp(repository.github.owner)
@@ -262,6 +290,13 @@ async function contextIssue(input: {
   const issue =
     input.issue ??
     (await fetchIssue(input.exec, input.repository, input.relationship.number))
+
+  if (!isIssueUrl(issue.url)) {
+    throw new Error(
+      `Reference #${issue.number} resolved to ${issue.url}, not an Issue`,
+    )
+  }
+
   const commentPage = await fetchIssueCommentPage(
     input.exec,
     input.repository,
@@ -285,6 +320,28 @@ async function contextIssue(input: {
     title: issue.title,
     url: issue.url,
   }
+}
+
+async function contextIssueIfIssue(input: {
+  exec: Exec
+  issue?: IssueMeta
+  limit: number
+  relationship: IssueRelationship
+  repository: ResolvedRepository
+}): Promise<ReviewContextIssue | undefined> {
+  try {
+    return await contextIssue(input)
+  } catch (error) {
+    if (isIssueLookupFailure(error)) return undefined
+
+    throw error
+  }
+}
+
+function presentIssue(
+  issue: ReviewContextIssue | undefined,
+): issue is ReviewContextIssue {
+  return Boolean(issue)
 }
 
 function orderReviewThreads(threads: ReviewThread[]): ReviewThread[] {
@@ -361,17 +418,19 @@ export async function buildReviewContextSnapshot(input: {
   )
 
   return {
-    closingIssues: await Promise.all(
-      closingRelationships.map((relationship) =>
-        contextIssue({
-          exec: input.exec,
-          issue: closingIssueMap.get(relationship.number),
-          limit: LIMITS.closingIssueComments,
-          relationship,
-          repository: input.repository,
-        }),
-      ),
-    ),
+    closingIssues: (
+      await Promise.all(
+        closingRelationships.map((relationship) =>
+          contextIssueIfIssue({
+            exec: input.exec,
+            issue: closingIssueMap.get(relationship.number),
+            limit: LIMITS.closingIssueComments,
+            relationship,
+            repository: input.repository,
+          }),
+        ),
+      )
+    ).filter(presentIssue),
     pullRequest: {
       author: input.pr.author?.login ?? safetyMeta.author,
       baseRef: input.pr.baseRefName,
@@ -389,16 +448,18 @@ export async function buildReviewContextSnapshot(input: {
       title: input.pr.title,
       url: input.pr.url,
     },
-    referencedIssues: await Promise.all(
-      referencedRelationships.map((relationship) =>
-        contextIssue({
-          exec: input.exec,
-          limit: LIMITS.referencedIssueComments,
-          relationship,
-          repository: input.repository,
-        }),
-      ),
-    ),
+    referencedIssues: (
+      await Promise.all(
+        referencedRelationships.map((relationship) =>
+          contextIssueIfIssue({
+            exec: input.exec,
+            limit: LIMITS.referencedIssueComments,
+            relationship,
+            repository: input.repository,
+          }),
+        ),
+      )
+    ).filter(presentIssue),
     reviewDiscussion: {
       prComments: boundedComments(prComments, LIMITS.prComments),
       prCommentsOmitted,


### PR DESCRIPTION
Closes #154

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix review context building so bare references that resolve to pull requests are skipped instead of being treated as issues.

## Current behavior (updates)

`/magi:review` attempted to fetch issue comments for bare PR references found in PR title, PR body, PR comments, or review thread comments, which could fail GraphQL issue lookup before review execution.

## New behavior

Referenced numbers are included in issue context only when the resolved target is an issue. Pull request and other non-issue lookup failures are skipped while unrelated lookup errors still fail.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Added regression coverage for PR references from title, body, PR comments, and review threads. Verified with `pnpm vitest run src/orchestrator/review-context.test.ts`.