### PR TITLE
fix(review): enforce background run concurrency

### DIFF
--- a/.changeset/queue-background-pr-runs.md
+++ b/.changeset/queue-background-pr-runs.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Enforce configured concurrency for background review and merge runs.

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -307,6 +307,152 @@ describe("MagiRunManager notifications", () => {
     }
   })
 
+  test("limits background review runs to configured concurrency", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-review-queue-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const repository = sampleRepository()
+    repository.concurrency.runs = 2
+    const resolvers: Array<(value: unknown) => void> = []
+    runReviewMock.mockImplementation((input) => {
+      return new Promise((resolve) => {
+        resolvers.push(() =>
+          resolve({
+            outputs: {
+              security: { findings: [], verdict: "MERGE" },
+            },
+            posted: {},
+            report: `Review report ${input.pr}`,
+            sessionIds: {},
+            verdict: "MERGE",
+          }),
+        )
+      })
+    })
+
+    try {
+      for (const pr of [1, 2, 3]) {
+        await manager.startReview({
+          config: { github: { owner: "owner", repo: "repo" } },
+          pr,
+          repository,
+        })
+      }
+
+      await vi.waitFor(() => expect(runReviewMock).toHaveBeenCalledTimes(2))
+      expect(runReviewMock.mock.calls.map(([input]) => input.pr)).toEqual([
+        1, 2,
+      ])
+
+      resolvers[0]?.({})
+
+      await vi.waitFor(() => expect(runReviewMock).toHaveBeenCalledTimes(3))
+      expect(runReviewMock.mock.calls.map(([input]) => input.pr)).toEqual([
+        1, 2, 3,
+      ])
+
+      resolvers[1]?.({})
+      resolvers[2]?.({})
+      await vi.waitFor(() => expect(resolvers).toHaveLength(3))
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("limits background merge runs to configured concurrency", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-merge-queue-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const repository = sampleRepository()
+    repository.concurrency.runs = 2
+    const resolvers: Array<(value: unknown) => void> = []
+    runMergeMock.mockImplementation((input) => {
+      return new Promise((resolve) => {
+        resolvers.push(() =>
+          resolve({
+            cycles: 0,
+            pr: input.pr,
+            report: `Merge report ${input.pr}`,
+            status: "approved",
+          }),
+        )
+      })
+    })
+
+    try {
+      for (const pr of [1, 2, 3]) {
+        await manager.startMerge({
+          config: { github: { owner: "owner", repo: "repo" } },
+          pr,
+          repository,
+        })
+      }
+
+      await vi.waitFor(() => expect(runMergeMock).toHaveBeenCalledTimes(2))
+      expect(runMergeMock.mock.calls.map(([input]) => input.pr)).toEqual([1, 2])
+
+      resolvers[0]?.({})
+
+      await vi.waitFor(() => expect(runMergeMock).toHaveBeenCalledTimes(3))
+      expect(runMergeMock.mock.calls.map(([input]) => input.pr)).toEqual([
+        1, 2, 3,
+      ])
+
+      resolvers[1]?.({})
+      resolvers[2]?.({})
+      await vi.waitFor(() => expect(resolvers).toHaveLength(3))
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  test("skips cancelled queued background review runs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-review-cancel-"))
+    const { manager } = managerWithPromptCapture(directory)
+    const repository = sampleRepository()
+    repository.concurrency.runs = 1
+    const resolvers: Array<(value: unknown) => void> = []
+    runReviewMock.mockImplementation((input) => {
+      return new Promise((resolve) => {
+        resolvers.push(() =>
+          resolve({
+            outputs: {
+              security: { findings: [], verdict: "MERGE" },
+            },
+            posted: {},
+            report: `Review report ${input.pr}`,
+            sessionIds: {},
+            verdict: "MERGE",
+          }),
+        )
+      })
+    })
+
+    try {
+      const states = []
+      for (const pr of [1, 2, 3]) {
+        states.push(
+          await manager.startReview({
+            config: { github: { owner: "owner", repo: "repo" } },
+            pr,
+            repository,
+          }),
+        )
+      }
+
+      await vi.waitFor(() => expect(runReviewMock).toHaveBeenCalledTimes(1))
+      await manager.cancel(states[1]!.runId)
+      resolvers[0]?.({})
+
+      await vi.waitFor(() => expect(runReviewMock).toHaveBeenCalledTimes(2))
+      expect(runReviewMock.mock.calls.map(([input]) => input.pr)).toEqual([
+        1, 3,
+      ])
+
+      resolvers[1]?.({})
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   test("limits background triage runs to configured concurrency", async () => {
     const directory = await mkdtemp(join(tmpdir(), "magi-triage-queue-"))
     const { manager } = managerWithPromptCapture(directory)

--- a/src/orchestrator/run-manager.ts
+++ b/src/orchestrator/run-manager.ts
@@ -131,6 +131,12 @@ interface QueuedTriageRun {
   runId: string
 }
 
+interface QueuedPrRun {
+  execute: () => Promise<void>
+  repository: ResolvedRepository
+  runId: string
+}
+
 export interface MagiClearSummary {
   branchDeleted: number
   branchFailed: number
@@ -694,6 +700,7 @@ function extractQuestionRequest(
 
 export class MagiRunManager {
   private active = new Map<string, MagiRunState>()
+  private activePrRuns = 0
   private activeTriageRuns = 0
   private countedToolParts = new Map<string, Set<string>>()
   private controllers = new Map<string, AbortController>()
@@ -702,6 +709,7 @@ export class MagiRunManager {
   private runPaths = new Map<string, string>()
   private outputDirs = new Set<string>()
   private sessionToRun = new Map<string, { agent: string; runId: string }>()
+  private prQueue: QueuedPrRun[] = []
   private triageQueue: QueuedTriageRun[] = []
 
   constructor(
@@ -779,9 +787,12 @@ export class MagiRunManager {
     if (input.sync)
       return this.executeSync(state, controller, execute, input.timeoutMs)
 
-    void execute().catch(async (error) => {
-      await this.failRun(runId, error)
+    this.prQueue.push({
+      execute,
+      repository: input.repository,
+      runId,
     })
+    this.drainPrQueue()
 
     return state
   }
@@ -858,9 +869,12 @@ export class MagiRunManager {
     if (input.sync)
       return this.executeSync(state, controller, execute, input.timeoutMs)
 
-    void execute().catch(async (error) => {
-      await this.failRun(runId, error)
+    this.prQueue.push({
+      execute,
+      repository: input.repository,
+      runId,
     })
+    this.drainPrQueue()
 
     return state
   }
@@ -947,6 +961,29 @@ export class MagiRunManager {
     this.drainTriageQueue()
 
     return state
+  }
+
+  private drainPrQueue(): void {
+    while (this.prQueue.length) {
+      const next = this.prQueue[0]
+      if (!next) return
+      if (this.activePrRuns >= next.repository.concurrency.runs) return
+      this.prQueue.shift()
+
+      const state = this.active.get(next.runId)
+      if (!state || state.status === "cancelled") continue
+
+      this.activePrRuns += 1
+      void next
+        .execute()
+        .catch(async (error) => {
+          await this.failRun(next.runId, error)
+        })
+        .finally(() => {
+          this.activePrRuns -= 1
+          this.drainPrQueue()
+        })
+    }
   }
 
   private drainTriageQueue(): void {


### PR DESCRIPTION
Closes #228

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds queued background execution for PR review and merge runs so non-sync starts do not release concurrency slots before the underlying workflow finishes.

## Current behavior (updates)

Non-sync review and merge starts returned immediately after launching execution, allowing more active background runs than `review.concurrency.runs`.

## New behavior

Background review and merge executions are queued in `MagiRunManager` and only up to `repository.concurrency.runs` run at once. Queued runs cancelled before starting are skipped, while sync behavior remains unchanged.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tests: `pnpm vitest run src/orchestrator/run-manager.test.ts`