### PR TITLE
fix(orchestrator): scope worktrees by run

### DIFF
--- a/.changeset/tall-tigers-count.md
+++ b/.changeset/tall-tigers-count.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Use run-scoped Magi worktree paths to avoid collisions between repeated runs for the same issue or pull request.

--- a/src/config/worktree.ts
+++ b/src/config/worktree.ts
@@ -34,3 +34,29 @@ export function worktreeBaseDirs(
     worktreeBaseDir(directory, config, "issue"),
   ]
 }
+
+export function prRunWorktreeDir(input: {
+  config: MagiConfig
+  directory: string
+  pr: number
+  runId: string
+}): string {
+  return join(
+    worktreeBaseDir(input.directory, input.config, "pr"),
+    String(input.pr),
+    input.runId,
+  )
+}
+
+export function issueRunWorktreeDir(input: {
+  config: MagiConfig
+  directory: string
+  issue: number
+  runId: string
+}): string {
+  return join(
+    worktreeBaseDir(input.directory, input.config, "issue"),
+    String(input.issue),
+    input.runId,
+  )
+}

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -889,6 +889,7 @@ describe("GitHub command helpers", () => {
 describe("createWorktree", () => {
   test("checks out pull requests without binding the head branch", async () => {
     const root = await mkdtemp(join(tmpdir(), "magi-worktrees-"))
+    const worktreePath = join(root, "1", "run-test")
     const commands: string[] = []
 
     try {
@@ -901,10 +902,11 @@ describe("createWorktree", () => {
         },
         repository,
         1,
-        root,
+        worktreePath,
       )
 
       expect(result.branch).toBeUndefined()
+      expect(result.path).toBe(worktreePath)
       expect(commands).toContain(
         "gh pr checkout 1 --repo 'owner/repo' --detach",
       )
@@ -915,6 +917,8 @@ describe("createWorktree", () => {
 
   test("serializes worktree creation for the same repository root", async () => {
     const root = await mkdtemp(join(tmpdir(), "magi-worktrees-"))
+    const firstWorktreePath = join(root, "1", "run-first")
+    const secondWorktreePath = join(root, "2", "run-second")
     const commands: string[] = []
     let markFirstCheckoutReached!: () => void
     let releaseFirstCheckout!: () => void
@@ -940,7 +944,7 @@ describe("createWorktree", () => {
         },
         repository,
         1,
-        root,
+        firstWorktreePath,
       )
 
       await firstCheckoutReached
@@ -954,21 +958,23 @@ describe("createWorktree", () => {
         },
         repository,
         2,
-        root,
+        secondWorktreePath,
       )
 
       await Promise.resolve()
 
-      expect(commands.some((command) => command.includes("pr-2"))).toBe(false)
+      expect(commands.some((command) => command.includes("run-second"))).toBe(
+        false,
+      )
 
       releaseFirstCheckout()
       await Promise.all([first, second])
 
       expect(
-        commands.filter((command) => command.includes("pr-1")),
+        commands.filter((command) => command.includes("run-first")),
       ).not.toHaveLength(0)
       expect(
-        commands.filter((command) => command.includes("pr-2")),
+        commands.filter((command) => command.includes("run-second")),
       ).not.toHaveLength(0)
     } finally {
       await removePath(root, { force: true, recursive: true })
@@ -977,6 +983,7 @@ describe("createWorktree", () => {
 
   test("retries checkout when git config is locked", async () => {
     const root = await mkdtemp(join(tmpdir(), "magi-worktrees-"))
+    const worktreePath = join(root, "1", "run-test")
     let checkoutAttempts = 0
 
     try {
@@ -996,7 +1003,7 @@ describe("createWorktree", () => {
         },
         repository,
         1,
-        root,
+        worktreePath,
       )
 
       expect(checkoutAttempts).toBe(2)
@@ -1008,7 +1015,7 @@ describe("createWorktree", () => {
   test("removes a partially created worktree after checkout failure", async () => {
     const root = await mkdtemp(join(tmpdir(), "magi-worktrees-"))
     const commands: string[] = []
-    const worktreePath = join(root, "pr-1")
+    const worktreePath = join(root, "1", "run-test")
 
     try {
       await expect(
@@ -1023,7 +1030,7 @@ describe("createWorktree", () => {
           },
           repository,
           1,
-          root,
+          worktreePath,
         ),
       ).rejects.toThrow("checkout failed")
 

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1178,10 +1178,11 @@ export async function createWorktree(
   exec: Exec,
   repository: ResolvedRepository,
   pr: number,
-  root: string,
+  worktreePath: string,
 ): Promise<CreatedWorktree> {
-  const worktreePath = join(root, `pr-${pr}`)
-  const lockKey = `${repoSpecifier(repository)}:${root}`
+  const lockKey = `${repoSpecifier(repository)}:${dirname(
+    dirname(worktreePath),
+  )}`
 
   return withWorktreeCreateLock(lockKey, async () => {
     let worktreeAdded = false

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -36,7 +36,7 @@ import {
   composeReviewPrompt,
 } from "../prompts/compose"
 import { prRunOutputDir } from "../config/output"
-import { worktreeBaseDir } from "../config/worktree"
+import { prRunWorktreeDir } from "../config/worktree"
 import {
   parseCloseReconsiderationOutput,
   parseFindingValidationOutput,
@@ -987,14 +987,13 @@ export async function runReview(
   if (mode.type === "already_reviewed" && !input.allowAlreadyReviewed)
     throw new Error("PR has already been reviewed by all configured accounts")
 
-  const outputDir = join(
-    prRunOutputDir({
-      config: input.config,
-      directory: input.directory,
-      pr: input.pr,
-    }),
-    ...(input.runId ? [input.runId] : []),
-  )
+  const runId = input.runId ?? `run-${Date.now().toString(36)}`
+  const outputDir = prRunOutputDir({
+    config: input.config,
+    directory: input.directory,
+    pr: input.pr,
+    runId,
+  })
 
   await mkdir(outputDir, { recursive: true })
 
@@ -1070,15 +1069,19 @@ export async function runReview(
     await input.onProgress?.({ report: checkResult.report, type: "ci_report" })
   }
 
-  const worktreeRoot = worktreeBaseDir(input.directory, input.config, "pr")
+  const worktreePath = prRunWorktreeDir({
+    config: input.config,
+    directory: input.directory,
+    pr: input.pr,
+    runId,
+  })
   await input.onProgress?.({ phase: "creating worktree", type: "phase" })
   const worktree = await createWorktree(
     exec,
     input.repository,
     input.pr,
-    worktreeRoot,
+    worktreePath,
   )
-  const worktreePath = worktree.path
   await input.onProgress?.({
     branch: worktree.branch,
     type: "worktree_created",

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -716,6 +716,9 @@ describe("triage orchestration", () => {
     expect(assignIndex).toBeGreaterThan(-1)
     expect(assignIndex).toBeLessThan(worktreeIndex)
     expect(assignIndex).toBeLessThan(prIndex)
+    expect(result.commands[worktreeIndex]).toContain(
+      "/.magi/worktrees/issue/1/run-test",
+    )
     expect(result.commands[prIndex]).toContain(
       "--title 'fix(triage): use creator PR metadata'",
     )

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -25,7 +25,7 @@ import type {
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { issueRunOutputDir } from "../config/output"
-import { worktreeBaseDir } from "../config/worktree"
+import { issueRunWorktreeDir } from "../config/worktree"
 import {
   assignIssue,
   closeIssue,
@@ -1186,6 +1186,7 @@ async function finishWithResult(input: {
   previousMarker?: TriageMarker
   relationship: RelationshipSummary
   result: FinalResult
+  runId: string
 }): Promise<TriageRunResult> {
   const triage = input.input.repository.triage
   if (!triage) throw new Error("triage configuration is required")
@@ -1300,6 +1301,7 @@ async function finishWithResult(input: {
         input: input.input,
         issue: input.issue,
         outputDir: input.outputDir,
+        runId: input.runId,
       })
       if (prUrl) {
         await writeJson(join(input.outputDir, "pr.json"), { url: prUrl })
@@ -1377,6 +1379,7 @@ async function createImplementationPr(input: {
   input: TriageRunInput
   issue: IssueMeta
   outputDir: string
+  runId: string
 }): Promise<string | undefined> {
   const creator = input.input.repository.agents.triageCreator
   if (!creator) return undefined
@@ -1392,10 +1395,12 @@ async function createImplementationPr(input: {
     )
 
     const branch = `magi/issue-${input.issue.number}-${Date.now().toString(36)}`
-    const worktreePath = join(
-      worktreeBaseDir(input.input.directory, input.input.config, "issue"),
-      `issue-${input.issue.number}`,
-    )
+    const worktreePath = issueRunWorktreeDir({
+      config: input.input.config,
+      directory: input.input.directory,
+      issue: input.issue.number,
+      runId: input.runId,
+    })
     await mkdir(dirname(worktreePath), { recursive: true })
     await input.input.exec(
       `git worktree add -b ${shellQuote(branch)} ${shellQuote(worktreePath)}`,
@@ -1572,6 +1577,7 @@ export async function runTriage(
           processed,
           relationship,
           result,
+          runId,
         })
       }
 
@@ -1704,6 +1710,7 @@ export async function runTriage(
           processed,
           relationship,
           result: relatedPrDecision,
+          runId,
         })
       }
       return finishWithResult({
@@ -1714,6 +1721,7 @@ export async function runTriage(
         processed,
         relationship,
         result: { category: null, disposition: "clear_only" },
+        runId,
       })
     }
   }
@@ -1826,5 +1834,6 @@ export async function runTriage(
       category: null,
       disposition: "ask",
     },
+    runId,
   })
 }


### PR DESCRIPTION
Closes #212

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Aligns Magi worktree paths with per-run artifact directories so repeated runs for the same issue or pull request do not collide with leftover worktrees.

## Current behavior (updates)

Issue implementation PR worktrees and PR review worktrees used fixed issue/PR-number paths, which could collide across repeated or aborted runs.

## New behavior

Issue implementation PR worktrees now use `.magi/worktrees/issue/<issue>/<runId>`, and PR review/merge worktrees now use `.magi/worktrees/pr/<pr>/<runId>`. Cleanup continues to use the recorded worktree path.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/github/commands.test.ts src/orchestrator/review.test.ts src/orchestrator/triage.test.ts`.