### PR TITLE
fix(orchestrator): abort child sessions on sync timeout

### DIFF
--- a/.changeset/abort-sync-timeout-sessions.md
+++ b/.changeset/abort-sync-timeout-sessions.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Abort active child model sessions when synchronous Magi runs time out or fail.

--- a/src/orchestrator/model.test.ts
+++ b/src/orchestrator/model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, test, vi } from "vitest"
 import {
   promptModelText,
   runModelWithRepair,
@@ -28,6 +28,40 @@ describe("promptModelText", () => {
         sessionId: "session-1",
       }),
     ).resolves.toBe("## claude\n\nVisible answer")
+  })
+
+  test("aborts the active session when the prompt signal is aborted", async () => {
+    const abortedSessions: string[] = []
+    let resolvePrompt: (value: unknown) => void = () => undefined
+    const client: ModelClient = {
+      session: {
+        abort: async (input) => {
+          abortedSessions.push(input.path.id)
+
+          return true
+        },
+        create: async () => ({ id: "session-1" }),
+        prompt: async () =>
+          new Promise((resolve) => {
+            resolvePrompt = resolve
+          }),
+      },
+    }
+    const controller = new AbortController()
+    const promise = promptModelText({
+      client,
+      model: "anthropic/claude",
+      prompt: "Question?",
+      sessionId: "session-1",
+      signal: controller.signal,
+    })
+
+    controller.abort()
+
+    await vi.waitFor(() => expect(abortedSessions).toEqual(["session-1"]))
+    resolvePrompt({ info: { text: "late answer" } })
+
+    await expect(promise).rejects.toThrow()
   })
 })
 

--- a/src/orchestrator/model.ts
+++ b/src/orchestrator/model.ts
@@ -199,17 +199,27 @@ export async function promptModelText(input: {
 }): Promise<string> {
   throwIfAborted(input.signal)
 
-  const result = await input.client.session.prompt({
-    body: {
-      model: modelBody(input.model),
-      parts: [{ type: "text", text: input.prompt }],
-    },
-    path: { id: input.sessionId },
-  })
+  const abort = () => {
+    void input.client.session
+      .abort?.({ path: { id: input.sessionId } })
+      .catch(() => undefined)
+  }
+  input.signal?.addEventListener("abort", abort, { once: true })
+  try {
+    const result = await input.client.session.prompt({
+      body: {
+        model: modelBody(input.model),
+        parts: [{ type: "text", text: input.prompt }],
+      },
+      path: { id: input.sessionId },
+    })
 
-  throwIfAborted(input.signal)
+    throwIfAborted(input.signal)
 
-  return extractText(result, input.allowEmpty)
+    return extractText(result, input.allowEmpty)
+  } finally {
+    input.signal?.removeEventListener("abort", abort)
+  }
 }
 
 async function sendPrompt(

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -64,6 +64,11 @@ describe("MagiRunManager notifications", () => {
         },
       },
       session: {
+        abort: async (input) => {
+          actions.push({ input, type: "session.abort" })
+
+          return true
+        },
         create: async () => ({ id: "session" }),
         delete: async (input) => {
           actions.push({ input, type: "session.delete" })
@@ -506,6 +511,99 @@ describe("MagiRunManager notifications", () => {
 
       expect(state.status).toBe("failed")
       expect(state.error).toBe("Magi sync run timed out after 0.001 seconds.")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("fails and aborts active review child sessions on synchronous timeout", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-sync-review-timeout-"))
+    const { actions, manager } = managerWithPromptCapture(directory)
+    const privateManager = manager as unknown as {
+      active: Map<string, MagiRunState>
+    }
+
+    runReviewMock.mockImplementationOnce((input) => {
+      const state = privateManager.active.get(input.runId)
+      state!.reviewers.security!.sessionId = "review-session"
+      state!.reviewers.security!.status = "running"
+
+      return new Promise(() => undefined)
+    })
+
+    try {
+      const statePromise = manager.startReview({
+        config: { github: { owner: "owner", repo: "repo" } },
+        pr: 7557,
+        repository: sampleRepository(),
+        sync: true,
+        timeoutMs: 1000,
+      })
+      await vi.waitFor(() => expect(runReviewMock).toHaveBeenCalledTimes(1))
+      const state = await statePromise
+
+      expect(state.status).toBe("failed")
+      expect(state.reviewers.security).toMatchObject({
+        error: "Magi sync run timed out after 1 seconds.",
+        status: "failed",
+      })
+      expect(actions).toContainEqual({
+        input: { path: { id: "review-session" } },
+        type: "session.abort",
+      })
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("fails and aborts active triage creator sessions on synchronous timeout", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-sync-triage-timeout-"))
+    const { actions, manager } = managerWithPromptCapture(directory)
+    const repository = sampleTriageRepository({
+      clear: ["triage"],
+      close: false,
+      create: true,
+      merge: false,
+      review: false,
+    })
+    repository.agents.triageCreator = {
+      account: "creator-bot",
+      author: { email: "creator@example.com", name: "Creator Bot" },
+      model: "mock/model",
+      permission: "deny",
+    }
+    const privateManager = manager as unknown as {
+      active: Map<string, MagiRunState>
+    }
+
+    runTriageMock.mockImplementationOnce((input) => {
+      const state = privateManager.active.get(input.runId)
+      state!.triageCreator!.sessionId = "creator-session"
+      state!.triageCreator!.status = "running"
+
+      return new Promise(() => undefined)
+    })
+
+    try {
+      const statePromise = manager.startTriage({
+        config: { github: { owner: "owner", repo: "repo" } },
+        issue: 115,
+        repository,
+        sync: true,
+        timeoutMs: 1000,
+      })
+      await vi.waitFor(() => expect(runTriageMock).toHaveBeenCalledTimes(1))
+      const state = await statePromise
+
+      expect(state.status).toBe("failed")
+      expect(state.triageCreator).toMatchObject({
+        error: "Magi sync run timed out after 1 seconds.",
+        status: "failed",
+      })
+      expect(actions).toContainEqual({
+        input: { path: { id: "creator-session" } },
+        type: "session.abort",
+      })
     } finally {
       await rm(directory, { force: true, recursive: true })
     }

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -1085,61 +1085,7 @@ export class MagiRunManager {
     state.status = "cancelled"
     state.phase = "cancelled"
     state.completedAt = now()
-    if (
-      state.editor?.status === "pending" ||
-      state.editor?.status === "running" ||
-      state.editor?.status === "repairing"
-    ) {
-      state.editor.status = "cancelled"
-    }
-    if (state.editor?.sessionId) {
-      await this.input.client.session
-        .abort?.({ path: { id: state.editor.sessionId } })
-        .catch(() => undefined)
-    }
-    if (
-      state.triageCreator?.status === "pending" ||
-      state.triageCreator?.status === "running" ||
-      state.triageCreator?.status === "repairing" ||
-      state.triageCreator?.status === "blocked"
-    ) {
-      state.triageCreator.status = "cancelled"
-    }
-    if (state.triageCreator?.sessionId) {
-      await this.input.client.session
-        .abort?.({ path: { id: state.triageCreator.sessionId } })
-        .catch(() => undefined)
-    }
-    for (const reviewer of Object.values(state.reviewers)) {
-      if (
-        reviewer.status === "pending" ||
-        reviewer.status === "running" ||
-        reviewer.status === "repairing" ||
-        reviewer.status === "blocked"
-      ) {
-        reviewer.status = "cancelled"
-      }
-      if (reviewer.sessionId) {
-        await this.input.client.session
-          .abort?.({ path: { id: reviewer.sessionId } })
-          .catch(() => undefined)
-      }
-    }
-    for (const classifier of Object.values(state.ciClassifiers ?? {})) {
-      if (
-        classifier.status === "pending" ||
-        classifier.status === "running" ||
-        classifier.status === "repairing" ||
-        classifier.status === "blocked"
-      ) {
-        classifier.status = "cancelled"
-      }
-      if (classifier.sessionId) {
-        await this.input.client.session
-          .abort?.({ path: { id: classifier.sessionId } })
-          .catch(() => undefined)
-      }
-    }
+    await this.finishActiveAgents(state, "cancelled")
     if (state.worktreePath) {
       await removeWorktree(this.input.exec, state.worktreePath).catch(
         () => undefined,
@@ -1806,6 +1752,33 @@ export class MagiRunManager {
       ),
       ...Object.entries(state.reviewers),
     ]
+  }
+
+  private isActiveAgent(agent: MagiRunAgentState): boolean {
+    return (
+      agent.status === "pending" ||
+      agent.status === "running" ||
+      agent.status === "repairing" ||
+      agent.status === "blocked"
+    )
+  }
+
+  private async finishActiveAgents(
+    state: MagiRunState,
+    status: "cancelled" | "failed",
+    error?: string,
+  ): Promise<void> {
+    for (const [, agent] of this.agentEntries(state)) {
+      if (this.isActiveAgent(agent)) {
+        agent.status = status
+        if (error != null) agent.error = error
+      }
+      if (agent.sessionId) {
+        await this.input.client.session
+          .abort?.({ path: { id: agent.sessionId } })
+          .catch(() => undefined)
+      }
+    }
   }
 
   private selectPendingAgent(
@@ -2845,52 +2818,7 @@ export class MagiRunManager {
     state.phase = "failed"
     state.completedAt = now()
     state.error = errorMessage(error)
-    if (
-      state.editor?.status === "pending" ||
-      state.editor?.status === "running" ||
-      state.editor?.status === "repairing" ||
-      state.editor?.status === "blocked"
-    ) {
-      state.editor.status = "failed"
-      state.editor.error = state.error
-    }
-    if (state.editor?.sessionId) {
-      await this.input.client.session
-        .abort?.({ path: { id: state.editor.sessionId } })
-        .catch(() => undefined)
-    }
-    for (const reviewer of Object.values(state.reviewers)) {
-      if (
-        reviewer.status === "pending" ||
-        reviewer.status === "running" ||
-        reviewer.status === "repairing" ||
-        reviewer.status === "blocked"
-      ) {
-        reviewer.status = "failed"
-        reviewer.error = state.error
-      }
-      if (reviewer.sessionId) {
-        await this.input.client.session
-          .abort?.({ path: { id: reviewer.sessionId } })
-          .catch(() => undefined)
-      }
-    }
-    for (const classifier of Object.values(state.ciClassifiers ?? {})) {
-      if (
-        classifier.status === "pending" ||
-        classifier.status === "running" ||
-        classifier.status === "repairing" ||
-        classifier.status === "blocked"
-      ) {
-        classifier.status = "failed"
-        classifier.error = state.error
-      }
-      if (classifier.sessionId) {
-        await this.input.client.session
-          .abort?.({ path: { id: classifier.sessionId } })
-          .catch(() => undefined)
-      }
-    }
+    await this.finishActiveAgents(state, "failed", state.error)
     await this.persist(state)
     await this.notify(
       state,


### PR DESCRIPTION
Closes #213

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Abort active child model sessions when a synchronous Magi run times out or otherwise fails, including triage creator sessions.

## Current behavior (updates)

Synchronous timeout failure marked the run failed but could leave active child sessions running, especially triage creator sessions.

## New behavior

Failure and cancellation paths now share active-agent cleanup that marks active child agents terminal and aborts known session IDs. In-flight model prompts also abort their active OpenCode session when their AbortSignal fires.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm exec vitest run src/orchestrator/run-manager.test.ts src/orchestrator/model.test.ts`.