### PR TITLE
docs(merge): document close reconsideration prompt

### DIFF
--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -94,27 +94,28 @@ The merge flow also writes the review artifacts listed in [`/magi:review`](revie
 
 Important settings for `/magi:merge`:
 
-| Setting                           | Purpose                                                            |
-| --------------------------------- | ------------------------------------------------------------------ |
-| `merge.editor`                    | Editor agent, model, persona, permissions, GitHub account, author. |
-| `review.agents`                   | Reviewer agents used for initial review and re-review.             |
-| `merge.automation.close`          | Run `gh pr close` after a close decision.                          |
-| `merge.automation.merge`          | Merge or enqueue the PR after approval.                            |
-| `merge.checks.wait`               | Wait for PR checks after editor changes.                           |
-| `review.merge.approvalPolicy`     | Decide readiness by `majority` or `unanimous`.                     |
-| `review.merge.auto`               | Pass `--auto` to `gh pr merge` outside merge queue mode.           |
-| `review.merge.deleteBranch`       | Delete the PR branch during non-queue merges when configured.      |
-| `merge.maxThreadResolutionCycles` | Maximum fix/reply attempts per unresolved review thread.           |
-| `review.merge.queue`              | Enqueue the PR through GitHub GraphQL and poll queue completion.   |
-| `review.merge.method`             | Merge method: `merge`, `squash`, or `rebase`.                      |
-| `merge.prompts.edit`              | Editor prompt template.                                            |
-| `merge.prompts.editGuidelines`    | Shared edit guidance file.                                         |
-| `merge.prompts.ciClassification`  | Post-edit failed-check classification prompt template.             |
-| `review.prompts.rereview`         | Re-review prompt template.                                         |
-| `review.safety.requiredLabels`    | Required PR labels before merge flow.                              |
-| `review.safety.blockedPaths`      | Changed-file glob patterns that block merge flow.                  |
-| `review.safety.maxChangedFiles`   | Maximum changed file count before merge flow is blocked.           |
-| `review.safety.allowAuthors`      | Allowed PR authors when configured.                                |
+| Setting                               | Purpose                                                            |
+| ------------------------------------- | ------------------------------------------------------------------ |
+| `merge.editor`                        | Editor agent, model, persona, permissions, GitHub account, author. |
+| `review.agents`                       | Reviewer agents used for initial review and re-review.             |
+| `merge.automation.close`              | Run `gh pr close` after a close decision.                          |
+| `merge.automation.merge`              | Merge or enqueue the PR after approval.                            |
+| `merge.checks.wait`                   | Wait for PR checks after editor changes.                           |
+| `review.merge.approvalPolicy`         | Decide readiness by `majority` or `unanimous`.                     |
+| `review.merge.auto`                   | Pass `--auto` to `gh pr merge` outside merge queue mode.           |
+| `review.merge.deleteBranch`           | Delete the PR branch during non-queue merges when configured.      |
+| `merge.maxThreadResolutionCycles`     | Maximum fix/reply attempts per unresolved review thread.           |
+| `review.merge.queue`                  | Enqueue the PR through GitHub GraphQL and poll queue completion.   |
+| `review.merge.method`                 | Merge method: `merge`, `squash`, or `rebase`.                      |
+| `merge.prompts.edit`                  | Editor prompt template.                                            |
+| `merge.prompts.editGuidelines`        | Shared edit guidance file.                                         |
+| `merge.prompts.ciClassification`      | Post-edit failed-check classification prompt template.             |
+| `review.prompts.rereview`             | Re-review prompt template.                                         |
+| `review.prompts.closeReconsideration` | Close reconsideration prompt template used during re-review.       |
+| `review.safety.requiredLabels`        | Required PR labels before merge flow.                              |
+| `review.safety.blockedPaths`          | Changed-file glob patterns that block merge flow.                  |
+| `review.safety.maxChangedFiles`       | Maximum changed file count before merge flow is blocked.           |
+| `review.safety.allowAuthors`          | Allowed PR authors when configured.                                |
 
 See [Config](/docs/config.md) for the complete configuration reference.
 


### PR DESCRIPTION
Closes #167

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Documents `review.prompts.closeReconsideration` in the `/magi:merge` important settings table.

## Current behavior (updates)

The merge command docs list re-review prompt settings but omit the close reconsideration prompt used during merge re-review.

## New behavior

The `/magi:merge` configuration table now surfaces `review.prompts.closeReconsideration` with the other important merge settings.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change.