### PR TITLE
fix(review): reject unsupported review states

### DIFF
--- a/.changeset/reject-unsupported-review-states.md
+++ b/.changeset/reject-unsupported-review-states.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Reject unsupported GitHub review states instead of treating them as close votes.

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -175,6 +175,18 @@ describe("review flow", () => {
     })
   })
 
+  test("rejects unsupported GitHub review states", () => {
+    expect(() =>
+      reviewOutputFromState({
+        author: { login: "bot-a" },
+        body: "Looks fine overall.",
+        commit: { oid: "head" },
+        state: "COMMENTED",
+        submittedAt: "2026-01-01T00:00:00Z",
+      }),
+    ).toThrow("Unsupported GitHub review state: COMMENTED")
+  })
+
   test("detects replies after the reviewer latest thread comment", () => {
     expect(
       hasPendingThreadReply(

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -334,7 +334,7 @@ function reviewStateToVerdict(
   if (state === "APPROVED") return "MERGE"
   if (state === "CHANGES_REQUESTED") return "CHANGES_REQUESTED"
 
-  return "CLOSE"
+  throw new Error(`Unsupported GitHub review state: ${state}`)
 }
 
 function hasBlockingCiReports(reports: CheckWaitReport[]): boolean {


### PR DESCRIPTION
Closes #176

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Reject unsupported GitHub review states when reusing existing reviews instead of silently treating them as close votes.

## Current behavior (updates)

Existing review states other than `APPROVED` and `CHANGES_REQUESTED` fell through to `CLOSE` during skipped review reuse.

## New behavior

Unsupported GitHub review states now fail with a clear error, and unit coverage verifies `COMMENTED` is not mapped to `CLOSE`.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/review.test.ts`.