### PR TITLE
fix(merge): document sync flag

### DIFF
--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -5,12 +5,15 @@
 ```txt
 /magi:merge <PR...>
 /magi:merge --dry-run <PR...>
+/magi:merge --sync <PR...>
 /magi:merge --no-merge --max-cycles 1 <PR...>
 ```
 
 `<PR...>` accepts one or more PR numbers or PR URLs separated by spaces or commas.
 
 Use `--dry-run` to run review, editor, re-review, majority voting, and reporting without posting to GitHub, pushing editor commits, resolving threads, merging, closing, or rerunning CI jobs. The editor may still modify and commit inside Magi's temporary worktree so reviewers can inspect the local diff.
+
+Use `--sync` to wait for the merge flow to complete and return the run report instead of only starting a background run.
 
 Per-run flags override merged config before validation and resolution. If both positive and negative boolean flags are supplied, the later flag wins. `--dry-run` remains the strongest safety mode and prevents GitHub mutations even when automation-enabling flags are supplied.
 
@@ -25,6 +28,7 @@ Merge flags:
 | `--retry-failed-jobs <n>`                                 | `review.checks.retryFailedJobs`   |
 | `--reviewer-concurrency <n>`                              | `review.concurrency.reviewers`    |
 | `--run-concurrency <n>`                                   | `review.concurrency.runs`         |
+| `--sync`                                                  | Wait for completion               |
 | `--wait-checks`, `--no-wait-checks`                       | `review.checks.wait`              |
 | `--wait-checks-after-edit`, `--no-wait-checks-after-edit` | `merge.checks.wait`               |
 


### PR DESCRIPTION
Closes #171

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Document the `/magi:merge --sync` flag in the merge command usage and flags table.

## Current behavior (updates)

The merge command accepts `--sync`, but the command documentation does not list or explain it.

## New behavior

The merge command documentation now shows `--sync` usage and explains that it waits for completion and returns the run report instead of only starting a background run.

## Is this a breaking change (Yes/No):

No

## Additional Information

Docs-only change.