### PR TITLE
fix(tools): require explicit sync timeout

### DIFF
--- a/.changeset/quiet-badgers-drum.md
+++ b/.changeset/quiet-badgers-drum.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Only apply synchronous Magi start timeouts when users pass an explicit --timeout flag.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -52,18 +52,31 @@ describe("parsePrs", () => {
       dryRun: true,
       prs: [7581],
       sync: false,
+      timeoutMs: undefined,
     })
     expect(parseRunArguments("7581", true)).toEqual({
       configOverrides: {},
       dryRun: true,
       prs: [7581],
       sync: false,
+      timeoutMs: undefined,
     })
     expect(parseRunArguments("--sync 7581", false)).toEqual({
       configOverrides: {},
       dryRun: false,
       prs: [7581],
       sync: true,
+      timeoutMs: undefined,
+    })
+  })
+
+  test("parses explicit review timeout flag", () => {
+    expect(parseRunArguments("--sync --timeout 600 7581", false)).toEqual({
+      configOverrides: {},
+      dryRun: false,
+      prs: [7581],
+      sync: true,
+      timeoutMs: 600_000,
     })
   })
 
@@ -84,6 +97,19 @@ describe("parsePrs", () => {
       dryRun: false,
       prs: [7581],
       sync: false,
+      timeoutMs: undefined,
+    })
+  })
+
+  test("parses explicit merge timeout flag", () => {
+    expect(
+      parseRunArguments("7581 --sync --timeout 120", false, "merge"),
+    ).toEqual({
+      configOverrides: {},
+      dryRun: false,
+      prs: [7581],
+      sync: true,
+      timeoutMs: 120_000,
     })
   })
 
@@ -107,6 +133,7 @@ describe("parsePrs", () => {
       dryRun: false,
       prs: [7581],
       sync: false,
+      timeoutMs: undefined,
     })
   })
 
@@ -158,12 +185,24 @@ describe("parseIssues", () => {
       dryRun: true,
       issues: [47],
       sync: false,
+      timeoutMs: undefined,
     })
     expect(parseIssueRunArguments("47 --sync", false)).toEqual({
       configOverrides: {},
       dryRun: false,
       issues: [47],
       sync: true,
+      timeoutMs: undefined,
+    })
+  })
+
+  test("parses explicit triage timeout flag", () => {
+    expect(parseIssueRunArguments("47 --sync --timeout 300", false)).toEqual({
+      configOverrides: {},
+      dryRun: false,
+      issues: [47],
+      sync: true,
+      timeoutMs: 300_000,
     })
   })
 
@@ -188,6 +227,7 @@ describe("parseIssues", () => {
       dryRun: false,
       issues: [47],
       sync: false,
+      timeoutMs: undefined,
     })
   })
 
@@ -213,7 +253,10 @@ describe("tool descriptions", () => {
       client: { session: {} },
       directory: ".",
     } as never)
-    const tools = plugin.tool as Record<string, { description: string }>
+    const tools = plugin.tool as Record<
+      string,
+      { args?: Record<string, unknown>; description: string }
+    >
 
     expect(tools.magi_review.description).toContain(
       "do not tell users to call follow-up tools by name",
@@ -221,6 +264,11 @@ describe("tool descriptions", () => {
     expect(tools.magi_merge.description).toContain(
       "do not tell users to call follow-up tools by name",
     )
+    for (const name of ["magi_review", "magi_merge", "magi_triage"]) {
+      expect(Object.keys(tools[name]?.args ?? {})).not.toContain(
+        "timeoutSeconds",
+      )
+    }
     for (const name of ["magi_status", "magi_output", "magi_cancel"]) {
       expect(tools[name]?.description).toContain(
         "Assistant-facing follow-up tool.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ interface ParsedRunArguments {
   dryRun: boolean
   prs: number[]
   sync: boolean
+  timeoutMs?: number
 }
 
 interface ParsedIssueRunArguments {
@@ -51,6 +52,7 @@ interface ParsedIssueRunArguments {
   dryRun: boolean
   issues: number[]
   sync: boolean
+  timeoutMs?: number
 }
 
 type ModelCatalogClient = {
@@ -167,6 +169,7 @@ export function parseRunArguments(
   const configOverrides: Record<string, unknown> = {}
   const prTokens: string[] = []
   let sync = false
+  let timeoutMs: number | undefined
 
   for (let index = 0; index < tokens.length; index++) {
     const token = tokens[index]!
@@ -187,6 +190,11 @@ export function parseRunArguments(
           ["language"],
           nextFlagValue(tokens, ++index, token),
         )
+        break
+      case "--timeout":
+        timeoutMs =
+          parseIntegerFlag(nextFlagValue(tokens, ++index, token), token, 0) *
+          1_000
         break
       case "--merge":
       case "--no-merge":
@@ -259,7 +267,13 @@ export function parseRunArguments(
     }
   }
 
-  return { configOverrides, dryRun, prs: parsePrs(prTokens.join(" ")), sync }
+  return {
+    configOverrides,
+    dryRun,
+    prs: parsePrs(prTokens.join(" ")),
+    sync,
+    timeoutMs,
+  }
 }
 
 export function parseIssueRunArguments(
@@ -270,6 +284,7 @@ export function parseIssueRunArguments(
   const configOverrides: Record<string, unknown> = {}
   const issueTokens: string[] = []
   let sync = false
+  let timeoutMs: number | undefined
 
   for (let index = 0; index < tokens.length; index++) {
     const token = tokens[index]!
@@ -290,6 +305,11 @@ export function parseIssueRunArguments(
           ["language"],
           nextFlagValue(tokens, ++index, token),
         )
+        break
+      case "--timeout":
+        timeoutMs =
+          parseIntegerFlag(nextFlagValue(tokens, ++index, token), token, 0) *
+          1_000
         break
       case "--close":
       case "--no-close":
@@ -349,6 +369,7 @@ export function parseIssueRunArguments(
     dryRun,
     issues: parseIssues(issueTokens.join(" ")),
     sync,
+    timeoutMs,
   }
 }
 
@@ -688,7 +709,6 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
           sync: tool.schema.boolean().optional(),
-          timeoutSeconds: tool.schema.number().optional(),
         },
         async execute(args, context) {
           const parsed = parseRunArguments(
@@ -729,10 +749,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 parentSessionId: context.sessionID,
                 signal: context.abort,
                 sync,
-                timeoutMs:
-                  args.timeoutSeconds == null
-                    ? undefined
-                    : args.timeoutSeconds * 1_000,
+                timeoutMs: parsed.timeoutMs,
               }),
             { signal: context.abort },
           )
@@ -755,7 +772,6 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           prs: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
           sync: tool.schema.boolean().optional(),
-          timeoutSeconds: tool.schema.number().optional(),
         },
         async execute(args, context) {
           const parsed = parseRunArguments(args.prs, args.dryRun ?? false)
@@ -791,10 +807,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 parentSessionId: context.sessionID,
                 signal: context.abort,
                 sync,
-                timeoutMs:
-                  args.timeoutSeconds == null
-                    ? undefined
-                    : args.timeoutSeconds * 1_000,
+                timeoutMs: parsed.timeoutMs,
               }),
             { signal: context.abort },
           )
@@ -815,7 +828,6 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           issues: tool.schema.string(),
           dryRun: tool.schema.boolean().optional(),
           sync: tool.schema.boolean().optional(),
-          timeoutSeconds: tool.schema.number().optional(),
         },
         async execute(args, context) {
           const parsed = parseIssueRunArguments(
@@ -865,10 +877,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
                 repository,
                 signal: context.abort,
                 sync,
-                timeoutMs:
-                  args.timeoutSeconds == null
-                    ? undefined
-                    : args.timeoutSeconds * 1_000,
+                timeoutMs: parsed.timeoutMs,
               }),
             { signal: context.abort },
           )


### PR DESCRIPTION
Closes #211

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Prevents Magi start tools from accepting orchestrator-provided structured sync timeouts. Review, merge, and triage now only pass a sync timeout when the user includes an explicit `--timeout <seconds>` flag in the PR or issue argument text.

## Current behavior (updates)

`magi_review`, `magi_merge`, and `magi_triage` exposed `timeoutSeconds` as a structured tool argument, which allowed assistants to provide a timeout even when the user did not ask for one.

## New behavior

The start tools no longer expose `timeoutSeconds`. `parseRunArguments` and `parseIssueRunArguments` parse `--timeout <seconds>` into `timeoutMs`, and leave it unset when no explicit flag is present.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/index.test.ts`.