### PR TITLE
fix(ci): fail on classifier agent errors

### DIFF
--- a/.changeset/fail-ci-classifier-errors.md
+++ b/.changeset/fail-ci-classifier-errors.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Fail CI classification when any classifier agent fails instead of ignoring the failed vote.

--- a/src/orchestrator/ci.test.ts
+++ b/src/orchestrator/ci.test.ts
@@ -779,7 +779,8 @@ describe("check handling", () => {
     ])
   })
 
-  test("does not convert classifier failures to scope-in", async () => {
+  test("fails when any classifier agent fails", async () => {
+    const failures: string[] = []
     const failed = [
       {
         bucket: "fail",
@@ -794,8 +795,26 @@ describe("check handling", () => {
       waitForChecksWithClassification({
         client: {
           session: {
-            create: async () => ({ id: "session" }),
-            prompt: async () => ({ parts: [] }),
+            create: async (input) => ({
+              id: input.body.title.includes(" a") ? "session-a" : "session",
+            }),
+            prompt: async (input) => {
+              if (input.path.id === "session-a") return { parts: [] }
+
+              return {
+                info: {
+                  text: JSON.stringify({
+                    checks: [
+                      {
+                        classification: "SCOPE_OUT",
+                        name: "Test",
+                        reason: "Unrelated transient failure.",
+                      },
+                    ],
+                  }),
+                },
+              }
+            },
           },
         },
         directory: ".",
@@ -808,15 +827,27 @@ describe("check handling", () => {
         },
         pr: 1,
         repairAttempts: 0,
+        onClassifierProgress: (progress) => {
+          if (progress.type === "classifier_failed") {
+            failures.push(progress.error)
+          }
+        },
         wait: true,
         repository: {
           ...repository,
           checks: { ...repository.checks, retryFailedJobs: 0 },
           agents: {
-            reviewers: [reviewer({ account: "a", key: "a" })],
+            reviewers: [
+              reviewer({ account: "a", key: "a" }),
+              reviewer({ account: "b", index: 1, key: "b" }),
+              reviewer({ account: "c", index: 2, key: "c" }),
+            ],
           },
         },
       }),
-    ).rejects.toThrow("CI classification did not reach majority for Test")
+    ).rejects.toThrow("OpenCode session.prompt did not return text output")
+    expect(failures).toEqual([
+      "OpenCode session.prompt did not return text output",
+    ])
   })
 })

--- a/src/orchestrator/ci.ts
+++ b/src/orchestrator/ci.ts
@@ -600,7 +600,7 @@ async function classifyChecks(input: {
           type: "classifier_failed",
         })
 
-        return { reviewer: reviewer.key, output: undefined }
+        throw error
       }
     },
     { signal: input.signal },
@@ -609,9 +609,8 @@ async function classifyChecks(input: {
 
   return {
     classified: input.checks.map((item) => {
-      const successfulVotes = votes.filter((vote) => vote.output)
-      const checkVotes = successfulVotes.map((vote) => {
-        const check = vote.output?.checks.find(
+      const checkVotes = votes.map((vote) => {
+        const check = vote.output.checks.find(
           (output) => output.name === item.check.name,
         )
 
@@ -622,7 +621,6 @@ async function classifyChecks(input: {
           reviewer: vote.reviewer,
         }
       })
-      const failures = votes.filter((vote) => !vote.output)
       const scopeIn = checkVotes.filter(
         (vote) => vote.classification === "SCOPE_IN",
       )
@@ -644,9 +642,6 @@ async function classifyChecks(input: {
       const reasons = checkVotes
         .filter((vote) => vote.classification === classification)
         .map((vote) => `${vote.reviewer}: ${vote.reason}`)
-      for (const failure of failures) {
-        reasons.push(`${failure.reviewer}: classifier failed; vote ignored`)
-      }
 
       return {
         check: item.check,


### PR DESCRIPTION
Closes #180

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Make CI classification fail the active run when any configured classifier agent fails, matching reviewer and editor failure handling.

## Current behavior (updates)

Failed classifier model runs were caught, recorded as failed, and then converted into ignored votes that could allow classification to continue.

## New behavior

Classifier failures are reported through progress and rethrown immediately, so review or merge orchestration fails instead of continuing with an ignored vote.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/ci.test.ts`.