### PR TITLE
fix(review): validate rereview new findings

### DIFF
--- a/.changeset/validate-rereview-findings.md
+++ b/.changeset/validate-rereview-findings.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Validate rereview new findings before posting request-changes comments.

--- a/src/orchestrator/findings.test.ts
+++ b/src/orchestrator/findings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { applyFindingValidation } from "./findings"
+import { applyFindingValidation, reviewFindingTargets } from "./findings"
 
 describe("applyFindingValidation", () => {
   test("keeps only findings that reach finding-level majority", () => {
@@ -94,5 +94,118 @@ describe("applyFindingValidation", () => {
     expect(result.outputs.a.findings).toEqual([
       { fix: "fix 2", issue: "issue 2", line: 2, path: "a.ts" },
     ])
+  })
+
+  test("includes rereview new findings in validation targets", () => {
+    expect(
+      reviewFindingTargets({
+        a: {
+          followUps: [],
+          newFindings: [{ body: "issue", line: 1, path: "a.ts" }],
+          resolve: [],
+          verdict: "CHANGES_REQUESTED",
+        },
+      }),
+    ).toEqual([
+      {
+        finding: {
+          fix: "Please address this before merging.",
+          issue: "issue",
+          line: 1,
+          path: "a.ts",
+          startLine: undefined,
+        },
+        findingIndex: 0,
+        reviewer: "a",
+      },
+    ])
+  })
+
+  test("filters rereview new findings using finding-level majority", () => {
+    const result = applyFindingValidation({
+      outputs: {
+        a: {
+          followUps: [],
+          newFindings: [
+            { body: "issue 1", line: 1, path: "a.ts" },
+            { body: "issue 2", line: 2, path: "a.ts" },
+          ],
+          resolve: [],
+          verdict: "CHANGES_REQUESTED",
+        },
+        b: { followUps: [], newFindings: [], resolve: [], verdict: "MERGE" },
+        c: { followUps: [], newFindings: [], resolve: [], verdict: "MERGE" },
+      },
+      reviewerKeys: ["a", "b", "c"],
+      validations: {
+        b: {
+          votes: [
+            { findingIndex: 0, reviewer: "a", vote: "DISAGREE" },
+            { findingIndex: 1, reviewer: "a", vote: "AGREE" },
+          ],
+        },
+        c: {
+          votes: [
+            { findingIndex: 0, reviewer: "a", vote: "DISAGREE" },
+            { findingIndex: 1, reviewer: "a", vote: "DISAGREE" },
+          ],
+        },
+      },
+    })
+
+    expect(result.outputs.a).toMatchObject({
+      newFindings: [{ body: "issue 2", line: 2, path: "a.ts" }],
+      verdict: "CHANGES_REQUESTED",
+    })
+  })
+
+  test("turns rereview into merge when all new findings are rejected", () => {
+    const result = applyFindingValidation({
+      outputs: {
+        a: {
+          followUps: [],
+          newFindings: [{ body: "issue", line: 1, path: "a.ts" }],
+          resolve: [],
+          verdict: "CHANGES_REQUESTED",
+        },
+        b: { followUps: [], newFindings: [], resolve: [], verdict: "MERGE" },
+        c: { followUps: [], newFindings: [], resolve: [], verdict: "MERGE" },
+      },
+      reviewerKeys: ["a", "b", "c"],
+      validations: {
+        b: { votes: [{ findingIndex: 0, reviewer: "a", vote: "DISAGREE" }] },
+        c: { votes: [{ findingIndex: 0, reviewer: "a", vote: "DISAGREE" }] },
+      },
+    })
+
+    expect(result.outputs.a).toMatchObject({
+      newFindings: [],
+      verdict: "MERGE",
+    })
+  })
+
+  test("keeps rereview changes requested when follow-ups remain", () => {
+    const result = applyFindingValidation({
+      outputs: {
+        a: {
+          followUps: [{ body: "Please still update this.", commentId: 1 }],
+          newFindings: [{ body: "issue", line: 1, path: "a.ts" }],
+          resolve: [],
+          verdict: "CHANGES_REQUESTED",
+        },
+        b: { followUps: [], newFindings: [], resolve: [], verdict: "MERGE" },
+        c: { followUps: [], newFindings: [], resolve: [], verdict: "MERGE" },
+      },
+      reviewerKeys: ["a", "b", "c"],
+      validations: {
+        b: { votes: [{ findingIndex: 0, reviewer: "a", vote: "DISAGREE" }] },
+        c: { votes: [{ findingIndex: 0, reviewer: "a", vote: "DISAGREE" }] },
+      },
+    })
+
+    expect(result.outputs.a).toMatchObject({
+      newFindings: [],
+      verdict: "CHANGES_REQUESTED",
+    })
   })
 })

--- a/src/orchestrator/findings.ts
+++ b/src/orchestrator/findings.ts
@@ -1,5 +1,12 @@
-import type { Finding, FindingValidationOutput, ReviewOutput } from "../types"
+import type {
+  Finding,
+  FindingValidationOutput,
+  RereviewOutput,
+  ReviewOutput,
+} from "../types"
 import { majorityThreshold } from "./majority"
+
+type ValidatedOutput = RereviewOutput | ReviewOutput
 
 export interface FindingValidationTarget {
   finding: Finding
@@ -12,13 +19,25 @@ export interface FindingValidationSummary {
   kept: FindingValidationTarget[]
 }
 
+function validationFindings(output: ValidatedOutput): Finding[] {
+  if ("findings" in output) return output.findings
+
+  return output.newFindings.map((finding) => ({
+    fix: "Please address this before merging.",
+    issue: finding.body,
+    line: finding.line,
+    path: finding.path,
+    startLine: finding.startLine,
+  }))
+}
+
 export function reviewFindingTargets(
-  outputs: Record<string, ReviewOutput>,
+  outputs: Record<string, ValidatedOutput>,
 ): FindingValidationTarget[] {
   return Object.entries(outputs).flatMap(([reviewer, output]) => {
     if (output.verdict !== "CHANGES_REQUESTED") return []
 
-    return output.findings.map((finding, findingIndex) => ({
+    return validationFindings(output).map((finding, findingIndex) => ({
       finding,
       findingIndex,
       reviewer,
@@ -66,11 +85,27 @@ export function applyFindingValidation(input: {
 }): {
   outputs: Record<string, ReviewOutput>
   summary: FindingValidationSummary
+}
+export function applyFindingValidation(input: {
+  outputs: Record<string, ValidatedOutput>
+  reviewerKeys: string[]
+  validations: Record<string, FindingValidationOutput>
+}): {
+  outputs: Record<string, ValidatedOutput>
+  summary: FindingValidationSummary
+}
+export function applyFindingValidation(input: {
+  outputs: Record<string, ValidatedOutput>
+  reviewerKeys: string[]
+  validations: Record<string, FindingValidationOutput>
+}): {
+  outputs: Record<string, ValidatedOutput>
+  summary: FindingValidationSummary
 } {
   const threshold = majorityThreshold(input.reviewerKeys.length)
   const kept: FindingValidationTarget[] = []
   const discarded: FindingValidationTarget[] = []
-  const next: Record<string, ReviewOutput> = {}
+  const next: Record<string, ValidatedOutput> = {}
 
   for (const [reviewer, output] of Object.entries(input.outputs)) {
     if (output.verdict !== "CHANGES_REQUESTED") {
@@ -78,7 +113,10 @@ export function applyFindingValidation(input: {
       continue
     }
 
-    const findings = output.findings.filter((finding, findingIndex) => {
+    const keptIndexes = new Set<number>()
+    const findings = validationFindings(output)
+
+    findings.forEach((finding, findingIndex) => {
       let agrees = 1
 
       for (const validator of input.reviewerKeys) {
@@ -96,16 +134,31 @@ export function applyFindingValidation(input: {
 
       if (agrees >= threshold) {
         kept.push(target)
-        return true
+        keptIndexes.add(findingIndex)
+        return
       }
 
       discarded.push(target)
-      return false
     })
 
-    next[reviewer] = findings.length
-      ? { ...output, findings }
-      : { findings: [], verdict: "MERGE" }
+    if ("findings" in output) {
+      const keptFindings = output.findings.filter((_finding, index) =>
+        keptIndexes.has(index),
+      )
+
+      next[reviewer] = keptFindings.length
+        ? { ...output, findings: keptFindings }
+        : { findings: [], verdict: "MERGE" }
+      continue
+    }
+
+    const newFindings = output.newFindings.filter((_finding, index) =>
+      keptIndexes.has(index),
+    )
+    next[reviewer] =
+      newFindings.length || output.followUps.length
+        ? { ...output, newFindings }
+        : { ...output, newFindings, verdict: "MERGE" }
   }
 
   return { outputs: next, summary: { discarded, kept } }

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -559,12 +559,10 @@ async function runFindingValidation(input: {
   outputs: Record<string, RereviewOutput | ReviewOutput>
   summary: FindingValidationSummary
 }> {
-  const reviewOutputs = Object.fromEntries(
-    input.entries.flatMap((entry) =>
-      isReviewOutput(entry.value) ? [[entry.key, entry.value]] : [],
-    ),
-  ) as Record<string, ReviewOutput>
-  const targets = reviewFindingTargets(reviewOutputs)
+  const outputs = Object.fromEntries(
+    input.entries.map((entry) => [entry.key, entry.value]),
+  )
+  const targets = reviewFindingTargets(outputs)
 
   if (!targets.length) {
     return {
@@ -682,7 +680,7 @@ async function runFindingValidation(input: {
     ),
   )
   const filtered = applyFindingValidation({
-    outputs: reviewOutputs,
+    outputs,
     reviewerKeys: input.reviewInput.repository.agents.reviewers.map(
       (reviewer) => reviewer.key,
     ),
@@ -697,7 +695,7 @@ async function runFindingValidation(input: {
   await input.reviewInput.onProgress?.({
     discarded: filtered.summary.discarded.length,
     kept: filtered.summary.kept.length,
-    reviewersChangedToMerge: Object.entries(reviewOutputs)
+    reviewersChangedToMerge: Object.entries(outputs)
       .filter(([reviewer, output]) => {
         return (
           output.verdict === "CHANGES_REQUESTED" &&


### PR DESCRIPTION
Closes #175

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Validate rereview `newFindings` through the existing finding-level majority filter before request-changes comments are posted.

## Current behavior (updates)

Rereview `newFindings` were posted directly by `/magi:review` without the same cross-reviewer validation used for initial findings.

## New behavior

Rereview `newFindings` are converted into validation targets, filtered by majority votes, and only retained findings can be posted as request-changes comments.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/findings.test.ts src/orchestrator/review.test.ts`.