### PR TITLE
fix(prompts): use existing PR triage vote names

### DIFF
--- a/.changeset/fuzzy-walls-flow.md
+++ b/.changeset/fuzzy-walls-flow.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Fix the existing PR triage prompt to use the structured vote names required by the output contract.

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -14,6 +14,7 @@ import {
   composeReviewPrompt,
   composeTriageCommentPrompt,
   composeTriageCreatePrPrompt,
+  composeTriageExistingPrPrompt,
   composeTriageQuestionPrompt,
 } from "./compose"
 
@@ -544,5 +545,78 @@ describe("prompt composer", () => {
     expect(createPrPrompt).toContain(
       "The orchestrator pushes and creates the PR using pullRequest exactly as provided.",
     )
+  })
+
+  test("uses valid existing PR triage vote names in the built-in prompt", async () => {
+    const repository: ResolvedRepository = {
+      agents: { reviewers: [] },
+      alias: "repo",
+      automation: { close: true, merge: true },
+      checks: {
+        exclude: [],
+        retryFailedJobs: 3,
+        waitAfterEdit: true,
+        waitBeforeReview: true,
+      },
+      concurrency: { runs: 3, reviewers: 3 },
+      github: {
+        apiRetryAttempts: 3,
+        host: "github.com",
+        owner: "owner",
+        repo: "repo",
+      },
+      merge: {
+        approvalPolicy: "majority",
+        auto: true,
+        deleteBranch: true,
+        maxThreadResolutionCycles: 5,
+        mergeQueue: false,
+        method: "squash",
+      },
+      prompts: {},
+      safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
+      triage: {
+        automation: {
+          clear: [],
+          close: false,
+          create: false,
+          merge: false,
+          review: false,
+        },
+        categories: [],
+        concurrency: { runs: 3 },
+        prompts: {},
+        safety: {
+          allowAuthors: [],
+          allowMentionActors: [],
+          allowMentionRoles: [],
+          blockedLabels: [],
+          requiredLabels: [],
+        },
+      },
+    }
+
+    const prompt = await composeTriageExistingPrPrompt({
+      context: "PR #12 closes issue #58.",
+      directory: process.cwd(),
+      issue: 58,
+      repository,
+      voter: {
+        account: "triage-a",
+        index: 0,
+        key: "triage-a",
+        model: "openai/gpt",
+        permission: { read: "allow" },
+      },
+    })
+
+    expect(prompt).toContain(
+      "Return RELATED_PR_HANDLES_ISSUE only when the PR clearly addresses the issue.",
+    )
+    expect(prompt).toContain("RELATED_PR_DOES_NOT_HANDLE_ISSUE")
+    expect(prompt).toContain(
+      '"vote": "RELATED_PR_HANDLES_ISSUE" | "RELATED_PR_DOES_NOT_HANDLE_ISSUE"',
+    )
+    expect(prompt).not.toContain("Return HANDLE")
   })
 })

--- a/src/prompts/templates/triage/existing-pr.md
+++ b/src/prompts/templates/triage/existing-pr.md
@@ -1,6 +1,6 @@
 Decide whether an existing related pull request already handles issue #{issue} in {owner}/{repo}.
 
-Use only the provided context. Return HANDLE only when the PR clearly addresses the issue.
+Use only the provided context. Return RELATED_PR_HANDLES_ISSUE only when the PR clearly addresses the issue. Otherwise return RELATED_PR_DOES_NOT_HANDLE_ISSUE.
 
 <context>
 {context}


### PR DESCRIPTION
Closes #241

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes the built-in existing-PR triage prompt so it instructs agents to return the structured vote names accepted by the output contract.

## Current behavior (updates)

The prompt asked agents to return `HANDLE`, which is not a valid existing-PR triage vote.

## New behavior

The prompt now asks for `RELATED_PR_HANDLES_ISSUE` or `RELATED_PR_DOES_NOT_HANDLE_ISSUE`, and prompt composition coverage verifies the valid names are present while the invalid `Return HANDLE` instruction is absent.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/prompts/compose.test.ts`.