### PR TITLE
refactor(github): remove legacy check wait helpers

### DIFF
--- a/.changeset/remove-legacy-check-wait.md
+++ b/.changeset/remove-legacy-check-wait.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Remove unused legacy check-wait helpers from GitHub command utilities.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -22,7 +22,6 @@ import {
   repoSpecifier,
   searchDuplicateIssues,
   shellQuote,
-  waitForChecks,
   waitForMergeQueue,
 } from "./commands"
 
@@ -1034,57 +1033,5 @@ describe("createWorktree", () => {
     } finally {
       await removePath(root, { force: true, recursive: true })
     }
-  })
-})
-
-describe("waitForChecks", () => {
-  test("returns an empty report when checks pass", async () => {
-    const commands: string[] = []
-    const result = await waitForChecks(
-      async (command) => {
-        commands.push(command)
-        return ""
-      },
-      repository,
-      1,
-    )
-
-    expect(result).toEqual({
-      attempts: 0,
-      excluded: [],
-      failed: [],
-      rerun: [],
-      scopeInside: [],
-      scopeOutsideRecovered: [],
-      scopeOutsideUnresolved: [],
-    })
-    expect(commands).toHaveLength(1)
-    expect(commands[0]).toContain("gh pr checks 1")
-  })
-
-  test("returns failed checks without classifying or rerunning", async () => {
-    const failed = [
-      {
-        bucket: "fail",
-        link: "https://github.com/owner/repo/actions/runs/1/job/123",
-        name: "Test",
-        state: "FAILURE",
-        workflow: "CI",
-      },
-    ]
-
-    const result = await waitForChecks(
-      async (command) => {
-        if (command.includes("--watch")) throw new Error("checks failed")
-        if (command.includes("--json")) return JSON.stringify(failed)
-
-        return ""
-      },
-      repository,
-      1,
-    )
-
-    expect(result?.failed).toEqual(failed)
-    expect(result?.rerun).toEqual([])
   })
 })

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -980,37 +980,6 @@ export async function fetchPullRequestSafetyMeta(
   return { author, changedFiles, files, labels }
 }
 
-export async function waitForChecks(
-  exec: Exec,
-  repository: ResolvedRepository,
-  pr: number,
-  enabled = repository.checks.waitBeforeReview,
-): Promise<CheckWaitReport | undefined> {
-  if (!enabled) return undefined
-
-  const report: CheckWaitReport = {
-    attempts: 0,
-    excluded: [],
-    failed: [],
-    rerun: [],
-    scopeInside: [],
-    scopeOutsideRecovered: [],
-    scopeOutsideUnresolved: [],
-  }
-
-  try {
-    await watchChecks(exec, repository, pr)
-    return report
-  } catch {
-    report.failed = applyCheckExclusions({
-      checks: await fetchFailedChecks(exec, repository, pr),
-      excluded: report.excluded,
-      patterns: repository.checks.exclude,
-    })
-    return report
-  }
-}
-
 export async function watchChecks(
   exec: Exec,
   repository: ResolvedRepository,
@@ -1018,18 +987,6 @@ export async function watchChecks(
 ): Promise<void> {
   await exec(
     `gh pr checks ${pr} --repo ${shellQuote(repoSpecifier(repository))} --watch`,
-  )
-}
-
-export async function fetchFailedChecks(
-  exec: Exec,
-  repository: ResolvedRepository,
-  pr: number,
-): Promise<PullRequestCheck[]> {
-  const checks = await fetchPullRequestChecks(exec, repository, pr)
-
-  return checks.filter(
-    (check) => isFailedCheck(check) || isCancelledCheck(check),
   )
 }
 


### PR DESCRIPTION
Closes #182

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Remove the unused legacy check-wait helpers from GitHub command utilities and delete their dedicated tests.

## Current behavior (updates)

`src/github/commands.ts` exported `waitForChecks` and `fetchFailedChecks`, but active review and merge orchestration use `waitForChecksWithClassification` from `src/orchestrator/ci.ts`.

## New behavior

The unused legacy helpers are no longer exported or tested. The active CI classification flow remains unchanged.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/github/commands.test.ts`.