### PR TITLE
docs(prompts): document merge edit review findings

### DIFF
--- a/docs/prompts/merge/edit.md
+++ b/docs/prompts/merge/edit.md
@@ -10,6 +10,6 @@ Built-in template: [`merge/edit.md`](/src/prompts/templates/merge/edit.md)
 | --------------------- | --------------------------------------- |
 | `{pr}`                | Pull request number.                    |
 | `{owner}` / `{repo}`  | GitHub repository owner and name.       |
-| `{reviewFindings}`    | Blocking review findings to address.   |
+| `{reviewFindings}`    | Blocking review findings to address.    |
 | `{worktreePath}`      | Temporary PR worktree path.             |
 | `{unresolvedThreads}` | JSON list of unresolved review threads. |

--- a/docs/prompts/merge/edit.md
+++ b/docs/prompts/merge/edit.md
@@ -10,5 +10,6 @@ Built-in template: [`merge/edit.md`](/src/prompts/templates/merge/edit.md)
 | --------------------- | --------------------------------------- |
 | `{pr}`                | Pull request number.                    |
 | `{owner}` / `{repo}`  | GitHub repository owner and name.       |
+| `{reviewFindings}`    | Blocking review findings to address.   |
 | `{worktreePath}`      | Temporary PR worktree path.             |
 | `{unresolvedThreads}` | JSON list of unresolved review threads. |


### PR DESCRIPTION
Closes #163

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Document the missing `{reviewFindings}` placeholder for the merge edit prompt.

## Current behavior (updates)

The merge edit prompt documentation lists the available placeholders but omits `{reviewFindings}` even though the built-in template and prompt composer use it.

## New behavior

The placeholder table now includes `{reviewFindings}` as the blocking review findings to address.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change; no tests were run.