### PR TITLE
test(run-manager): allow concurrent triage start ordering

### DIFF
--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -493,16 +493,20 @@ describe("MagiRunManager notifications", () => {
       }
 
       await vi.waitFor(() => expect(runTriageMock).toHaveBeenCalledTimes(2))
-      expect(runTriageMock.mock.calls.map(([input]) => input.issue)).toEqual([
-        1, 2,
-      ])
+      expect(
+        runTriageMock.mock.calls
+          .map(([input]) => input.issue)
+          .toSorted((left, right) => left - right),
+      ).toEqual([1, 2])
 
       resolvers[0]?.({})
 
       await vi.waitFor(() => expect(runTriageMock).toHaveBeenCalledTimes(3))
-      expect(runTriageMock.mock.calls.map(([input]) => input.issue)).toEqual([
-        1, 2, 3,
-      ])
+      expect(
+        runTriageMock.mock.calls
+          .map(([input]) => input.issue)
+          .toSorted((left, right) => left - right),
+      ).toEqual([1, 2, 3])
 
       resolvers[1]?.({})
       resolvers[2]?.({})


### PR DESCRIPTION
Closes N/A - issue intentionally not specified per request.

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates the run manager triage concurrency test so it verifies the configured concurrency behavior without depending on the nondeterministic order in which concurrent async runs reach the mocked triage function.

## Current behavior (updates)

The test expected concurrent triage runs to reach the mock strictly in issue order, which can fail when each run performs asynchronous setup before invoking triage.

## New behavior

The test now asserts that the expected issues are started within the concurrency limit, regardless of the ordering between simultaneously started runs.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validation:
- pnpm vitest run src/orchestrator/run-manager.test.ts
- pnpm test