### PR TITLE
fix(review): preserve reused review findings

### DIFF
--- a/.changeset/preserve-reused-review-findings.md
+++ b/.changeset/preserve-reused-review-findings.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Preserve inline findings when reusing current changes-requested reviews.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -623,6 +623,61 @@ describe("GitHub command helpers", () => {
     expectBalancedBraces(extractGraphqlQuery(graphqlCommand))
   })
 
+  test("normalizes PR review comments from GraphQL review nodes", async () => {
+    const reviews = await fetchPullRequestReviews(
+      async () =>
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: {
+                  nodes: [
+                    {
+                      author: { login: "bot-a" },
+                      body: "Changes requested: 1 inline comment.",
+                      comments: {
+                        nodes: [
+                          {
+                            body: "**Issue:** Keep finding.\n\n**Fix:** Restore it.",
+                            line: 20,
+                            path: "src/orchestrator/review.ts",
+                            startLine: 18,
+                          },
+                        ],
+                      },
+                      commit: { oid: "head" },
+                      state: "CHANGES_REQUESTED",
+                      submittedAt: "2026-01-01T00:00:00Z",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      repository,
+      7557,
+    )
+
+    expect(reviews).toEqual([
+      {
+        author: { login: "bot-a" },
+        body: "Changes requested: 1 inline comment.",
+        comments: [
+          {
+            body: "**Issue:** Keep finding.\n\n**Fix:** Restore it.",
+            line: 20,
+            path: "src/orchestrator/review.ts",
+            startLine: 18,
+          },
+        ],
+        commit: { oid: "head" },
+        state: "CHANGES_REQUESTED",
+        submittedAt: "2026-01-01T00:00:00Z",
+      },
+    ])
+  })
+
   test("passes configured GitHub host to GraphQL requests", async () => {
     let graphqlCommand = ""
     const enterprise = {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -68,9 +68,17 @@ export interface ReviewThreadComment {
 export interface PullRequestReview {
   author: { login: string }
   body?: string
+  comments?: PullRequestReviewComment[]
   commit?: { oid: string }
   state: string
   submittedAt: string
+}
+
+export interface PullRequestReviewComment {
+  body: string
+  line?: number | null
+  path: string
+  startLine?: number | null
 }
 
 export interface PullRequestCommit {
@@ -884,19 +892,30 @@ export async function fetchPullRequestReviews(
   repository: ResolvedRepository,
   pr: number,
 ): Promise<PullRequestReview[]> {
-  const query = `query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviews(first: 100) { nodes { author { login } submittedAt state body commit { oid } } } } } }`
+  const query = `query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviews(first: 100) { nodes { author { login } submittedAt state body commit { oid } comments(first: 100) { nodes { body path line startLine } } } } } } }`
   const raw = await exec(
     `gh api${ghHostOption(repository)} graphql -f query=${shellQuote(query)} -F owner=${shellQuote(repository.github.owner)} -F repo=${shellQuote(repository.github.repo)} -F pr=${pr}`,
   )
   const data = JSON.parse(raw) as {
     data: {
       repository: {
-        pullRequest: { reviews: { nodes: PullRequestReview[] } }
+        pullRequest: {
+          reviews: {
+            nodes: Array<
+              Omit<PullRequestReview, "comments"> & {
+                comments?: { nodes?: PullRequestReviewComment[] }
+              }
+            >
+          }
+        }
       }
     }
   }
 
-  return data.data.repository.pullRequest.reviews.nodes
+  return data.data.repository.pullRequest.reviews.nodes.map((review) => ({
+    ...review,
+    comments: review.comments?.nodes ?? [],
+  }))
 }
 
 export async function fetchPullRequestCommits(

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -156,6 +156,41 @@ describe("review flow", () => {
     })
   })
 
+  test("restores current inline review findings from review comments", () => {
+    expect(
+      reviewOutputFromState({
+        author: { login: "bot-a" },
+        body: "Changes requested: 1 inline comment.",
+        comments: [
+          {
+            body: [
+              "**Issue:** Reused reviews should keep inline findings.",
+              "",
+              "**Fix:** Restore findings from review comments.",
+            ].join("\n"),
+            line: 42,
+            path: "src/orchestrator/review.ts",
+            startLine: 40,
+          },
+        ],
+        commit: { oid: "head" },
+        state: "CHANGES_REQUESTED",
+        submittedAt: "2026-01-01T00:00:00Z",
+      }),
+    ).toEqual({
+      findings: [
+        {
+          fix: "Restore findings from review comments.",
+          issue: "Reused reviews should keep inline findings.",
+          line: 42,
+          path: "src/orchestrator/review.ts",
+          startLine: 40,
+        },
+      ],
+      verdict: "CHANGES_REQUESTED",
+    })
+  })
+
   test("ignores legacy body-only requirement findings without inline targets", () => {
     expect(
       reviewOutputFromState({

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -436,11 +436,54 @@ function reviewFindingsFromBody(
   return { findings }
 }
 
+function parsePostedFindingComment(
+  body: string,
+): Pick<Finding, "fix" | "issue"> | undefined {
+  const match =
+    /^\*\*Issue:\*\*\s*([\s\S]*?)\s*\r?\n\r?\n\*\*Fix:\*\*\s*([\s\S]+?)\s*$/.exec(
+      body,
+    )
+
+  if (!match) return undefined
+
+  return {
+    fix: match[2]?.trim() || "Please address this before merging.",
+    issue: match[1]?.trim() || "Review finding.",
+  }
+}
+
+function reviewFindingsFromComments(
+  comments: PullRequestReview["comments"] | undefined,
+): Pick<ReviewOutput, "findings"> {
+  return {
+    findings: (comments ?? []).flatMap((comment) => {
+      if (comment.line == null) return []
+
+      const parsed = parsePostedFindingComment(comment.body)
+      if (!parsed) return []
+
+      return [
+        {
+          ...parsed,
+          line: comment.line,
+          path: comment.path,
+          startLine: comment.startLine ?? undefined,
+        },
+      ]
+    }),
+  }
+}
+
 export function reviewOutputFromState(review: PullRequestReview): ReviewOutput {
   const verdict = reviewStateToVerdict(review.state)
 
-  if (verdict === "CHANGES_REQUESTED")
+  if (verdict === "CHANGES_REQUESTED") {
+    const fromComments = reviewFindingsFromComments(review.comments)
+
+    if (fromComments.findings.length) return { ...fromComments, verdict }
+
     return { ...reviewFindingsFromBody(review.body), verdict }
+  }
 
   return verdict === "CLOSE"
     ? {


### PR DESCRIPTION
Closes #178

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Preserves findings when `/magi:review` reuses an existing current `CHANGES_REQUESTED` review that was posted with inline comments.

## Current behavior (updates)

Reused changes-requested reviews only reconstructed findings from legacy review body sections, so current summary-only review bodies could produce empty findings.

## New behavior

PR review fetching now includes review inline comments, and reused changes-requested reviews restore findings from those comments before falling back to legacy body parsing.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/review.test.ts src/github/commands.test.ts`.