### PR TITLE
docs(merge): document report artifact

### DIFF
--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -87,6 +87,7 @@ Merge artifacts are written to the run output directory:
 | `{reviewer}.rereview.cycle-{cycle}.raw.txt`    | Raw re-review model output.                  |
 | `{reviewer}.rereview.cycle-{cycle}.json`       | Parsed re-review JSON.                       |
 | `rereview-majority.cycle-{cycle}.json`         | Re-review majority counts and result.        |
+| `report.md`                                    | Final human-readable merge run report.       |
 
 The merge flow also writes the review artifacts listed in [`/magi:review`](review.md).
 


### PR DESCRIPTION
Closes #170

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Documents the merge run `report.md` artifact in the `/magi:merge` command docs.

## Current behavior (updates)

The merge artifact table omitted the final human-readable report even though merge runs write `report.md`.

## New behavior

The merge artifact table now lists `report.md` and describes it as the final human-readable merge run report.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change. Tests were not run because no executable code changed.