### PR TITLE
fix(triage): run comment classification as reporter

### DIFF
--- a/.changeset/spotty-ravens-triage.md
+++ b/.changeset/spotty-ravens-triage.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Run triage comment classification as the configured reporter and persist its session for cleanup.

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -1006,6 +1006,38 @@ describe("MagiRunManager notifications", () => {
     ])
   })
 
+  test("records triage sessions for clearing", async () => {
+    const { manager } = managerWithPromptCapture()
+    const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
+    const state = sampleTriageState(directory)
+    const privateManager = manager as unknown as {
+      active: Map<string, MagiRunState>
+      applyTriageProgress(runId: string, progress: unknown): Promise<void>
+      sessionToRun: Map<string, { agent: string; runId: string }>
+    }
+
+    privateManager.active.set("triage-run", state)
+    try {
+      await privateManager.applyTriageProgress("triage-run", {
+        agent: "Balthasar",
+        key: "triage:comment-classification:Balthasar:classifier-session",
+        sessionId: "classifier-session",
+        type: "triage_session",
+      })
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+
+    expect(state.sessionIds).toEqual({
+      "triage:comment-classification:Balthasar:classifier-session":
+        "classifier-session",
+    })
+    expect(privateManager.sessionToRun.get("classifier-session")).toEqual({
+      agent: "Balthasar",
+      runId: "triage-run",
+    })
+  })
+
   test("notifies triage creator failures", async () => {
     const { manager, prompts } = managerWithPromptCapture()
     const directory = await mkdtemp(join(tmpdir(), "magi-run-"))
@@ -1788,6 +1820,7 @@ describe("MagiRunManager notifications", () => {
 
     state.status = "completed"
     state.phase = "completed"
+    state.sessionIds = { classifier: "classifier-session" }
     state.worktreeBranch = "pr-7557"
     state.worktreePath = worktreePath
     await mkdir(outputDir, { recursive: true })
@@ -1803,6 +1836,10 @@ describe("MagiRunManager notifications", () => {
       expect(actions).toMatchObject([
         {
           input: { path: { id: "child-session" } },
+          type: "session.delete",
+        },
+        {
+          input: { path: { id: "classifier-session" } },
           type: "session.delete",
         },
       ])

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -2167,6 +2167,19 @@ export class MagiRunManager {
       state.worktreeBranch = progress.branch
     }
 
+    if (progress.type === "triage_session") {
+      if (progress.options)
+        this.input.setSessionOptions?.(progress.sessionId, progress.options)
+      state.sessionIds = {
+        ...state.sessionIds,
+        [progress.key]: progress.sessionId,
+      }
+      this.sessionToRun.set(progress.sessionId, {
+        agent: progress.agent,
+        runId,
+      })
+    }
+
     if (progress.type === "triage_agent_started") {
       const reviewer = state.reviewers[progress.reviewer]
       if (reviewer) reviewer.status = "running"

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -996,12 +996,40 @@ describe("triage orchestration", () => {
         action("COMMENT"),
         "Reconsidered comment",
       ],
+      repository: {
+        ...repository,
+        agents: {
+          ...repository.agents,
+          triage: repository.agents.triage?.map((agent) =>
+            agent.key === "Balthasar"
+              ? { ...agent, persona: "Reporter persona" }
+              : agent,
+          ),
+        },
+        triage: {
+          ...repository.triage!,
+          reporter: "Balthasar",
+        },
+      },
     })
 
     expect(result.result.result).toEqual(decision("feature", "rejected"))
+    expect(result.prompts[0]).toContain("Reporter persona")
+    expect(result.progress).toEqual(
+      expect.arrayContaining([
+        {
+          agent: "Balthasar",
+          key: expect.stringContaining(
+            "triage:comment-classification:Balthasar:session-1",
+          ),
+          sessionId: "session-1",
+          type: "triage_session",
+        },
+      ]),
+    )
     expect(
       result.sessionTitles.some((title) =>
-        title.includes("triage comment classification"),
+        title.includes("triage comment classification #1 (Balthasar)"),
       ),
     ).toBe(true)
     expect(

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -139,6 +139,13 @@ export type TriageRunProgress =
   | { sessionId: string; type: "triage_creator_completed" }
   | { error: string; type: "triage_creator_failed" }
   | { type: "pr_created"; url: string }
+  | {
+      agent: string
+      key: string
+      options?: ModelRunProgress["options"]
+      sessionId: string
+      type: "triage_session"
+    }
   | { branch: string; type: "worktree_created"; worktreePath: string }
 
 interface TriageMarker {
@@ -889,8 +896,7 @@ async function classifyMentionReplies(input: {
   outputDir: string
   replies: IssueComment[]
 }) {
-  const agent = input.input.repository.agents.triage?.[0]
-  if (!agent) throw new Error("triage.agents is required")
+  const agent = triageReporter(input.input.repository, input.input.issue)
   const prompt = await composeTriageCommentClassificationPrompt({
     context: JSON.stringify(
       { context: input.context, mentionReplies: input.replies },
@@ -905,6 +911,17 @@ async function classifyMentionReplies(input: {
   const result = await runModelWithRepair({
     client: input.input.client,
     model: agent.model,
+    onProgress: async (progress) => {
+      if (progress.type !== "session_created") return
+
+      await emitProgress(input.input, {
+        agent: agent.key,
+        key: `triage:comment-classification:${agent.key}:${progress.sessionId}`,
+        options: progress.options,
+        sessionId: progress.sessionId,
+        type: "triage_session",
+      })
+    },
     options: agent.options,
     parentSessionId: input.input.parentSessionId,
     parse: parseTriageCommentClassificationOutput,
@@ -913,7 +930,7 @@ async function classifyMentionReplies(input: {
     repairAttempts: 3,
     schemaName: "triage comment classification",
     signal: input.input.signal,
-    title: `Magi triage comment classification #${input.input.issue}`,
+    title: `Magi triage comment classification #${input.input.issue} (${agent.key})`,
   })
 
   await writeJson(


### PR DESCRIPTION
Closes #215

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Run triage mention-reply comment classification with the resolved triage reporter and persist its model session so clear can delete it.

## Current behavior (updates)

Comment classification for reconsideration used the first configured triage agent and did not emit a tracked session into run state.

## New behavior

Comment classification uses the configured or issue-number-selected triage reporter, emits a triage session progress event, and stores that session in state.sessionIds for cleanup.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm test -- src/orchestrator/triage.test.ts src/orchestrator/run-manager.test.ts`.