### PR TITLE
feat(commands): remove sync wait timeouts

### DIFF
--- a/.changeset/remove-sync-timeout.md
+++ b/.changeset/remove-sync-timeout.md
@@ -1,5 +1,5 @@
 ---
-"opencode-magi": minor
+"opencode-magi": patch
 ---
 
 Remove default and maximum wait timeouts from synchronous Magi runs and blocking status checks.

--- a/.changeset/remove-sync-timeout.md
+++ b/.changeset/remove-sync-timeout.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Remove default and maximum wait timeouts from synchronous Magi runs and blocking status checks.

--- a/src/index.ts
+++ b/src/index.ts
@@ -688,6 +688,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
           sync: tool.schema.boolean().optional(),
+          timeoutSeconds: tool.schema.number().optional(),
         },
         async execute(args, context) {
           const parsed = parseRunArguments(
@@ -728,6 +729,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 parentSessionId: context.sessionID,
                 signal: context.abort,
                 sync,
+                timeoutMs:
+                  args.timeoutSeconds == null
+                    ? undefined
+                    : args.timeoutSeconds * 1_000,
               }),
             { signal: context.abort },
           )
@@ -750,6 +755,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
           sync: tool.schema.boolean().optional(),
+          timeoutSeconds: tool.schema.number().optional(),
         },
         async execute(args, context) {
           const parsed = parseRunArguments(args.prs, args.dryRun ?? false)
@@ -785,6 +791,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 parentSessionId: context.sessionID,
                 signal: context.abort,
                 sync,
+                timeoutMs:
+                  args.timeoutSeconds == null
+                    ? undefined
+                    : args.timeoutSeconds * 1_000,
               }),
             { signal: context.abort },
           )
@@ -805,6 +815,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           issues: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
           sync: tool.schema.boolean().optional(),
+          timeoutSeconds: tool.schema.number().optional(),
         },
         async execute(args, context) {
           const parsed = parseIssueRunArguments(
@@ -854,6 +865,10 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 repository,
                 signal: context.abort,
                 sync,
+                timeoutMs:
+                  args.timeoutSeconds == null
+                    ? undefined
+                    : args.timeoutSeconds * 1_000,
               }),
             { signal: context.abort },
           )

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -36,6 +36,7 @@ describe("MagiRunManager notifications", () => {
     runReviewMock.mockReset()
     runTriageMock.mockReset()
     vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   function managerWithPromptCapture(directory = ".") {
@@ -313,6 +314,139 @@ describe("MagiRunManager notifications", () => {
 
       expect(state.status).toBe("failed")
       expect(state.error).toBe("review failed")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("does not time out synchronous runs after ten minutes", async () => {
+    vi.useFakeTimers()
+    const directory = await mkdtemp(join(tmpdir(), "magi-sync-no-timeout-"))
+    const { manager } = managerWithPromptCapture(directory)
+    let resolveReview: (value: unknown) => void = () => undefined
+
+    runReviewMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveReview = resolve
+      }),
+    )
+
+    try {
+      let resolved = false
+      const statePromise = manager
+        .startReview({
+          config: { github: { owner: "owner", repo: "repo" } },
+          pr: 7557,
+          repository: sampleRepository(),
+          sync: true,
+        })
+        .then((state) => {
+          resolved = true
+
+          return state
+        })
+
+      await vi.advanceTimersByTimeAsync(600_000)
+
+      expect(resolved).toBe(false)
+
+      resolveReview({
+        outputs: {
+          security: {
+            findings: [],
+            verdict: "MERGE",
+          },
+        },
+        posted: { security: "approved" },
+        report: "Review report",
+        sessionIds: {},
+        verdict: "MERGE",
+      })
+
+      const state = await statePromise
+
+      expect(state.status).toBe("completed")
+      expect(state.phase).toBe("completed")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("waits without a default timeout for blocking status", async () => {
+    vi.useFakeTimers()
+    const directory = await mkdtemp(join(tmpdir(), "magi-status-no-timeout-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const outputDir = join(directory, ".magi", "runs", "pr", "7557", "run")
+
+    try {
+      await mkdir(outputDir, { recursive: true })
+      await writeFile(
+        join(outputDir, "state.json"),
+        JSON.stringify(sampleReviewState(outputDir)),
+      )
+
+      let resolved = false
+      const statusPromise = manager
+        .status({ block: true, pr: 7557 })
+        .then((states) => {
+          resolved = true
+
+          return states
+        })
+
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(resolved).toBe(false)
+
+      await writeFile(
+        join(outputDir, "state.json"),
+        JSON.stringify({
+          ...sampleReviewState(outputDir),
+          phase: "completed",
+          status: "completed",
+        }),
+      )
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      const states = await statusPromise
+
+      expect(states[0]?.status).toBe("completed")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("honors blocking status timeouts above ten minutes", async () => {
+    vi.useFakeTimers()
+    const directory = await mkdtemp(join(tmpdir(), "magi-status-long-timeout-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const outputDir = join(directory, ".magi", "runs", "pr", "7557", "run")
+
+    try {
+      await mkdir(outputDir, { recursive: true })
+      await writeFile(
+        join(outputDir, "state.json"),
+        JSON.stringify(sampleReviewState(outputDir)),
+      )
+
+      let resolved = false
+      const statusPromise = manager
+        .status({ block: true, pr: 7557, timeoutMs: 600_001 })
+        .then((states) => {
+          resolved = true
+
+          return states
+        })
+
+      await vi.advanceTimersByTimeAsync(600_000)
+
+      expect(resolved).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      const states = await statusPromise
+
+      expect(states[0]?.status).toBe("running")
     } finally {
       await rm(directory, { force: true, recursive: true })
     }

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -372,6 +372,30 @@ describe("MagiRunManager notifications", () => {
     }
   })
 
+  test("honors explicit synchronous run timeouts", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-sync-timeout-"))
+    const { manager } = managerWithPromptCapture(directory)
+
+    runReviewMock.mockReturnValueOnce(new Promise(() => undefined))
+
+    try {
+      const statePromise = manager.startReview({
+        config: { github: { owner: "owner", repo: "repo" } },
+        pr: 7557,
+        repository: sampleRepository(),
+        sync: true,
+        timeoutMs: 1,
+      })
+
+      const state = await statePromise
+
+      expect(state.status).toBe("failed")
+      expect(state.error).toBe("Magi sync run timed out after 0.001 seconds.")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   test("waits without a default timeout for blocking status", async () => {
     vi.useFakeTimers()
     const directory = await mkdtemp(join(tmpdir(), "magi-status-no-timeout-"))

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -151,7 +151,6 @@ const DEFAULT_CLEAR_OPTIONS: MagiClearOptions = {
   session: true,
   worktree: true,
 }
-const SYNC_RUN_TIMEOUT_MS = 600_000
 
 function createRunId(): string {
   return `run-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`
@@ -943,7 +942,7 @@ export class MagiRunManager {
       timeoutMs?: number
     } = {},
   ): Promise<MagiRunState[]> {
-    const timeoutMs = Math.min(input.timeoutMs ?? 60_000, 600_000)
+    const timeoutMs = input.timeoutMs
     const startedAt = Date.now()
 
     while (input.block) {
@@ -954,7 +953,8 @@ export class MagiRunManager {
         states.every((state) => !isActiveStatus(state.status))
       )
         return states
-      if (Date.now() - startedAt >= timeoutMs) return states
+      if (timeoutMs != null && Date.now() - startedAt >= timeoutMs)
+        return states
       await new Promise((resolve) => setTimeout(resolve, 1_000))
     }
 
@@ -1809,28 +1809,11 @@ export class MagiRunManager {
     controller: AbortController,
     execute: () => Promise<void>,
   ): Promise<MagiRunState> {
-    let timeout: ReturnType<typeof setTimeout> | undefined
-    const timeoutPromise = new Promise<"timeout">((resolve) => {
-      timeout = setTimeout(() => resolve("timeout"), SYNC_RUN_TIMEOUT_MS)
-    })
-
     try {
-      const result = await Promise.race([
-        execute().then(() => "completed" as const),
-        timeoutPromise,
-      ])
-      if (result === "timeout") {
-        controller.abort()
-        await this.failRun(
-          state.runId,
-          new Error("Magi sync run timed out after 600 seconds."),
-        )
-      }
+      await execute()
     } catch (error) {
       controller.abort()
       await this.failRun(state.runId, error)
-    } finally {
-      if (timeout) clearTimeout(timeout)
     }
 
     return (await this.readStateByRunId(state.runId)) ?? state

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -713,6 +713,7 @@ export class MagiRunManager {
     repository: ResolvedRepository
     signal?: AbortSignal
     sync?: boolean
+    timeoutMs?: number
   }): Promise<MagiRunState> {
     const runId = createRunId()
     const outputDir = prRunOutputDir({
@@ -767,7 +768,8 @@ export class MagiRunManager {
         runId,
         signal: controller.signal,
       })
-    if (input.sync) return this.executeSync(state, controller, execute)
+    if (input.sync)
+      return this.executeSync(state, controller, execute, input.timeoutMs)
 
     void execute().catch(async (error) => {
       await this.failRun(runId, error)
@@ -784,6 +786,7 @@ export class MagiRunManager {
     repository: ResolvedRepository
     signal?: AbortSignal
     sync?: boolean
+    timeoutMs?: number
   }): Promise<MagiRunState> {
     const runId = createRunId()
     const outputDir = prRunOutputDir({
@@ -844,7 +847,8 @@ export class MagiRunManager {
         runId,
         signal: controller.signal,
       })
-    if (input.sync) return this.executeSync(state, controller, execute)
+    if (input.sync)
+      return this.executeSync(state, controller, execute, input.timeoutMs)
 
     void execute().catch(async (error) => {
       await this.failRun(runId, error)
@@ -861,6 +865,7 @@ export class MagiRunManager {
     repository: ResolvedRepository
     signal?: AbortSignal
     sync?: boolean
+    timeoutMs?: number
   }): Promise<MagiRunState> {
     const runId = createRunId()
     const outputDir = issueRunOutputDir({
@@ -923,7 +928,8 @@ export class MagiRunManager {
         runId,
         signal: controller.signal,
       })
-    if (input.sync) return this.executeSync(state, controller, execute)
+    if (input.sync)
+      return this.executeSync(state, controller, execute, input.timeoutMs)
 
     void execute().catch(async (error) => {
       await this.failRun(runId, error)
@@ -1808,12 +1814,36 @@ export class MagiRunManager {
     state: MagiRunState,
     controller: AbortController,
     execute: () => Promise<void>,
+    timeoutMs?: number,
   ): Promise<MagiRunState> {
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise =
+      timeoutMs == null
+        ? undefined
+        : new Promise<"timeout">((resolve) => {
+            timeout = setTimeout(() => resolve("timeout"), timeoutMs)
+          })
+
     try {
-      await execute()
+      const result = await (timeoutPromise
+        ? Promise.race([
+            execute().then(() => "completed" as const),
+            timeoutPromise,
+          ])
+        : execute().then(() => "completed" as const))
+      if (result === "timeout") {
+        const timeoutSeconds = (timeoutMs ?? 0) / 1_000
+        controller.abort()
+        await this.failRun(
+          state.runId,
+          new Error(`Magi sync run timed out after ${timeoutSeconds} seconds.`),
+        )
+      }
     } catch (error) {
       controller.abort()
       await this.failRun(state.runId, error)
+    } finally {
+      if (timeout) clearTimeout(timeout)
     }
 
     return (await this.readStateByRunId(state.runId)) ?? state
@@ -1965,6 +1995,7 @@ export class MagiRunManager {
     runId: string
     signal?: AbortSignal
     sync?: boolean
+    timeoutMs?: number
   }): Promise<void> {
     const state = this.active.get(input.runId)
     if (state) {
@@ -2030,6 +2061,7 @@ export class MagiRunManager {
         repository: input.repository,
         signal: input.signal,
         sync: input.sync,
+        timeoutMs: input.timeoutMs,
       })
       if (input.sync) this.assertSuccessfulSyncFollowUp(followUp)
     } else if (followUpPr != null && triageAutomation?.review) {
@@ -2041,6 +2073,7 @@ export class MagiRunManager {
         repository: input.repository,
         signal: input.signal,
         sync: input.sync,
+        timeoutMs: input.timeoutMs,
       })
       if (input.sync) this.assertSuccessfulSyncFollowUp(followUp)
     }


### PR DESCRIPTION
Closes #157

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Remove default and maximum wait limits from synchronous Magi runs and blocking status checks so long-running runs can complete naturally.

## Current behavior (updates)

Synchronous Magi runs failed after 600 seconds. Blocking status checks defaulted to 60 seconds and capped explicit timeouts at 600 seconds.

## New behavior

Synchronous runs wait indefinitely by default, and `timeoutSeconds` can be specified for `magi_review`, `magi_merge`, and `magi_triage` when a caller wants a limit. Blocking status checks also wait indefinitely by default, and explicit `timeoutSeconds` values are honored without a hard cap.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification: `pnpm vitest run src/orchestrator/run-manager.test.ts src/index.test.ts`
