### PR TITLE
fix(triage): enforce background run concurrency

### DIFF
--- a/.changeset/curly-masks-wait.md
+++ b/.changeset/curly-masks-wait.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Enforce configured triage run concurrency for background triage commands.

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -298,6 +298,112 @@ describe("MagiRunManager notifications", () => {
     }
   })
 
+  test("limits background triage runs to configured concurrency", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-triage-queue-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const repository = sampleTriageRepository({
+      clear: ["triage"],
+      close: false,
+      create: false,
+      merge: false,
+      review: false,
+    })
+    repository.triage!.concurrency.runs = 2
+    const resolvers: Array<(value: unknown) => void> = []
+    runTriageMock.mockImplementation((input) => {
+      return new Promise((resolve) => {
+        resolvers.push(() =>
+          resolve({
+            issue: input.issue,
+            outputDir: join(directory, `triage-${input.issue}`),
+            report: "Triage report",
+            result: { category: "bug", disposition: "accepted" },
+          }),
+        )
+      })
+    })
+
+    try {
+      for (const issue of [1, 2, 3]) {
+        await manager.startTriage({
+          config: { github: { owner: "owner", repo: "repo" } },
+          issue,
+          repository,
+        })
+      }
+
+      await vi.waitFor(() => expect(runTriageMock).toHaveBeenCalledTimes(2))
+      expect(runTriageMock.mock.calls.map(([input]) => input.issue)).toEqual([
+        1, 2,
+      ])
+
+      resolvers[0]?.({})
+
+      await vi.waitFor(() => expect(runTriageMock).toHaveBeenCalledTimes(3))
+      expect(runTriageMock.mock.calls.map(([input]) => input.issue)).toEqual([
+        1, 2, 3,
+      ])
+
+      resolvers[1]?.({})
+      resolvers[2]?.({})
+      await vi.waitFor(() => expect(resolvers).toHaveLength(3))
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("skips cancelled queued background triage runs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-triage-cancel-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const repository = sampleTriageRepository({
+      clear: ["triage"],
+      close: false,
+      create: false,
+      merge: false,
+      review: false,
+    })
+    repository.triage!.concurrency.runs = 1
+    const resolvers: Array<(value: unknown) => void> = []
+    runTriageMock.mockImplementation((input) => {
+      return new Promise((resolve) => {
+        resolvers.push(() =>
+          resolve({
+            issue: input.issue,
+            outputDir: join(directory, `triage-${input.issue}`),
+            report: "Triage report",
+            result: { category: "bug", disposition: "accepted" },
+          }),
+        )
+      })
+    })
+
+    try {
+      const states = []
+      for (const issue of [1, 2, 3]) {
+        states.push(
+          await manager.startTriage({
+            config: { github: { owner: "owner", repo: "repo" } },
+            issue,
+            repository,
+          }),
+        )
+      }
+
+      await vi.waitFor(() => expect(runTriageMock).toHaveBeenCalledTimes(1))
+      await manager.cancel(states[1]!.runId)
+      resolvers[0]?.({})
+
+      await vi.waitFor(() => expect(runTriageMock).toHaveBeenCalledTimes(2))
+      expect(runTriageMock.mock.calls.map(([input]) => input.issue)).toEqual([
+        1, 3,
+      ])
+
+      resolvers[1]?.({})
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   test("marks synchronous runs failed when execution fails", async () => {
     const directory = await mkdtemp(join(tmpdir(), "magi-sync-fail-"))
     const { manager } = managerWithPromptCapture(directory)

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -125,6 +125,12 @@ type NumberFilter = number | number[]
 
 export interface MagiClearOptions extends Required<ClearConfig> {}
 
+interface QueuedTriageRun {
+  execute: () => Promise<void>
+  repository: ResolvedRepository
+  runId: string
+}
+
 export interface MagiClearSummary {
   branchDeleted: number
   branchFailed: number
@@ -688,6 +694,7 @@ function extractQuestionRequest(
 
 export class MagiRunManager {
   private active = new Map<string, MagiRunState>()
+  private activeTriageRuns = 0
   private countedToolParts = new Map<string, Set<string>>()
   private controllers = new Map<string, AbortController>()
   private eventLastUpdates = new Map<string, number>()
@@ -695,6 +702,7 @@ export class MagiRunManager {
   private runPaths = new Map<string, string>()
   private outputDirs = new Set<string>()
   private sessionToRun = new Map<string, { agent: string; runId: string }>()
+  private triageQueue: QueuedTriageRun[] = []
 
   constructor(
     private readonly input: {
@@ -931,11 +939,38 @@ export class MagiRunManager {
     if (input.sync)
       return this.executeSync(state, controller, execute, input.timeoutMs)
 
-    void execute().catch(async (error) => {
-      await this.failRun(runId, error)
+    this.triageQueue.push({
+      execute,
+      repository: input.repository,
+      runId,
     })
+    this.drainTriageQueue()
 
     return state
+  }
+
+  private drainTriageQueue(): void {
+    while (this.triageQueue.length) {
+      const next = this.triageQueue[0]
+      if (!next) return
+      const limit = next.repository.triage?.concurrency.runs ?? 1
+      if (this.activeTriageRuns >= limit) return
+      this.triageQueue.shift()
+
+      const state = this.active.get(next.runId)
+      if (!state || state.status === "cancelled") continue
+
+      this.activeTriageRuns += 1
+      void next
+        .execute()
+        .catch(async (error) => {
+          await this.failRun(next.runId, error)
+        })
+        .finally(() => {
+          this.activeTriageRuns -= 1
+          this.drainTriageQueue()
+        })
+    }
   }
 
   async status(


### PR DESCRIPTION
Closes #204

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a background triage execution queue so non-sync triage runs respect the configured `triage.concurrency.runs` limit.

## Current behavior (updates)

Background `/magi:triage` starts could release the `mapPool` slot immediately because `startTriage()` returned before the actual triage work finished, allowing more runs than configured to execute at once.

## New behavior

Non-sync triage starts persist queued run state and enqueue execution through `MagiRunManager`. The queue starts only up to the configured run concurrency, drains when active triage executions finish, and skips queued runs that were cancelled before starting. Sync behavior is unchanged.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/run-manager.test.ts`.