### PR TITLE
feat(triage): use agent-owned issue comments

### DIFF
--- a/.changeset/triage-agent-comment-ownership.md
+++ b/.changeset/triage-agent-comment-ownership.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": major
+---
+
+Revise triage comment ownership to use triage agent accounts and reporter-based final decision comments.

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -49,11 +49,10 @@
     }
   },
   "triage": {
-    "account": "hirotomoyamada",
     "agents": [
-      { "ref": "melchior" },
-      { "ref": "balthasar" },
-      { "ref": "caspar" }
+      { "ref": "melchior", "account": "melchior-magi" },
+      { "ref": "balthasar", "account": "balthasar-magi" },
+      { "ref": "caspar", "account": "caspar-magi" }
     ],
     "creator": { "ref": "hirotomoyamada" },
     "automation": { "create": true }

--- a/schema.json
+++ b/schema.json
@@ -116,12 +116,13 @@
     "triageAgent": {
       "type": "object",
       "if": { "not": { "required": ["ref"] } },
-      "then": { "required": ["model"] },
+      "then": { "required": ["model", "account"] },
       "additionalProperties": false,
       "properties": {
         "ref": { "type": "string", "minLength": 1 },
         "id": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
         "model": { "type": "string", "minLength": 1 },
+        "account": { "type": "string", "minLength": 1 },
         "options": { "type": "object", "additionalProperties": true },
         "permissions": { "$ref": "#/$defs/permissions" },
         "persona": { "type": "string" }
@@ -334,7 +335,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "account": { "type": "string", "minLength": 1 },
         "agents": {
           "type": "array",
           "minItems": 3,
@@ -349,6 +349,7 @@
         "safety": { "$ref": "#/$defs/triageSafety" },
         "concurrency": { "$ref": "#/$defs/triageConcurrency" },
         "prompts": { "$ref": "#/$defs/triagePrompts" },
+        "reporter": { "type": "string", "minLength": 1 },
         "output": { "type": "string" },
         "worktree": { "type": "string" }
       }

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -62,7 +62,7 @@ describe("resolveRepository", () => {
   test("resolves default triage categories", () => {
     const repo = resolveRepository({
       github: { owner: "owner", repo: "repo" },
-      triage: { account: "magi-bot", agents: [] },
+      triage: { agents: [] },
     })
 
     expect(repo.triage?.categories).toEqual([
@@ -98,7 +98,6 @@ describe("resolveRepository", () => {
     const repo = resolveRepository({
       github: { owner: "owner", repo: "repo" },
       triage: {
-        account: "magi-bot",
         agents: [],
         automation: { create: true, merge: true, review: true },
       },
@@ -115,7 +114,6 @@ describe("resolveRepository", () => {
     const repo = resolveRepository({
       github: { owner: "owner", repo: "repo" },
       triage: {
-        account: "magi-bot",
         agents: [],
         categories: [{ id: "question" }],
       },

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -173,7 +173,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
     triageCreator: creator
       ? {
           ...creator,
-          account: creator.account ?? config.triage?.account ?? "",
+          account: creator.account ?? "",
           permission: resolveTriageCreatorPermission(agents, creator),
         }
       : undefined,
@@ -251,7 +251,6 @@ export function resolveRepository(config: MagiConfig): ResolvedRepository {
       requiredLabels: config.review?.safety?.requiredLabels ?? [],
     },
     triage: {
-      account: config.triage?.account,
       automation: {
         clear: config.triage?.automation?.clear ?? ["triage"],
         close: config.triage?.automation?.close ?? false,
@@ -265,6 +264,7 @@ export function resolveRepository(config: MagiConfig): ResolvedRepository {
       },
       output: config.triage?.output,
       prompts: config.triage?.prompts ?? {},
+      reporter: config.triage?.reporter,
       safety: {
         allowAuthors: config.triage?.safety?.allowAuthors ?? [],
         allowMentionActors: config.triage?.safety?.allowMentionActors ?? [],

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -34,9 +34,9 @@ const config: MagiConfig = {
 }
 const reviewers = config.review?.agents ?? []
 const triageAgents = [
-  { model: "openai/gpt" },
-  { model: "anthropic/claude" },
-  { model: "google/gemini" },
+  { account: "triage-a", model: "openai/gpt" },
+  { account: "triage-b", model: "anthropic/claude" },
+  { account: "triage-c", model: "google/gemini" },
 ]
 
 describe("validateConfig", () => {
@@ -80,11 +80,10 @@ describe("validateConfig", () => {
         editor: { ref: "editor", persona: "Edit carefully" },
       },
       triage: {
-        account: "triage-bot",
         agents: [
-          { ref: "shared", id: "first" },
-          { ref: "shared", id: "second" },
-          { ref: "shared", id: "third" },
+          { ref: "shared", account: "triage-a", id: "first" },
+          { ref: "shared", account: "triage-b", id: "second" },
+          { ref: "shared", account: "triage-c", id: "third" },
         ],
         creator: { ref: "editor", account: "creator-bot" },
       },
@@ -246,11 +245,10 @@ describe("validateConfig", () => {
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
           agents: [
-            { model: "openai/gpt" },
-            { id: "product", model: "anthropic/claude" },
-            { id: "maintainer", model: "google/gemini" },
+            { account: "triage-a", model: "openai/gpt" },
+            { account: "triage-b", id: "product", model: "anthropic/claude" },
+            { account: "triage-c", id: "maintainer", model: "google/gemini" },
           ],
         },
       },
@@ -260,17 +258,50 @@ describe("validateConfig", () => {
     expect(result).toMatchObject({ errors: [], ok: true })
   })
 
+  test("validates triage reporter against resolved triage agent keys", async () => {
+    const result = await validateConfig(
+      {
+        github: { owner: "owner", repo: "repo" },
+        triage: {
+          agents: [
+            { account: "triage-a", model: "openai/gpt" },
+            { account: "triage-b", id: "product", model: "anthropic/claude" },
+            { account: "triage-c", model: "google/gemini" },
+          ],
+          reporter: "product",
+        },
+      },
+      { requireReview: false, requireTriage: true },
+    )
+    const generated = await validateConfig(
+      {
+        github: { owner: "owner", repo: "repo" },
+        triage: { agents: triageAgents, reporter: "triage-1" },
+      },
+      { requireReview: false, requireTriage: true },
+    )
+    const invalid = await validateConfig(
+      {
+        github: { owner: "owner", repo: "repo" },
+        triage: { agents: triageAgents, reporter: "missing" },
+      },
+      { requireReview: false, requireTriage: true },
+    )
+
+    expect(result).toMatchObject({ errors: [], ok: true })
+    expect(generated).toMatchObject({ errors: [], ok: true })
+    expect(invalid.ok).toBe(false)
+    expect(invalid.errors).toContain(
+      "triage.reporter must match a triage agent key: missing",
+    )
+  })
+
   test("requires triage creator when PR creation automation is enabled", async () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
-          agents: [
-            { model: "openai/gpt" },
-            { model: "anthropic/claude" },
-            { model: "google/gemini" },
-          ],
+          agents: triageAgents,
           automation: { create: true },
         },
       },
@@ -288,12 +319,7 @@ describe("validateConfig", () => {
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
-          agents: [
-            { model: "openai/gpt" },
-            { model: "anthropic/claude" },
-            { model: "google/gemini" },
-          ],
+          agents: triageAgents,
           automation: { merge: true, review: true },
         },
       },
@@ -314,12 +340,7 @@ describe("validateConfig", () => {
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
-          agents: [
-            { model: "openai/gpt" },
-            { model: "anthropic/claude" },
-            { model: "google/gemini" },
-          ],
+          agents: triageAgents,
           automation: { pr: true } as unknown as NonNullable<
             MagiConfig["triage"]
           >["automation"],
@@ -337,12 +358,7 @@ describe("validateConfig", () => {
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
-          agents: [
-            { model: "openai/gpt" },
-            { model: "anthropic/claude" },
-            { model: "google/gemini" },
-          ],
+          agents: triageAgents,
           prompts: {
             createPr: "triage-create.md",
           } as unknown as NonNullable<MagiConfig["triage"]>["prompts"],
@@ -383,7 +399,6 @@ describe("validateConfig", () => {
         {
           github: { owner: "owner", repo: "repo" },
           triage: {
-            account: "magi-bot",
             agents: triageAgents,
             categories,
           },
@@ -404,7 +419,6 @@ describe("validateConfig", () => {
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
           agents: triageAgents,
           categories: [{ id }],
         },
@@ -421,12 +435,7 @@ describe("validateConfig", () => {
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
-          agents: [
-            { model: "openai/gpt" },
-            { model: "anthropic/claude" },
-            { model: "google/gemini" },
-          ],
+          agents: triageAgents,
           categories: {} as NonNullable<MagiConfig["triage"]>["categories"],
         },
       },
@@ -589,12 +598,7 @@ describe("validateConfig", () => {
           },
         },
         triage: {
-          account: "magi-bot",
-          agents: [
-            { model: "openai/gpt" },
-            { model: "anthropic/claude" },
-            { model: "google/gemini" },
-          ],
+          agents: triageAgents,
           prompts: { createGuidelines: "create-guide.txt" },
         },
       },
@@ -889,12 +893,7 @@ describe("validateConfig", () => {
       {
         github: { owner: "owner", repo: "repo" },
         triage: {
-          account: "magi-bot",
-          agents: [
-            { model: "openai/gpt" },
-            { model: "anthropic/claude" },
-            { model: "google/gemini" },
-          ],
+          agents: triageAgents,
           automation: { create: true },
           creator: {
             account: "creator-bot",

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -74,6 +74,7 @@ const EDITOR_KEYS = new Set([
   "persona",
 ])
 const TRIAGE_AGENT_KEYS = new Set([
+  "account",
   "id",
   "model",
   "options",
@@ -109,7 +110,6 @@ const MERGE_KEYS = new Set([
   "prompts",
 ])
 const TRIAGE_KEYS = new Set([
-  "account",
   "agents",
   "automation",
   "categories",
@@ -117,6 +117,7 @@ const TRIAGE_KEYS = new Set([
   "creator",
   "output",
   "prompts",
+  "reporter",
   "safety",
   "worktree",
 ])
@@ -498,6 +499,8 @@ function validateTriageAgentList(
     if (!agent.model) errors.push(`${path}[${index}].model is required`)
     validateString(agent.model, `${path}[${index}].model`, errors)
     validateModel(agent.model, `${path}[${index}].model`, errors, catalog)
+    if (!agent.account) errors.push(`${path}[${index}].account is required`)
+    validateString(agent.account, `${path}[${index}].account`, errors)
     validateString(agent.persona, `${path}[${index}].persona`, errors)
     if (agent.options != null && !isPlainObject(agent.options))
       errors.push(`${path}[${index}].options must be an object`)
@@ -539,17 +542,22 @@ function validateResolvedReviewers(
   }
 }
 
-function validateResolvedAgentKeys(
-  agents: { key: string }[],
+function validateResolvedTriageAgents(
+  agents: { account: string; key: string }[],
   path: string,
   errors: string[],
 ): void {
   const keys = new Set<string>()
+  const accounts = new Set<string>()
 
   for (const agent of agents) {
     if (keys.has(agent.key))
       errors.push(`${path} has duplicate agent key: ${agent.key}`)
     keys.add(agent.key)
+
+    if (accounts.has(agent.account))
+      errors.push(`${path} has duplicate agent account: ${agent.account}`)
+    accounts.add(agent.account)
   }
 }
 
@@ -928,10 +936,11 @@ function validateTriage(
   validateKnownKeys(triage, "triage", TRIAGE_KEYS, errors)
   const automation = triage.automation as TriageAutomationConfig | undefined
   const concurrency = triage.concurrency as TriageConcurrencyConfig | undefined
+  const creator = triage.creator as TriageCreatorConfig | undefined
+  const reporter =
+    typeof triage.reporter === "string" ? triage.reporter : undefined
   const safety = triage.safety as TriageSafetyConfig | undefined
 
-  if (!triage.account) errors.push("triage.account is required")
-  validateString(triage.account, "triage.account", errors)
   if (!triage.agents) errors.push("triage.agents is required")
   validateTriageAgentList(
     triage.agents as TriageAgentConfig[] | undefined,
@@ -940,21 +949,28 @@ function validateTriage(
     options.modelCatalog,
   )
   if (Array.isArray(triage.agents)) {
-    validateResolvedAgentKeys(
-      resolveAgents(config).triage ?? [],
+    const resolvedTriageAgents = resolveAgents(config).triage ?? []
+    validateResolvedTriageAgents(
+      resolvedTriageAgents,
       "triage.resolvedAgents",
       errors,
     )
+    if (
+      reporter != null &&
+      !resolvedTriageAgents.some((agent) => agent.key === reporter)
+    ) {
+      errors.push(`triage.reporter must match a triage agent key: ${reporter}`)
+    }
   }
-  validateTriageCreator(
-    triage.creator as TriageCreatorConfig | undefined,
-    "triage.creator",
-    errors,
-    options.modelCatalog,
-  )
-  if (automation?.create && !triage.creator)
+  validateString(triage.reporter, "triage.reporter", errors)
+  validateTriageCreator(creator, "triage.creator", errors, options.modelCatalog)
+  if (automation?.create && !creator)
     errors.push(
       "triage.creator is required when triage.automation.create is true",
+    )
+  if (automation?.create && creator && !creator.account)
+    errors.push(
+      "triage.creator.account is required when triage.automation.create is true",
     )
 
   if (automation != null && !isPlainObject(automation)) {
@@ -1090,8 +1106,8 @@ async function validateAuth(
   const agents = resolveAgents(config)
 
   for (const reviewer of agents.reviewers) accounts.add(reviewer.account)
+  for (const agent of agents.triage ?? []) accounts.add(agent.account)
   if (agents.editor) accounts.add(agents.editor.account)
-  if (config.triage?.account) accounts.add(config.triage.account)
   if (agents.triageCreator?.account) accounts.add(agents.triageCreator.account)
 
   await Promise.all(
@@ -1192,30 +1208,25 @@ async function validateRepositoryPermissions(
     }),
   )
 
-  if (config.triage?.account) {
-    try {
-      const permissions = await fetchPermissions(
-        config,
-        exec,
-        config.triage.account,
-      )
+  await Promise.all(
+    (agents.triage ?? []).map(async (agent) => {
+      try {
+        const permissions = await fetchPermissions(config, exec, agent.account)
 
-      if (!permissions.pull) {
-        errors.push(
-          `GitHub account cannot read repository for issue triage: ${config.triage.account}`,
+        if (!permissions.pull) {
+          errors.push(
+            `GitHub account cannot read repository for issue triage: ${agent.account}`,
+          )
+        }
+      } catch (error) {
+        warnings.push(
+          `Could not validate repository permissions for GitHub account: ${agent.account} (${(error as Error).message})`,
         )
       }
-    } catch (error) {
-      warnings.push(
-        `Could not validate repository permissions for GitHub account: ${config.triage.account} (${(error as Error).message})`,
-      )
-    }
-  }
+    }),
+  )
 
-  if (
-    agents.triageCreator?.account &&
-    agents.triageCreator.account !== config.triage?.account
-  ) {
+  if (agents.triageCreator?.account) {
     try {
       const permissions = await fetchPermissions(
         config,

--- a/src/orchestrator/scenarios.test.ts
+++ b/src/orchestrator/scenarios.test.ts
@@ -684,7 +684,6 @@ function triageRepository(
 ): ResolvedRepository {
   const { automation, safety, ...rest } = overrides
   const triage = {
-    account: "magi-bot",
     categories: [
       {
         description: "Something is broken or behaves incorrectly.",
@@ -732,6 +731,7 @@ function triageRepository(
       ...repository.agents,
       triage: [
         {
+          account: "melchior-bot",
           id: "Melchior",
           index: 0,
           key: "Melchior",
@@ -739,6 +739,7 @@ function triageRepository(
           permission: "deny",
         },
         {
+          account: "balthasar-bot",
           id: "Balthasar",
           index: 1,
           key: "Balthasar",
@@ -746,6 +747,7 @@ function triageRepository(
           permission: "deny",
         },
         {
+          account: "caspar-bot",
           id: "Caspar",
           index: 2,
           key: "Caspar",
@@ -795,7 +797,11 @@ async function runTriageScenario(input: {
 }
 
 function triageVote(vote: string): string {
-  return JSON.stringify({ reason: `${vote} reason`, vote })
+  return JSON.stringify({
+    body: vote === "ASK" ? `${vote} body` : undefined,
+    reason: `${vote} reason`,
+    vote,
+  })
 }
 
 function duplicateVote(vote: string, duplicateOf?: number): string {
@@ -1131,7 +1137,6 @@ describe("scenario: /magi:triage", () => {
         triageVote("YES"),
         triageVote("YES"),
         triageAction("COMMENT"),
-        "Bug accepted comment",
       ],
     })
 
@@ -1155,7 +1160,6 @@ describe("scenario: /magi:triage", () => {
         triageVote("YES"),
         triageVote("YES"),
         triageAction("COMMENT"),
-        "Feature accepted comment",
       ],
     })
 
@@ -1176,7 +1180,6 @@ describe("scenario: /magi:triage", () => {
         duplicateVote("DUPLICATE", 10),
         duplicateVote("NOT_DUPLICATE"),
         triageAction("COMMENT"),
-        "Duplicate comment",
       ],
     })
 
@@ -1228,7 +1231,6 @@ describe("scenario: /magi:triage", () => {
         triageVote("RELATED_PR_HANDLES_ISSUE"),
         triageVote("RELATED_PR_DOES_NOT_HANDLE_ISSUE"),
         triageAction("CLOSE"),
-        "Merged PR comment",
       ],
       relatedPullRequests: [
         {
@@ -1257,14 +1259,14 @@ describe("scenario: /magi:triage", () => {
     const result = await runTriageScenario({
       comments: [
         comment({
-          author: "magi-bot",
+          author: "melchior-bot",
           body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=FEATURE_ACCEPTED action=COMMENT checkpoint=10 pr=none processed= -->",
           id: 10,
         }),
         comment({
           author: "maintainer",
           authorAssociation: "MEMBER",
-          body: "@magi-bot this should be reconsidered",
+          body: "@melchior-bot this should be reconsidered",
           id: 11,
         }),
       ],
@@ -1278,7 +1280,6 @@ describe("scenario: /magi:triage", () => {
         triageVote("NO"),
         triageVote("ASK"),
         triageAction("COMMENT"),
-        "Reconsidered comment",
       ],
     })
 
@@ -1291,7 +1292,7 @@ describe("scenario: /magi:triage", () => {
       category: "feature",
       disposition: "rejected",
     })
-    expect(commentBody).toContain("Reconsidered comment")
+    expect(commentBody).toContain("NO reason")
     expect(
       result.sessionTitles.some((title) => title.includes("triage reconsider")),
     ).toBe(true)

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -24,6 +24,7 @@ const repository: ResolvedRepository = {
     reviewers: [],
     triage: [
       {
+        account: "melchior-bot",
         id: "Melchior",
         index: 0,
         key: "Melchior",
@@ -31,6 +32,7 @@ const repository: ResolvedRepository = {
         permission: "deny",
       },
       {
+        account: "balthasar-bot",
         id: "Balthasar",
         index: 1,
         key: "Balthasar",
@@ -38,6 +40,7 @@ const repository: ResolvedRepository = {
         permission: "deny",
       },
       {
+        account: "caspar-bot",
         id: "Caspar",
         index: 2,
         key: "Caspar",
@@ -72,7 +75,6 @@ const repository: ResolvedRepository = {
   prompts: {},
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
   triage: {
-    account: "magi-bot",
     automation: {
       clear: ["triage"],
       close: false,
@@ -356,7 +358,11 @@ async function runScenario(input: {
 }
 
 function vote(vote: string): string {
-  return JSON.stringify({ reason: `${vote} reason`, vote })
+  return JSON.stringify({
+    body: vote === "ASK" ? `${vote} body` : undefined,
+    reason: `${vote} reason`,
+    vote,
+  })
 }
 
 function duplicateVote(vote: string, duplicateOf?: number): string {
@@ -499,7 +505,7 @@ describe("triage orchestration", () => {
       outputs: [vote("ASK"), vote("ASK"), vote("bug"), action("ASK")],
     })
     const comment = await readFile(
-      join(result.result.outputDir, "comment.md"),
+      join(result.result.outputDir, "Melchior.ask-comment.md"),
       "utf8",
     )
     const visibleComment = comment.split("<!-- opencode-magi:triage")[0]
@@ -509,9 +515,7 @@ describe("triage orchestration", () => {
       category: null,
       disposition: "ask",
     })
-    expect(visibleComment).toContain(
-      "@author I can't determine what should be done",
-    )
+    expect(visibleComment).toContain("ASK body")
     expect(visibleComment).not.toContain("bug")
     expect(visibleComment).not.toContain("feature")
   })
@@ -655,7 +659,7 @@ describe("triage orchestration", () => {
     ).toBe(true)
   })
 
-  test("assigns the issue to the triage account before creating an implementation PR", async () => {
+  test("assigns the issue to the triage creator account before creating an implementation PR", async () => {
     const result = await runScenario({
       dryRun: false,
       issue: issue({ type: "Feature" }),
@@ -664,7 +668,6 @@ describe("triage orchestration", () => {
         vote("YES"),
         vote("YES"),
         action("PR"),
-        "Feature accepted comment",
         JSON.stringify({
           commitMessage: "fix(orchestrator): address issue",
           commitSha: "abc123",
@@ -700,7 +703,7 @@ describe("triage orchestration", () => {
     })
 
     const assignIndex = result.commands.findIndex((command) =>
-      command.includes("--add-assignee 'magi-bot'"),
+      command.includes("--add-assignee 'creator-bot'"),
     )
     const worktreeIndex = result.commands.findIndex((command) =>
       command.startsWith("git worktree add"),
@@ -754,7 +757,7 @@ describe("triage orchestration", () => {
     const result = await runScenario({
       comments: [
         comment({
-          author: "magi-bot",
+          author: "melchior-bot",
           body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=BUG_ACCEPTED action=COMMENT checkpoint=10 pr=none processed= -->",
           id: 10,
         }),
@@ -771,7 +774,7 @@ describe("triage orchestration", () => {
     const result = await runScenario({
       comments: [
         comment({
-          author: "magi-bot",
+          author: "melchior-bot",
           body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=FEATURE_ACCEPTED action=PR checkpoint=10 pr=none processed= -->",
           id: 10,
         }),
@@ -833,7 +836,7 @@ describe("triage orchestration", () => {
     const result = await runScenario({
       comments: [
         comment({
-          author: "magi-bot",
+          author: "melchior-bot",
           body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=BUG_REJECTED action=CLOSE checkpoint=10 pr=none processed= -->",
           id: 10,
         }),
@@ -866,7 +869,7 @@ describe("triage orchestration", () => {
     const result = await runScenario({
       comments: [
         comment({
-          author: "magi-bot",
+          author: "melchior-bot",
           body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=FEATURE_ACCEPTED action=COMMENT checkpoint=10 pr=none processed= -->",
           id: 10,
         }),
@@ -970,14 +973,14 @@ describe("triage orchestration", () => {
     const result = await runScenario({
       comments: [
         comment({
-          author: "magi-bot",
+          author: "melchior-bot",
           body: "Previous comment\n\n<!-- opencode-magi:triage v=1 issue=1 result=FEATURE_ACCEPTED action=COMMENT checkpoint=10 pr=none processed= -->",
           id: 10,
         }),
         comment({
           author: "maintainer",
           authorAssociation: "MEMBER",
-          body: "@magi-bot this should be reconsidered",
+          body: "@melchior-bot this should be reconsidered",
           id: 11,
         }),
       ],

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -48,11 +48,9 @@ import {
   composeTriageActionPrompt,
   composeTriageCategoryPrompt,
   composeTriageCommentClassificationPrompt,
-  composeTriageCommentPrompt,
   composeTriageCreatePrPrompt,
   composeTriageDuplicatePrompt,
   composeTriageExistingPrPrompt,
-  composeTriageQuestionPrompt,
   composeTriageReconsiderPrompt,
 } from "../prompts/compose"
 import {
@@ -66,7 +64,6 @@ import {
 } from "../prompts/output"
 import { aggregateStringMajority, majorityThreshold } from "./majority"
 import {
-  runModelText,
   runModelWithRepair,
   type ModelClient,
   type ModelRunResult,
@@ -144,6 +141,7 @@ export type TriageRunProgress =
   | { branch: string; type: "worktree_created"; worktreePath: string }
 
 interface TriageMarker {
+  account?: string
   action?: string
   checkpoint?: number
   commentId?: number
@@ -163,6 +161,18 @@ interface RelationshipSummary {
   mentionReplies: IssueComment[]
   previousMarker?: TriageMarker
   relatedPullRequests: RelatedPullRequest[]
+}
+
+type VoteRunOutput<T extends string> = TriageVoteOutput<T> & {
+  promptText: string
+  raw: string
+  reviewer: string
+  sessionId: string
+}
+
+interface PhaseVoteResult<T extends string> {
+  outputs: VoteRunOutput<T>[]
+  vote?: T
 }
 
 interface ActionPlan {
@@ -372,7 +382,9 @@ async function runVote<
   run: TriageRunInput
   schemaName: string
   signal?: AbortSignal
-}): Promise<O & { promptText: string; raw: string; sessionId: string }> {
+}): Promise<
+  O & { promptText: string; raw: string; reviewer: string; sessionId: string }
+> {
   const prompt = await input.prompt({
     context: input.context,
     directory: input.directory,
@@ -428,6 +440,7 @@ async function runVote<
     ...result.value,
     promptText: prompt,
     raw: result.raw,
+    reviewer: input.agent.key,
     sessionId: result.sessionId,
   }
 }
@@ -443,6 +456,7 @@ async function writeVoteArtifacts(input: {
   await writeFile(`${base}.prompt.txt`, `${input.output.promptText}\n`)
   await writeFile(`${base}.raw.txt`, `${input.output.raw}\n`)
   await writeJson(`${base}.json`, {
+    body: input.output.body,
     reason: input.output.reason,
     vote: input.output.vote,
   })
@@ -552,7 +566,7 @@ async function runPhaseVote<T extends string>(input: {
   prompt: TriagePromptComposer
   schemaName: string
   votes: readonly T[]
-}): Promise<T | undefined> {
+}): Promise<PhaseVoteResult<T>> {
   const agents = input.input.repository.agents.triage
   if (!agents?.length) throw new Error("triage.agents is required")
   await emitProgress(input.input, { phase: input.phase, type: "phase" })
@@ -599,7 +613,7 @@ async function runPhaseVote<T extends string>(input: {
     majority,
   )
 
-  return majority.vote
+  return { outputs, vote: majority.vote }
 }
 
 async function relationshipScan(input: TriageRunInput, issue: IssueMeta) {
@@ -609,17 +623,22 @@ async function relationshipScan(input: TriageRunInput, issue: IssueMeta) {
       fetchRelatedPullRequests(input.exec, input.repository, input.issue),
       searchDuplicateIssues(input.exec, input.repository, issue),
     ])
+  const triageAccounts = new Set(
+    (input.repository.agents.triage ?? []).map((agent) => agent.account),
+  )
   const markers = comments
-    .filter((comment) => comment.author === input.repository.triage?.account)
+    .filter((comment) => triageAccounts.has(comment.author))
     .map((comment) => {
       const parsed = parseTriageMarker(comment.body)
-      return parsed ? { ...parsed, commentId: comment.id } : undefined
+      return parsed
+        ? { ...parsed, account: comment.author, commentId: comment.id }
+        : undefined
     })
     .filter(Boolean) as TriageMarker[]
   const previousMarker = markers.at(-1)
   const mentionReplies = previousMarker
     ? eligibleMentionReplies({
-        account: input.repository.triage?.account ?? "",
+        account: previousMarker.account ?? "",
         comments,
         marker: previousMarker,
         processed: previousMarker.processed,
@@ -905,7 +924,7 @@ async function runReconsiderationVote(input: {
   context: string
   input: TriageRunInput
   outputDir: string
-}): Promise<TriageBinaryVote | undefined> {
+}): Promise<PhaseVoteResult<TriageBinaryVote>> {
   return runPhaseVote<TriageBinaryVote>({
     context: input.context,
     input: input.input,
@@ -918,72 +937,67 @@ async function runReconsiderationVote(input: {
   })
 }
 
-async function composeResultComment(input: {
+function triageReporter(
+  repository: ResolvedRepository,
+  issue: number,
+): ResolvedTriageAgent {
+  const agents = repository.agents.triage ?? []
+  if (!agents.length) throw new Error("triage.agents is required")
+  const configured = repository.triage?.reporter
+  const reporter = configured
+    ? agents.find((agent) => agent.key === configured)
+    : agents[Math.abs(issue) % agents.length]
+
+  if (!reporter) throw new Error(`Unknown triage reporter: ${configured}`)
+
+  return reporter
+}
+
+function decisionCommentBody(input: {
   action: string
-  context: string
-  input: TriageRunInput
-  issue: IssueMeta
-  outputDir: string
-  processed?: number[]
+  reason?: string
   result: FinalResult
-}): Promise<string> {
-  const agents = input.input.repository.agents.triage
-  if (!agents?.length) throw new Error("triage.agents is required")
-  if (
-    input.result.disposition === "ask" &&
-    input.result.askReason === "category_unclear"
-  ) {
-    const language = input.input.repository.language?.toLowerCase() ?? ""
-    const body =
-      language.includes("ja") || language.includes("japanese")
-        ? `@${input.issue.author} 現在の説明だけでは、何をすべきか判断できません。\n\n期待する動作、実際の動作、必要な理由、関連する例・ログ・スクリーンショットなどを追記してください。`
-        : `@${input.issue.author} I can't determine what should be done from the current description.\n\nPlease add more detail, such as the expected behavior, the actual behavior, the reason this is needed, or any relevant examples, logs, or screenshots.`
-    const comment = `${body}\n\n${marker({
-      action: input.action,
-      checkpoint: "pending",
-      decision: input.result,
-      issue: input.issue.number,
-      processed: input.processed,
-    })}`
+}): string {
+  const reason = input.reason?.trim()
+  const result = JSON.stringify(input.result)
 
-    await writeFile(join(input.outputDir, "comment.md"), `${comment}\n`)
-    return comment
-  }
-  const prompt = await (
-    input.result.disposition === "ask"
-      ? composeTriageQuestionPrompt
-      : composeTriageCommentPrompt
-  )({
-    author: input.issue.author,
-    context: input.context,
-    directory: input.input.directory,
-    issue: input.issue.number,
-    repository: input.input.repository,
-  })
-  const comment =
-    (
-      await runModelText({
-        allowEmpty: false,
-        client: input.input.client,
-        model: agents[0].model,
-        options: agents[0].options,
-        permission: agents[0].permission,
-        prompt,
-        signal: input.input.signal,
-        title: `Magi triage comment #${input.issue.number}`,
-      })
-    ).raw +
-    `\n\n${marker({
-      action: input.action,
-      checkpoint: "pending",
-      decision: input.result,
-      issue: input.issue.number,
-      processed: input.processed,
-    })}`
+  return reason
+    ? `Magi triage decision: ${result}\n\nReason: ${reason}`
+    : `Magi triage decision: ${result}\n\nAction: ${input.action}`
+}
 
-  await writeFile(join(input.outputDir, "comment.md"), `${comment}\n`)
+function agentForKey(
+  repository: ResolvedRepository,
+  key: string,
+): ResolvedTriageAgent {
+  const agent = repository.agents.triage?.find((item) => item.key === key)
+  if (!agent) throw new Error(`Unknown triage agent: ${key}`)
 
-  return comment
+  return agent
+}
+
+function askOutputs<T extends string>(
+  outputs: VoteRunOutput<T>[] | undefined,
+): VoteRunOutput<T>[] {
+  return (outputs ?? []).filter((output) => output.vote === "ASK")
+}
+
+function chooseDecisionReason(input: {
+  outputs?: VoteRunOutput<string>[]
+  reporter: ResolvedTriageAgent
+  vote: string
+}): string | undefined {
+  return (
+    input.outputs?.find(
+      (output) =>
+        output.reviewer === input.reporter.key &&
+        output.vote === input.vote &&
+        output.reason,
+    )?.reason ??
+    input.outputs?.find((output) => output.vote === input.vote)?.reason ??
+    input.outputs?.find((output) => output.reviewer === input.reporter.key)
+      ?.reason
+  )
 }
 
 async function postMarkedIssueComment(input: {
@@ -1016,9 +1030,35 @@ async function postMarkedIssueComment(input: {
           body,
         )
 
-  await writeJson(join(input.outputDir, "posted.json"), updated)
+  await writeJson(join(input.outputDir, `posted-${updated.id}.json`), {
+    account: input.account,
+    ...updated,
+  })
 
   return updated
+}
+
+async function postPlainIssueComment(input: {
+  account: string
+  body: string
+  exec: Exec
+  issue: number
+  outputDir: string
+  repository: ResolvedRepository
+}): Promise<{ id: number; url: string }> {
+  const posted = await postIssueComment(
+    input.exec,
+    input.repository,
+    input.issue,
+    input.account,
+    input.body,
+  )
+  await writeJson(join(input.outputDir, `posted-${posted.id}.json`), {
+    account: input.account,
+    ...posted,
+  })
+
+  return posted
 }
 
 async function persistProcessedMarker(input: {
@@ -1065,10 +1105,77 @@ async function persistProcessedMarker(input: {
   })
 }
 
+async function postAskComments(input: {
+  action: string
+  dryRun?: boolean
+  exec: Exec
+  issue: IssueMeta
+  mark: boolean
+  outputs: VoteRunOutput<string>[]
+  outputDir: string
+  processed?: number[]
+  repository: ResolvedRepository
+  result: FinalResult
+  run: TriageRunInput
+}): Promise<string[]> {
+  const urls: string[] = []
+
+  for (const output of askOutputs(input.outputs)) {
+    const agent = agentForKey(input.repository, output.reviewer)
+    const body = input.mark
+      ? `${output.body}\n\n${marker({
+          action: input.action,
+          checkpoint: "pending",
+          decision: input.result,
+          issue: input.issue.number,
+          processed: input.processed,
+        })}`
+      : output.body
+
+    if (!body?.trim()) continue
+
+    await writeFile(
+      join(input.outputDir, `${agent.key}.ask-comment.md`),
+      `${body}\n`,
+    )
+
+    if (input.dryRun) {
+      urls.push(`dry-run:would-comment:${agent.key}`)
+      continue
+    }
+
+    await emitProgress(input.run, { type: "comment_posting" })
+    const posted = input.mark
+      ? await postMarkedIssueComment({
+          account: agent.account,
+          body,
+          exec: input.exec,
+          issue: input.issue.number,
+          outputDir: input.outputDir,
+          repository: input.repository,
+        })
+      : await postPlainIssueComment({
+          account: agent.account,
+          body,
+          exec: input.exec,
+          issue: input.issue.number,
+          outputDir: input.outputDir,
+          repository: input.repository,
+        })
+    urls.push(posted.url)
+    await emitProgress(input.run, { type: "comment_posted", url: posted.url })
+  }
+
+  return urls
+}
+
 async function finishWithResult(input: {
+  askOutputs?: VoteRunOutput<string>[]
+  commentReason?: string
   context: string
   input: TriageRunInput
   issue: IssueMeta
+  markAskComments?: boolean
   outputDir: string
   plan?: ActionPlan
   processed?: number[]
@@ -1093,23 +1200,47 @@ async function finishWithResult(input: {
   })
 
   let prUrl: string | undefined
-  const comment = plan.postComment
-    ? await composeResultComment({
-        action: plan.action,
-        context: `Result: ${decisionText(input.result)}\nAction: ${plan.action}\n\n${input.context}`,
-        input: input.input,
-        issue: input.issue,
-        outputDir: input.outputDir,
-        processed: input.processed,
-        result: input.result,
-      })
-    : undefined
+  const reporter = triageReporter(input.input.repository, input.issue.number)
+  const comment =
+    plan.postComment && input.result.disposition !== "ask"
+      ? `${decisionCommentBody({
+          action: plan.action,
+          reason: input.commentReason,
+          result: input.result,
+        })}\n\n${marker({
+          action: plan.action,
+          checkpoint: "pending",
+          decision: input.result,
+          issue: input.issue.number,
+          processed: input.processed,
+        })}`
+      : undefined
+
+  if (comment) {
+    await writeFile(join(input.outputDir, "comment.md"), `${comment}\n`)
+  }
+
+  if (input.result.disposition === "ask" && input.askOutputs) {
+    await postAskComments({
+      action: plan.action,
+      dryRun: input.input.dryRun,
+      exec: input.input.exec,
+      issue: input.issue,
+      mark: input.markAskComments ?? false,
+      outputs: input.askOutputs,
+      outputDir: input.outputDir,
+      processed: input.processed,
+      repository: input.input.repository,
+      result: input.result,
+      run: input.input,
+    })
+  }
 
   if (!input.input.dryRun) {
     if (comment) {
       await emitProgress(input.input, { type: "comment_posting" })
       const posted = await postMarkedIssueComment({
-        account: triage.account ?? "",
+        account: reporter.account,
         body: comment,
         exec: input.input.exec,
         issue: input.issue.number,
@@ -1133,7 +1264,7 @@ async function finishWithResult(input: {
           input.input.repository,
           input.issue.number,
           clearLabels,
-          triage.account ?? "",
+          reporter.account,
         )
       }
     }
@@ -1146,7 +1277,7 @@ async function finishWithResult(input: {
           input.input.exec,
           input.input.repository,
           pr.number,
-          triage.account ?? "",
+          reporter.account,
         )
         closedPrs.push(pr.number)
       }
@@ -1156,7 +1287,7 @@ async function finishWithResult(input: {
         input.input.exec,
         input.input.repository,
         input.issue.number,
-        triage.account ?? "",
+        reporter.account,
       )
     }
     if (plan.createPr) {
@@ -1173,7 +1304,7 @@ async function finishWithResult(input: {
     }
     if (input.previousMarker && prUrl) {
       await persistProcessedMarker({
-        account: triage.account ?? "",
+        account: input.previousMarker.account ?? reporter.account,
         comments: input.relationship.comments,
         exec: input.input.exec,
         issue: input.issue,
@@ -1245,8 +1376,6 @@ async function createImplementationPr(input: {
 }): Promise<string | undefined> {
   const creator = input.input.repository.agents.triageCreator
   if (!creator) return undefined
-  const triage = input.input.repository.triage
-  if (!triage?.account) throw new Error("triage.account is required")
   await emitProgress(input.input, { type: "pr_creation_started" })
   await emitProgress(input.input, { type: "triage_creator_started" })
 
@@ -1255,7 +1384,7 @@ async function createImplementationPr(input: {
       input.input.exec,
       input.input.repository,
       input.issue.number,
-      triage.account,
+      creator.account,
     )
 
     const branch = `magi/issue-${input.issue.number}-${Date.now().toString(36)}`
@@ -1361,7 +1490,7 @@ export async function runTriage(
   input: TriageRunInput,
 ): Promise<TriageRunResult> {
   const triage = input.repository.triage
-  if (!triage?.account) throw new Error("triage.account is required")
+  if (!triage) throw new Error("triage configuration is required")
   const agents = input.repository.agents.triage
   if (!agents?.length) throw new Error("triage.agents is required")
 
@@ -1412,6 +1541,9 @@ export async function runTriage(
   await emitProgress(input, { phase: "triaging", type: "phase" })
   let processed = relationship.previousMarker?.processed ?? []
   let result: FinalResult | undefined
+  let askCommentOutputs: VoteRunOutput<string>[] | undefined
+  let commentReason: string | undefined
+  let markAskComments = false
 
   if (relationship.previousMarker) {
     if (!relationship.mentionReplies.length) {
@@ -1466,7 +1598,7 @@ export async function runTriage(
     if (!triggeringComments.length) {
       if (!input.dryRun) {
         await persistProcessedMarker({
-          account: triage.account,
+          account: relationship.previousMarker.account ?? "",
           comments: relationship.comments,
           exec: input.exec,
           issue,
@@ -1492,22 +1624,41 @@ export async function runTriage(
       },
     })
     await writeFile(join(outputDir, "context.md"), `${context}\n`)
-    const vote = await runReconsiderationVote({ context, input, outputDir })
     const previous = finalResultFromMarker(relationship.previousMarker)
-    result =
-      vote === "YES"
-        ? { category: previous.category, disposition: "accepted" }
-        : vote === "NO"
-          ? { category: previous.category, disposition: "rejected" }
-          : {
-              askReason: "acceptance_unclear",
-              category: previous.category,
-              disposition: "ask",
-            }
+    if (
+      previous.disposition !== "ask" ||
+      previous.askReason !== "acceptance_unclear"
+    ) {
+      const reconsideration = await runReconsiderationVote({
+        context,
+        input,
+        outputDir,
+      })
+      const reporter = triageReporter(input.repository, issue.number)
+      commentReason = chooseDecisionReason({
+        outputs: reconsideration.outputs,
+        reporter,
+        vote: reconsideration.vote ?? "ASK",
+      })
+      result =
+        reconsideration.vote === "YES"
+          ? { category: previous.category, disposition: "accepted" }
+          : reconsideration.vote === "NO"
+            ? { category: previous.category, disposition: "rejected" }
+            : {
+                askReason: "acceptance_unclear",
+                category: previous.category,
+                disposition: "ask",
+              }
+      if (result.disposition === "ask") {
+        askCommentOutputs = askOutputs(reconsideration.outputs)
+        markAskComments = true
+      }
+    }
   }
 
   if (!result && relationship.relatedPullRequests.length) {
-    const vote = await runPhaseVote<TriageExistingPrVote>({
+    const existingPr = await runPhaseVote<TriageExistingPrVote>({
       context,
       input,
       outputDir,
@@ -1517,7 +1668,7 @@ export async function runTriage(
       schemaName: "triage existing PR",
       votes: EXISTING_PR_VOTES,
     })
-    if (vote === "RELATED_PR_HANDLES_ISSUE") {
+    if (existingPr.vote === "RELATED_PR_HANDLES_ISSUE") {
       const merged = relationship.relatedPullRequests.some(
         (pr) => pr.state === "MERGED",
       )
@@ -1534,81 +1685,21 @@ export async function runTriage(
           createPr: false,
           postComment: true,
         }
-        await emitProgress(input, {
-          action: plan.action,
-          result: relatedPrDecision,
-          type: "decision",
-        })
-        await runActionPrompt({
+        return finishWithResult({
+          commentReason: chooseDecisionReason({
+            outputs: existingPr.outputs,
+            reporter: triageReporter(input.repository, issue.number),
+            vote: "RELATED_PR_HANDLES_ISSUE",
+          }),
           context,
-          input,
-          outputDir,
-          plan,
-          result: relatedPrDecision,
-        })
-        const body = await composeResultComment({
-          action: "CLOSE",
-          context: `Result: ${decisionText(relatedPrDecision)}\nAction: CLOSE\n\n${context}`,
           input,
           issue,
           outputDir,
+          plan,
           processed,
+          relationship,
           result: relatedPrDecision,
         })
-        if (!input.dryRun) {
-          await emitProgress(input, { type: "comment_posting" })
-          const posted = await postMarkedIssueComment({
-            account: triage.account,
-            body,
-            exec: input.exec,
-            issue: issue.number,
-            outputDir,
-            repository: input.repository,
-          })
-          await emitProgress(input, { type: "comment_posted", url: posted.url })
-          const clearLabels = existingClearLabels(
-            issue,
-            triage.automation.clear,
-          )
-
-          if (clearLabels.length) {
-            await removeIssueLabels(
-              input.exec,
-              input.repository,
-              issue.number,
-              clearLabels,
-              triage.account,
-            )
-          }
-          const closedPrs: number[] = []
-          for (const pr of relationship.relatedPullRequests.filter(
-            (pr) => pr.state === "OPEN",
-          )) {
-            await closePullRequest(
-              input.exec,
-              input.repository,
-              pr.number,
-              triage.account,
-            )
-            closedPrs.push(pr.number)
-          }
-          if (closedPrs.length)
-            await writeJson(join(outputDir, "closed-prs.json"), closedPrs)
-          await closeIssue(
-            input.exec,
-            input.repository,
-            issue.number,
-            triage.account,
-          )
-        }
-        const report = `Magi triage closed #${issue.number} because a related PR was merged.`
-        await writeFile(join(outputDir, "report.md"), `${report}\n`)
-        return {
-          issue: issue.number,
-          outputDir,
-          report,
-          result: relatedPrDecision,
-        }
       }
       return finishWithResult({
         context,
@@ -1633,6 +1724,7 @@ export async function runTriage(
     })
     if (duplicate) {
       context = `${context}\n\nDuplicate decision: ${JSON.stringify(duplicate)}`
+      commentReason = duplicate.reason
       result = { category: null, disposition: "duplicate" }
     }
   }
@@ -1643,23 +1735,23 @@ export async function runTriage(
       category: resolvedCategory,
       source: resolvedCategory ? "config" : "vote",
     })
-    const category =
-      resolvedCategory ??
-      (await runPhaseVote<TriageCategoryVote>({
-        context,
-        input,
-        outputDir,
-        parse: (text) =>
-          parseTriageCategoryOutput(
-            text,
-            triage.categories.map((item) => item.id),
-          ),
-        phase: "category",
-        prompt: composeTriageCategoryPrompt,
-        schemaName: "triage category",
-        votes: ["ASK", ...triage.categories.map((item) => item.id)],
-      })) ??
-      "ASK"
+    const categoryVote = resolvedCategory
+      ? undefined
+      : await runPhaseVote<TriageCategoryVote>({
+          context,
+          input,
+          outputDir,
+          parse: (text) =>
+            parseTriageCategoryOutput(
+              text,
+              triage.categories.map((item) => item.id),
+            ),
+          phase: "category",
+          prompt: composeTriageCategoryPrompt,
+          schemaName: "triage category",
+          votes: ["ASK", ...triage.categories.map((item) => item.id)],
+        })
+    const category = resolvedCategory ?? categoryVote?.vote ?? "ASK"
 
     if (category === "ASK") {
       result = {
@@ -1667,6 +1759,8 @@ export async function runTriage(
         category: null,
         disposition: "ask",
       }
+      askCommentOutputs = askOutputs(categoryVote?.outputs)
+      markAskComments = false
     } else {
       const categoryConfig = triage.categories.find(
         (item) => item.id === category,
@@ -1679,7 +1773,7 @@ export async function runTriage(
         null,
         2,
       )
-      const vote = await runPhaseVote<TriageBinaryVote>({
+      const acceptance = await runPhaseVote<TriageBinaryVote>({
         context: voteContext,
         input,
         outputDir,
@@ -1689,23 +1783,36 @@ export async function runTriage(
         schemaName: "triage acceptance",
         votes: BINARY_VOTES,
       })
+      const reporter = triageReporter(input.repository, issue.number)
+      commentReason = chooseDecisionReason({
+        outputs: acceptance.outputs,
+        reporter,
+        vote: acceptance.vote ?? "ASK",
+      })
       result =
-        vote === "YES"
+        acceptance.vote === "YES"
           ? { category, disposition: "accepted" }
-          : vote === "NO"
+          : acceptance.vote === "NO"
             ? { category, disposition: "rejected" }
             : {
                 askReason: "acceptance_unclear",
                 category,
                 disposition: "ask",
               }
+      if (result.disposition === "ask") {
+        askCommentOutputs = askOutputs(acceptance.outputs)
+        markAskComments = true
+      }
     }
   }
 
   return finishWithResult({
+    askOutputs: askCommentOutputs,
+    commentReason,
     context,
     input,
     issue,
+    markAskComments,
     outputDir,
     processed,
     relationship,

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -473,7 +473,6 @@ describe("prompt composer", () => {
       prompts: {},
       safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
       triage: {
-        account: "magi-bot",
         automation: {
           clear: ["triage"],
           close: false,

--- a/src/prompts/contracts.ts
+++ b/src/prompts/contracts.ts
@@ -226,8 +226,13 @@ Return exactly one JSON object and nothing else. Do not wrap it in markdown.
 The object must match this shape:
 {
   "vote": ${votes},
-  "reason": "Short rationale."
+  "reason": "Short rationale.",
+  "body": "Required only when vote is ASK. Public issue comment body asking for the missing information."
 }
+
+Rules:
+- body is required when vote is ASK and must be written for the issue author.
+- Omit body when vote is not ASK.
 </output_contract>`.trim()
 }
 

--- a/src/prompts/output.test.ts
+++ b/src/prompts/output.test.ts
@@ -354,11 +354,17 @@ describe("triage output parsing", () => {
       vote: "bug",
     })
     expect(
-      parseTriageBinaryOutput('{"vote":"ASK","reason":"missing"}'),
+      parseTriageBinaryOutput(
+        '{"vote":"ASK","reason":"missing","body":"Please clarify."}',
+      ),
     ).toEqual({
+      body: "Please clarify.",
       reason: "missing",
       vote: "ASK",
     })
+    expect(() =>
+      parseTriageBinaryOutput('{"vote":"ASK","reason":"missing"}'),
+    ).toThrow("ASK requires body")
   })
 
   test("requires duplicate target for duplicate vote", () => {

--- a/src/prompts/output.ts
+++ b/src/prompts/output.ts
@@ -143,10 +143,15 @@ function parseTriageVote<T extends string>(
   const data = extractJson(text) as Record<string, unknown>
   if (!data || typeof data !== "object")
     throw new Error("triage vote output must be an object")
+  const vote = requireOneOf(data.vote, "vote", votes)
+  const body = data.body == null ? undefined : requireString(data.body, "body")
+
+  if (vote === "ASK" && !body?.trim()) throw new Error("ASK requires body")
 
   return {
+    body,
     reason: requireString(data.reason, "reason"),
-    vote: requireOneOf(data.vote, "vote", votes),
+    vote,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface EditorConfig {
 }
 
 export interface TriageAgentConfig {
+  account: string
   id?: string
   model: string
   options?: ModelOptions
@@ -221,7 +222,6 @@ export interface TriageSafetyConfig {
 }
 
 export interface TriageConfig {
-  account?: string
   agents?: TriageAgentConfig[]
   automation?: TriageAutomationConfig
   categories?: TriageCategoryConfig[]
@@ -229,6 +229,7 @@ export interface TriageConfig {
   creator?: TriageCreatorConfig
   output?: string
   prompts?: TriagePromptConfig
+  reporter?: string
   safety?: TriageSafetyConfig
   worktree?: string
 }
@@ -318,12 +319,12 @@ export interface ResolvedRepository extends RepositoryConfig {
     maxChangedFiles?: number
   }
   triage?: {
-    account?: string
     automation: Required<TriageAutomationConfig>
     categories: ResolvedTriageCategory[]
     concurrency: Required<TriageConcurrencyConfig>
     output?: string
     prompts: TriagePromptConfig
+    reporter?: string
     safety: Required<TriageSafetyConfig>
     worktree?: string
   }
@@ -409,6 +410,7 @@ export interface TriageDecision {
 }
 
 export interface TriageVoteOutput<T extends string = string> {
+  body?: string
   reason: string
   vote: T
 }


### PR DESCRIPTION
Closes #161

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Revise `magi:triage` comment ownership so ASK comments and final decision reports are posted by configured triage agent accounts instead of a shared `triage.account` or first-agent summary model.

## Current behavior (updates)

`magi:triage` uses `triage.account` for posting and marker discovery, while the first triage agent model implicitly generates public result comments.

## New behavior

- Require `triage.agents[].account` and add optional `triage.reporter` using resolved triage agent keys.
- Post category ASK comments from ASK-voting agents without markers.
- Post acceptance ASK comments from ASK-voting agents with markers.
- Post accepted, rejected, duplicate, and merged-related-PR close reports from the selected reporter account with markers.
- Trust markers only from configured triage agent accounts, and use reporter/creator accounts for triage automation.

## Is this a breaking change (Yes/No):

Yes. `triage.account` is removed from the triage flow, and each `triage.agents[]` entry must provide an `account`. ASK-capable triage vote outputs now require `body` when `vote` is `ASK`.

## Additional Information

Tests: `pnpm test`