### PR TITLE
fix(merge): fetch missing diff commits

### DIFF
--- a/.changeset/fetch-missing-diff-commits.md
+++ b/.changeset/fetch-missing-diff-commits.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Fetch missing pull request diff commits before building local review targets.

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -200,6 +200,12 @@ export interface CreatedWorktree {
   path: string
 }
 
+export interface PullRequestCommitRequirement {
+  label: string
+  sha: string
+  source: "base" | "head"
+}
+
 const WORKTREE_CHECKOUT_RETRY_ATTEMPTS = 5
 const WORKTREE_CHECKOUT_RETRY_DELAY_MS = 100
 const worktreeCreateLocks = new Map<string, Promise<void>>()
@@ -216,6 +222,107 @@ function errorText(error: unknown): string {
   return [value.message, value.stderr, value.stdout]
     .filter((item): item is string => typeof item === "string")
     .join("\n")
+}
+
+async function localCommitExists(
+  exec: Exec,
+  worktreePath: string,
+  sha: string,
+): Promise<boolean> {
+  try {
+    await exec(`git cat-file -e ${shellQuote(`${sha}^{commit}`)}`, {
+      cwd: worktreePath,
+    })
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+function pullRequestCommitSource(input: {
+  meta: PullRequestMeta
+  repository: ResolvedRepository
+  source: PullRequestCommitRequirement["source"]
+}): { owner: string; refName: string; repo: string } {
+  if (input.source === "base") {
+    return {
+      owner: input.repository.github.owner,
+      refName: input.meta.baseRefName,
+      repo: input.repository.github.repo,
+    }
+  }
+
+  return {
+    owner:
+      input.meta.headRepositoryOwner?.login ?? input.repository.github.owner,
+    refName: input.meta.headRefName,
+    repo: input.meta.headRepository?.name ?? input.repository.github.repo,
+  }
+}
+
+async function fetchPullRequestCommitSource(input: {
+  exec: Exec
+  meta: PullRequestMeta
+  repository: ResolvedRepository
+  source: PullRequestCommitRequirement["source"]
+  worktreePath: string
+}): Promise<void> {
+  const commitSource = pullRequestCommitSource(input)
+
+  try {
+    await input.exec(
+      `git fetch --no-tags ${shellQuote(repositoryGitUrl(input.repository, commitSource.owner, commitSource.repo))} ${shellQuote(`refs/heads/${commitSource.refName}`)}`,
+      { cwd: input.worktreePath },
+    )
+  } catch (error) {
+    throw new Error(
+      `Could not fetch ${input.source} ref ${commitSource.refName} for #${input.meta.number}: ${errorText(error)}`,
+    )
+  }
+}
+
+export async function ensurePullRequestCommits(input: {
+  commits: PullRequestCommitRequirement[]
+  exec: Exec
+  meta: PullRequestMeta
+  repository: ResolvedRepository
+  worktreePath: string
+}): Promise<void> {
+  const missing: PullRequestCommitRequirement[] = []
+
+  for (const commit of input.commits) {
+    if (
+      !(await localCommitExists(input.exec, input.worktreePath, commit.sha))
+    ) {
+      missing.push(commit)
+    }
+  }
+
+  for (const source of new Set(missing.map((commit) => commit.source))) {
+    await fetchPullRequestCommitSource({
+      exec: input.exec,
+      meta: input.meta,
+      repository: input.repository,
+      source,
+      worktreePath: input.worktreePath,
+    })
+  }
+
+  for (const commit of missing) {
+    if (await localCommitExists(input.exec, input.worktreePath, commit.sha)) {
+      continue
+    }
+
+    const source = pullRequestCommitSource({
+      meta: input.meta,
+      repository: input.repository,
+      source: commit.source,
+    })
+    throw new Error(
+      `${commit.label} commit ${commit.sha} is unavailable after fetching ${commit.source} ref ${source.refName}`,
+    )
+  }
 }
 
 function isCheckoutConfigLockError(error: unknown): boolean {

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -26,7 +26,6 @@ import {
   pushHead,
   removeWorktree,
   resolveThread,
-  shellQuote,
   type ReviewThread,
   waitForMergeQueue,
   type CheckWaitReport,
@@ -44,7 +43,6 @@ import {
 import { throwIfAborted, withAbortSignal } from "./abort"
 import { waitForChecksWithClassification } from "./ci"
 import {
-  parseRightSideDiffTargets,
   validateInlineCommentTargets,
   type InlineCommentTargets,
 } from "./inline-comments"
@@ -52,7 +50,11 @@ import { closeMinorityReviewers, mergeVerdictForPolicy } from "./majority"
 import { type ModelClient, runModelWithRepair } from "./model"
 import { mapPool } from "./pool"
 import { formatMergeReport } from "./report"
-import { runReview, type ReviewRunProgress } from "./review"
+import {
+  inlineCommentTargetsForDiff,
+  runReview,
+  type ReviewRunProgress,
+} from "./review"
 import { checkSafetyGate, hasSafetyGate } from "./safety"
 
 export interface MergeRunInput {
@@ -451,12 +453,21 @@ async function runRereview(
 
   const meta = await fetchPullRequest(input.exec, input.repository, input.pr)
   const headSha = options.dryRunHeadSha ?? meta.headRefOid
-  const inlineCommentTargets = parseRightSideDiffTargets(
-    await input.exec(
-      `git diff --no-ext-diff --unified=3 ${shellQuote(meta.baseRefOid)} ${shellQuote(headSha)}`,
-      { cwd: worktreePath },
-    ),
-  )
+  const inlineCommentTargets = await inlineCommentTargetsForDiff({
+    ensure: options.dryRunHeadSha
+      ? undefined
+      : {
+          fromSource: "base",
+          meta,
+          repository: input.repository,
+          toSource: "head",
+        },
+    exec: input.exec,
+    fromSha: meta.baseRefOid,
+    range: "direct",
+    toSha: headSha,
+    worktreePath,
+  })
   const artifactDir = outputDir(input)
   let entries = await mapPool(
     input.repository.agents.reviewers,

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -1,5 +1,6 @@
-import type { PullRequestReview } from "../github/commands"
+import type { PullRequestMeta, PullRequestReview } from "../github/commands"
 import { describe, expect, test } from "vitest"
+import type { ResolvedRepository } from "../types"
 import {
   hasPendingThreadReply,
   inlineCommentTargetsForDiff,
@@ -9,6 +10,49 @@ import {
 } from "./review"
 
 const accounts = ["bot-a", "bot-b", "bot-c"]
+
+const repository: ResolvedRepository = {
+  agents: { reviewers: [] },
+  alias: "repo",
+  automation: { close: true, merge: true },
+  checks: {
+    exclude: [],
+    retryFailedJobs: 3,
+    waitAfterEdit: true,
+    waitBeforeReview: true,
+  },
+  concurrency: { runs: 3, reviewers: 3 },
+  github: {
+    apiRetryAttempts: 3,
+    host: "github.example.com",
+    owner: "owner",
+    repo: "repo",
+  },
+  merge: {
+    auto: true,
+    approvalPolicy: "majority",
+    deleteBranch: true,
+    maxThreadResolutionCycles: 5,
+    mergeQueue: false,
+    method: "squash",
+  },
+  prompts: {},
+  safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
+}
+
+const pullRequestMeta: PullRequestMeta = {
+  author: { login: "author" },
+  baseRefName: "main",
+  baseRefOid: "base-sha",
+  headRefName: "feature-branch",
+  headRefOid: "head-sha",
+  headRepository: { name: "repo" },
+  headRepositoryOwner: { login: "owner" },
+  isDraft: false,
+  number: 7,
+  title: "Fix diff targets",
+  url: "https://github.example.com/owner/repo/pull/7",
+}
 
 function review(account: string, commit: string, submittedAt: string) {
   return {
@@ -158,6 +202,95 @@ describe("review flow", () => {
       },
     ])
     expect(targets.get("src/app.ts")?.has(2)).toBe(true)
+  })
+
+  test("fetches missing pull request refs before building inline targets", async () => {
+    const calls: { command: string; cwd?: string }[] = []
+    const localCommits = new Set(["head-sha"])
+    const targets = await inlineCommentTargetsForDiff({
+      ensure: {
+        fromSource: "base",
+        meta: pullRequestMeta,
+        repository,
+        toSource: "head",
+      },
+      exec: async (command, options) => {
+        calls.push({ command, cwd: options?.cwd })
+
+        if (command.startsWith("git cat-file -e")) {
+          const sha = /'([^']+)\^\{commit\}'/.exec(command)?.[1]
+          if (sha && localCommits.has(sha)) return ""
+
+          throw new Error("missing commit")
+        }
+        if (command.startsWith("git fetch --no-tags")) {
+          localCommits.add("base-sha")
+
+          return ""
+        }
+
+        return [
+          "diff --git a/src/app.ts b/src/app.ts",
+          "--- a/src/app.ts",
+          "+++ b/src/app.ts",
+          "@@ -1 +1,2 @@",
+          " existing",
+          "+added",
+        ].join("\n")
+      },
+      fromSha: "base-sha",
+      toSha: "head-sha",
+      worktreePath: "/tmp/worktree",
+    })
+
+    expect(calls).toEqual([
+      {
+        command: "git cat-file -e 'base-sha^{commit}'",
+        cwd: "/tmp/worktree",
+      },
+      {
+        command: "git cat-file -e 'head-sha^{commit}'",
+        cwd: "/tmp/worktree",
+      },
+      {
+        command:
+          "git fetch --no-tags 'https://github.example.com/owner/repo.git' 'refs/heads/main'",
+        cwd: "/tmp/worktree",
+      },
+      {
+        command: "git cat-file -e 'base-sha^{commit}'",
+        cwd: "/tmp/worktree",
+      },
+      {
+        command: "git diff --no-ext-diff --unified=3 'base-sha'...'head-sha'",
+        cwd: "/tmp/worktree",
+      },
+    ])
+    expect(targets.get("src/app.ts")?.has(2)).toBe(true)
+  })
+
+  test("reports a clear error when a diff commit stays unavailable", async () => {
+    await expect(
+      inlineCommentTargetsForDiff({
+        ensure: {
+          fromSource: "base",
+          meta: pullRequestMeta,
+          repository,
+          toSource: "head",
+        },
+        exec: async (command) => {
+          if (command === "git cat-file -e 'head-sha^{commit}'") return ""
+          if (command.startsWith("git fetch --no-tags")) return ""
+
+          throw new Error("missing commit")
+        },
+        fromSha: "base-sha",
+        toSha: "head-sha",
+        worktreePath: "/tmp/worktree",
+      }),
+    ).rejects.toThrow(
+      "base commit base-sha is unavailable after fetching base ref main",
+    )
   })
 
   test("restores legacy inline review findings from the posted review body", () => {

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -18,13 +18,16 @@ import {
   fetchUnresolvedThreads,
   closePullRequest,
   mergePullRequest,
+  ensurePullRequestCommits,
   postApproval,
   postChangesRequested,
   postCloseComment,
   postReply,
   type CheckWaitReport,
+  type PullRequestMeta,
   type PullRequestReview,
   type PullRequestCommit,
+  type PullRequestCommitRequirement,
   removeWorktree,
   resolveThread,
   shellQuote,
@@ -382,16 +385,48 @@ function parseRereviewOutputWithInlineTargets(
 }
 
 export async function inlineCommentTargetsForDiff(input: {
+  ensure?: {
+    fromSource: PullRequestCommitRequirement["source"]
+    meta: PullRequestMeta
+    repository: ResolvedRepository
+    toSource: PullRequestCommitRequirement["source"]
+  }
   exec: Exec
   fromSha: string
+  range?: "direct" | "merge-base"
   toSha: string
   worktreePath: string
 }): Promise<InlineCommentTargets> {
+  if (input.ensure) {
+    await ensurePullRequestCommits({
+      commits: [
+        {
+          label: "base",
+          sha: input.fromSha,
+          source: input.ensure.fromSource,
+        },
+        {
+          label: "head",
+          sha: input.toSha,
+          source: input.ensure.toSource,
+        },
+      ],
+      exec: input.exec,
+      meta: input.ensure.meta,
+      repository: input.ensure.repository,
+      worktreePath: input.worktreePath,
+    })
+  }
+
+  const diffRange =
+    input.range === "direct"
+      ? `${shellQuote(input.fromSha)} ${shellQuote(input.toSha)}`
+      : `${shellQuote(input.fromSha)}...${shellQuote(input.toSha)}`
+
   return parseRightSideDiffTargets(
-    await input.exec(
-      `git diff --no-ext-diff --unified=3 ${shellQuote(input.fromSha)}...${shellQuote(input.toSha)}`,
-      { cwd: input.worktreePath },
-    ),
+    await input.exec(`git diff --no-ext-diff --unified=3 ${diffRange}`, {
+      cwd: input.worktreePath,
+    }),
   )
 }
 
@@ -1154,6 +1189,12 @@ export async function runReview(
       },
     )
     const initialInlineCommentTargets = await inlineCommentTargetsForDiff({
+      ensure: {
+        fromSource: "base",
+        meta,
+        repository: input.repository,
+        toSource: "head",
+      },
       exec,
       fromSha: meta.baseRefOid,
       toSha: meta.headRefOid,
@@ -1187,6 +1228,12 @@ export async function runReview(
             )
 
           const inlineCommentTargets = await inlineCommentTargetsForDiff({
+            ensure: {
+              fromSource: "head",
+              meta,
+              repository: input.repository,
+              toSource: "head",
+            },
             exec,
             fromSha: previous.commit.oid,
             toSha: meta.headRefOid,

--- a/src/orchestrator/scenarios.test.ts
+++ b/src/orchestrator/scenarios.test.ts
@@ -396,6 +396,7 @@ function createExec(
     if (command === "git branch --show-current") return "feature-branch\n"
     if (command.startsWith("git worktree remove")) return ""
     if (command.startsWith("git worktree prune")) return ""
+    if (command.startsWith("git cat-file -e")) return ""
     if (command.startsWith("git diff --no-ext-diff")) {
       return [
         "diff --git a/src/app.ts b/src/app.ts",


### PR DESCRIPTION
Closes #226

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fetches missing pull request base/head commits before building local diff targets for review and merge workflows.

## Current behavior (updates)

`/magi:merge` could surface raw `fatal: bad object` failures when the local worktree did not have the base commit needed by `git diff`.

## New behavior

The workflow checks required diff commits with `git cat-file`, fetches the relevant PR base/head refs when needed, retries the checks, and reports a clear unavailable-commit error if the commit still cannot be resolved.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/review.test.ts src/orchestrator/merge.test.ts src/orchestrator/scenarios.test.ts`.