### PR TITLE
fix(review): align inline target diff ranges

### DIFF
--- a/.changeset/align-review-diff-targets.md
+++ b/.changeset/align-review-diff-targets.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Align review inline target validation with the prompted three-dot diff ranges.

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -2,6 +2,7 @@ import type { PullRequestReview } from "../github/commands"
 import { describe, expect, test } from "vitest"
 import {
   hasPendingThreadReply,
+  inlineCommentTargetsForDiff,
   reviewOutputFromState,
   resolveReviewMode,
   reviewFreshnessTarget,
@@ -128,6 +129,35 @@ describe("review flow", () => {
     )
 
     expect(mode.type).toBe("already_reviewed")
+  })
+
+  test("builds inline targets from the prompted three-dot diff range", async () => {
+    const calls: { command: string; cwd?: string }[] = []
+    const targets = await inlineCommentTargetsForDiff({
+      exec: async (command, options) => {
+        calls.push({ command, cwd: options?.cwd })
+
+        return [
+          "diff --git a/src/app.ts b/src/app.ts",
+          "--- a/src/app.ts",
+          "+++ b/src/app.ts",
+          "@@ -1 +1,2 @@",
+          " existing",
+          "+added",
+        ].join("\n")
+      },
+      fromSha: "base-sha",
+      toSha: "head-sha",
+      worktreePath: "/tmp/worktree",
+    })
+
+    expect(calls).toEqual([
+      {
+        command: "git diff --no-ext-diff --unified=3 'base-sha'...'head-sha'",
+        cwd: "/tmp/worktree",
+      },
+    ])
+    expect(targets.get("src/app.ts")?.has(2)).toBe(true)
   })
 
   test("restores legacy inline review findings from the posted review body", () => {

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -154,6 +154,7 @@ type ReviewerAssignment =
   | { review: PullRequestReview; type: "skip" }
 
 type ReviewEntry = {
+  inlineCommentTargets: InlineCommentTargets
   key: string
   raw: string
   sessionId: string
@@ -377,6 +378,20 @@ function parseRereviewOutputWithInlineTargets(
   validateInlineCommentTargets(output.newFindings, targets, "newFindings")
 
   return output
+}
+
+export async function inlineCommentTargetsForDiff(input: {
+  exec: Exec
+  fromSha: string
+  toSha: string
+  worktreePath: string
+}): Promise<InlineCommentTargets> {
+  return parseRightSideDiffTargets(
+    await input.exec(
+      `git diff --no-ext-diff --unified=3 ${shellQuote(input.fromSha)}...${shellQuote(input.toSha)}`,
+      { cwd: input.worktreePath },
+    ),
+  )
 }
 
 function parsePostedFindingLocation(
@@ -721,7 +736,6 @@ async function runFindingValidation(input: {
 
 async function runCloseReconsideration(input: {
   entries: ReviewEntry[]
-  inlineCommentTargets: InlineCommentTargets
   meta: { baseRefOid: string; headRefOid: string }
   outputDir: string
   reviewContext: string
@@ -809,7 +823,7 @@ async function runCloseReconsideration(input: {
 
               validateInlineCommentTargets(
                 output.findings,
-                input.inlineCommentTargets,
+                entry.inlineCommentTargets,
               )
 
               return output
@@ -856,6 +870,7 @@ async function runCloseReconsideration(input: {
       input.sessionIds[reviewer.key] = result.sessionId
 
       return {
+        inlineCommentTargets: entry.inlineCommentTargets,
         key: entry.key,
         raw: result.raw,
         sessionId: result.sessionId,
@@ -1093,12 +1108,12 @@ export async function runReview(
         return [{ assignment, reviewer }]
       },
     )
-    const inlineCommentTargets = parseRightSideDiffTargets(
-      await exec(
-        `git diff --no-ext-diff --unified=3 ${shellQuote(meta.baseRefOid)} ${shellQuote(meta.headRefOid)}`,
-        { cwd: worktreePath },
-      ),
-    )
+    const initialInlineCommentTargets = await inlineCommentTargetsForDiff({
+      exec,
+      fromSha: meta.baseRefOid,
+      toSha: meta.headRefOid,
+      worktreePath,
+    })
     for (const reviewer of input.repository.agents.reviewers) {
       const assignment = mode.assignments.get(reviewer.account)
       if (assignment?.type !== "skip") continue
@@ -1125,6 +1140,13 @@ export async function runReview(
             throw new Error(
               `Missing previous review commit for ${reviewer.account}`,
             )
+
+          const inlineCommentTargets = await inlineCommentTargetsForDiff({
+            exec,
+            fromSha: previous.commit.oid,
+            toSha: meta.headRefOid,
+            worktreePath,
+          })
 
           const unresolved =
             unresolvedThreadsByAccount.get(reviewer.account) ??
@@ -1213,6 +1235,7 @@ export async function runReview(
           })
 
           return {
+            inlineCommentTargets,
             key: reviewer.key,
             raw: result.raw,
             sessionId: result.sessionId,
@@ -1263,7 +1286,10 @@ export async function runReview(
               },
               options: reviewer.options,
               parse: (text) =>
-                parseReviewOutputWithInlineTargets(text, inlineCommentTargets),
+                parseReviewOutputWithInlineTargets(
+                  text,
+                  initialInlineCommentTargets,
+                ),
               permission: reviewer.permission,
               prompt,
               repairAttempts: input.config.output?.repairAttempts ?? 3,
@@ -1293,6 +1319,7 @@ export async function runReview(
         })
 
         return {
+          inlineCommentTargets: initialInlineCommentTargets,
           key: reviewer.key,
           raw: result.raw,
           sessionId: result.sessionId,
@@ -1338,6 +1365,7 @@ export async function runReview(
         return [
           {
             key: reviewer.key,
+            inlineCommentTargets: initialInlineCommentTargets,
             raw: assignment.review.body ?? "",
             sessionId: "",
             value: reviewOutputFromState(assignment.review),
@@ -1347,7 +1375,6 @@ export async function runReview(
     )
     entries = await runCloseReconsideration({
       entries: [...entries, ...skippedCloseEntries],
-      inlineCommentTargets,
       meta,
       outputDir,
       reviewContext,


### PR DESCRIPTION
Closes #177

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Aligns review inline target validation with the same three-dot diff ranges shown to reviewers.

## Current behavior (updates)

Review prompts instructed agents to inspect three-dot diffs, while inline target validation used a two-dot base/head diff for all review modes.

## New behavior

Initial review validation uses the prompted base/head three-dot diff, and re-review validation uses the prompted previous-head/head three-dot diff for each reviewer.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/review.test.ts`.