### PR TITLE
fix(review): block approvals for scope-in ci failures

### DIFF
--- a/.changeset/block-ci-review-approvals.md
+++ b/.changeset/block-ci-review-approvals.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Prompt reviewers to request changes when scope-in CI failures are present.

--- a/src/orchestrator/ci.test.ts
+++ b/src/orchestrator/ci.test.ts
@@ -726,6 +726,14 @@ describe("check handling", () => {
     expect(result?.report.scopeInside).toMatchObject([
       { check: failed[0], classification: "SCOPE_IN" },
     ])
+    expect(result?.ciFailureContext).toContain(
+      "Do not approve this PR while this ci_failure_context is present.",
+    )
+    expect(result?.ciFailureContext).toContain("Return CHANGES_REQUESTED")
+    expect(result?.ciFailureContext).toContain(
+      "nearest responsible or first relevant changed line",
+    )
+    expect(result?.ciFailureContext).not.toContain("review hint")
     expect(result?.ciFailureContext).toContain("Type error")
     expectNoRunRerun(commands)
   })

--- a/src/orchestrator/ci.ts
+++ b/src/orchestrator/ci.ts
@@ -293,7 +293,15 @@ function ciFailureContextForClassified(
 
   return [
     "CI has scope-in failures that may be caused by this PR.",
-    "Use this as a review hint; still inspect the PR diff before reporting findings.",
+    "Treat these failures as blocking review issues until the checks pass.",
+    [
+      "Do not approve this PR while this ci_failure_context is present.",
+      "Return CHANGES_REQUESTED and include a finding for each failing CI check.",
+    ].join(" "),
+    [
+      "Still inspect the PR diff before reporting findings.",
+      "If a CI failure does not map to an exact changed line, anchor the finding to the nearest responsible or first relevant changed line.",
+    ].join(" "),
     "",
     ...sections,
   ].join("\n\n")


### PR DESCRIPTION
Closes #232

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates the CI failure context prompt so reviewers treat scope-in CI failures as blocking review issues instead of hints.

## Current behavior (updates)

Reviewers could approve a PR even when `ci_failure_context` described scope-in CI failures, causing approvals to be posted before merge orchestration stopped on unresolved CI.

## New behavior

When scope-in CI failures are present, reviewers are explicitly instructed not to approve, to return `CHANGES_REQUESTED`, and to anchor CI findings to the nearest responsible or first relevant changed line when no exact changed line exists.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/orchestrator/ci.test.ts`.