### PR TITLE
docs(merge): document safety_blocked outcome

### DIFF
--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -69,7 +69,7 @@ Merge outcomes:
 | `closed`             | A review or re-review majority was `CLOSE` and Magi ran `gh pr close`.                                                  |
 | `close_requested`    | A review or re-review decision was `CLOSE`, comments were posted, and `merge.automation.close` disabled the close step. |
 | `dequeued`           | With `review.merge.queue: true`, GitHub removed the PR from auto-merge or the merge queue.                              |
-| `safety_blocked`     | A merge safety gate blocked the PR before agent execution.                                                             |
+| `safety_blocked`     | A merge safety gate blocked the PR before agent execution.                                                              |
 | `changes_unresolved` | Unresolved review threads reached the per-thread `merge.maxThreadResolutionCycles` limit without a `MERGE` majority.    |
 | `ci_unresolved`      | Review and approvals completed, but scope-outside CI remained unresolved so Magi did not merge.                         |
 

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -69,6 +69,7 @@ Merge outcomes:
 | `closed`             | A review or re-review majority was `CLOSE` and Magi ran `gh pr close`.                                                  |
 | `close_requested`    | A review or re-review decision was `CLOSE`, comments were posted, and `merge.automation.close` disabled the close step. |
 | `dequeued`           | With `review.merge.queue: true`, GitHub removed the PR from auto-merge or the merge queue.                              |
+| `safety_blocked`     | A merge safety gate blocked the PR before agent execution.                                                             |
 | `changes_unresolved` | Unresolved review threads reached the per-thread `merge.maxThreadResolutionCycles` limit without a `MERGE` majority.    |
 | `ci_unresolved`      | Review and approvals completed, but scope-outside CI remained unresolved so Magi did not merge.                         |
 


### PR DESCRIPTION
Closes #165

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Document the implemented `safety_blocked` `/magi:merge` outcome in the merge outcomes table.

## Current behavior (updates)

The merge command documentation lists implemented merge result statuses but omits `safety_blocked`.

## New behavior

The merge outcomes table now describes `safety_blocked` as the result for PRs blocked by merge safety gates before agent execution.

## Is this a breaking change (Yes/No):

No

## Additional Information

Docs-only change; no tests were run.