### PR TITLE
fix(merge): show merge start message

### DIFF
--- a/.changeset/merge-start-message.md
+++ b/.changeset/merge-start-message.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Show merge-specific wording when asynchronous Magi merge runs start.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,10 @@
 import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import type { MagiConfig } from "./types"
+import type { MagiConfig, ResolvedRepository } from "./types"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 import {
   MagiPlugin,
+  formatRunStartMessage,
   parseIssueRunArguments,
   parseIssues,
   parsePrs,
@@ -208,6 +209,19 @@ describe("parseIssues", () => {
 })
 
 describe("tool descriptions", () => {
+  test("uses command-specific run start messages", () => {
+    const repository = {
+      github: { owner: "owner", repo: "repo" },
+    } as ResolvedRepository
+
+    expect(formatRunStartMessage("merge", repository, 123)).toBe(
+      "Started merge flow [#123](https://github.com/owner/repo/pull/123).",
+    )
+    expect(formatRunStartMessage("review", repository, 123)).toBe(
+      "Started reviewing [#123](https://github.com/owner/repo/pull/123).",
+    )
+  })
+
   test("marks follow-up tools as assistant-facing", async () => {
     const plugin = await MagiPlugin({
       client: { session: {} },

--- a/src/index.ts
+++ b/src/index.ts
@@ -494,6 +494,16 @@ function prMarkdownLink(repository: ResolvedRepository, pr: number): string {
   return `[#${pr}](${url})`
 }
 
+export function formatRunStartMessage(
+  command: "merge" | "review",
+  repository: ResolvedRepository,
+  pr: number,
+): string {
+  const action = command === "merge" ? "merge flow" : "reviewing"
+
+  return `Started ${action} ${prMarkdownLink(repository, pr)}.`
+}
+
 function issueMarkdownLink(
   repository: ResolvedRepository,
   issue: number,
@@ -739,9 +749,8 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           if (sync) return syncResult(runManager, states)
 
           return states
-            .map(
-              (state) =>
-                `Started reviewing ${prMarkdownLink(repository, state.pr as number)}.`,
+            .map((state) =>
+              formatRunStartMessage("merge", repository, state.pr as number),
             )
             .join("\n")
         },
@@ -801,9 +810,8 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           if (sync) return syncResult(runManager, states)
 
           return states
-            .map(
-              (state) =>
-                `Started reviewing ${prMarkdownLink(repository, state.pr as number)}.`,
+            .map((state) =>
+              formatRunStartMessage("review", repository, state.pr as number),
             )
             .join("\n")
         },


### PR DESCRIPTION
Closes #172

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes the asynchronous `/magi:merge` start response so it uses merge-specific wording instead of saying review started.

## Current behavior (updates)

Starting `/magi:merge` without `--sync` returned `Started reviewing ...`, which was misleading for merge runs.

## New behavior

Starting `/magi:merge` without `--sync` now returns `Started merge flow ...`, while `/magi:review` keeps `Started reviewing ...`.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/index.test.ts`.