### PR TITLE
docs(triage): document validation and flags

### DIFF
--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -5,6 +5,7 @@
 ```txt
 /magi:triage <ISSUE...>
 /magi:triage --dry-run <ISSUE...>
+/magi:triage --sync --timeout 300 <ISSUE...>
 /magi:triage --no-close --create --review <ISSUE...>
 ```
 
@@ -16,20 +17,22 @@ Per-run flags override merged config before validation and resolution. If both p
 
 Triage flags:
 
-| Flag                      | Overrides                  |
-| ------------------------- | -------------------------- |
-| `--language <value>`      | `language`                 |
-| `--close`, `--no-close`   | `triage.automation.close`  |
-| `--create`, `--no-create` | `triage.automation.create` |
-| `--review`, `--no-review` | `triage.automation.review` |
-| `--merge`, `--no-merge`   | `triage.automation.merge`  |
-| `--run-concurrency <n>`   | `triage.concurrency.runs`  |
+| Flag                      | Effect or override                                      |
+| ------------------------- | ------------------------------------------------------- |
+| `--sync`                  | Wait for the triage run to finish before returning.     |
+| `--timeout <seconds>`     | Stop waiting after this many seconds when synchronized. |
+| `--language <value>`      | `language`                                              |
+| `--close`, `--no-close`   | `triage.automation.close`                               |
+| `--create`, `--no-create` | `triage.automation.create`                              |
+| `--review`, `--no-review` | `triage.automation.review`                              |
+| `--merge`, `--no-merge`   | `triage.automation.merge`                               |
+| `--run-concurrency <n>`   | `triage.concurrency.runs`                               |
 
 ## What It Does
 
 `/magi:triage` triages GitHub issues with dedicated `triage.agents`. It does not reuse `review.agents`.
 
-Magi fetches bounded issue relationship data, asks triage agents to vote on existing PRs, duplicate issues, issue kind, and bug or feature decisions, then posts one author-mentioned result comment through `triage.account` unless the run is a clear-only linked PR case.
+Magi fetches bounded issue relationship data, asks triage agents to vote on existing PRs, duplicate issues, issue kind, and bug or feature decisions, then posts one author-mentioned result comment through the reporter triage agent account unless the run is a clear-only linked PR case. Configure `triage.reporter` to choose the reporter by resolved triage agent key; otherwise Magi selects one from the issue number.
 
 ## Flow
 
@@ -61,7 +64,7 @@ Triage results:
 
 ## Outputs
 
-Magi may post one author-mentioned issue comment through `triage.account`, close issues, close related open PRs, remove configured labels, create an implementation PR, or start review/merge automation for that PR depending on the final result and automation settings. Clear-only related PR runs do not post a comment.
+Magi may post one author-mentioned issue comment through the reporter triage agent account, close issues, close related open PRs, remove configured labels, create an implementation PR, or start review/merge automation for that PR depending on the final result and automation settings. Clear-only related PR runs do not post a comment.
 
 Triage artifacts are written to the issue run output directory:
 
@@ -83,8 +86,9 @@ Important settings:
 
 | Setting                                | Purpose                                                                                               |
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `triage.account`                       | GitHub account used for triage comments and mutations.                                                |
-| `triage.agents`                        | Dedicated issue triage voting agents.                                                                 |
+| `triage.agents`                        | Dedicated issue triage voting agents. Must be an odd-length array of at least 3 agents.               |
+| `triage.agents[].account`              | GitHub accounts used for voting and reporter mutations. Accounts must be unique after ref expansion.  |
+| `triage.reporter`                      | Optional resolved triage agent key used for comments and mutations.                                   |
 | `triage.creator`                       | Agent used for implementation PR creation when enabled.                                               |
 | `triage.categories`                    | Category IDs and label/type rules that can skip Category Vote. Type rules require GitHub issue types. |
 | `triage.automation.close`              | Enables closing rejected or duplicate issues.                                                         |
@@ -133,7 +137,7 @@ Magi currently fetches issue comments `last: 50`, related PR timeline items `fir
 
 ### Which GitHub accounts are used?
 
-`triage.account` posts triage comments, closes issues and related PRs, and removes labels. `triage.creator.account` pushes implementation branches and opens PRs when PR automation is enabled. Both accounts must be authenticated with GitHub CLI; the triage account needs repository read access, and the creator account needs push access when it differs from the triage account.
+Each `triage.agents[].account` must be authenticated with GitHub CLI and able to read the repository. The reporter triage agent account posts triage comments, closes issues and related PRs, and removes labels. `triage.reporter`, when configured, must match a resolved triage agent key such as an explicit `id` or generated `voter-1` key. `triage.creator.account` pushes implementation branches and opens PRs when PR automation is enabled, and must have repository push permission.
 
 ### What do the automation flags control?
 

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -42,20 +42,21 @@ It does not modify files, create runs, post to GitHub, or start agents.
 
 `/magi:validate` validates the same settings documented in [Config](/docs/config.md). The most important requirements are:
 
-| Setting                   | Requirement                                                 |
-| ------------------------- | ----------------------------------------------------------- |
-| `review.agents`           | Required for review/merge, at least 3 reviewers, odd count. |
-| `review.agents[].model`   | Required full OpenCode model ID in `provider/model` form.   |
-| `review.agents[].account` | Required GitHub account, unique across reviewers.           |
-| `merge.editor`            | Required by `/magi:merge`, optional for `/magi:review`.     |
-| `github.owner`            | Required for PR review/merge runs.                          |
-| `github.repo`             | Required for PR review/merge runs.                          |
-| `review.prompts.*`        | Must point to readable files when configured.               |
-| `merge.prompts.*`         | Must point to readable files when configured.               |
-| `triage.agents`           | Required for triage, at least 3 agents, odd count.          |
-| `triage.account`          | Required GitHub account for triage comments and mutations.  |
-| `triage.creator`          | Optional creator agent for triage PR automation.            |
-| `triage.prompts.*`        | Must point to readable files when configured.               |
+| Setting                   | Requirement                                                           |
+| ------------------------- | --------------------------------------------------------------------- |
+| `review.agents`           | Required for review/merge, at least 3 reviewers, odd count.           |
+| `review.agents[].model`   | Required full OpenCode model ID in `provider/model` form.             |
+| `review.agents[].account` | Required GitHub account, unique across reviewers.                     |
+| `merge.editor`            | Required by `/magi:merge`, optional for `/magi:review`.               |
+| `github.owner`            | Required for PR review/merge runs.                                    |
+| `github.repo`             | Required for PR review/merge runs.                                    |
+| `review.prompts.*`        | Must point to readable files when configured.                         |
+| `merge.prompts.*`         | Must point to readable files when configured.                         |
+| `triage.agents`           | Required for triage, at least 3 agents, odd count.                    |
+| `triage.agents[].account` | Required GitHub account, unique across resolved triage agents.        |
+| `triage.reporter`         | Optional resolved triage agent key used for comments and mutations.   |
+| `triage.creator`          | Required with `triage.creator.account` when PR automation is enabled. |
+| `triage.prompts.*`        | Must point to readable files when configured.                         |
 
 ## FAQ
 
@@ -73,7 +74,7 @@ Yes. The slash command enables auth checks by default and runs `gh auth token --
 
 ### Does it check repository permissions?
 
-Yes, after auth succeeds. Reviewer accounts must be able to read the repository. The editor account must be able to push for editor operations. The triage account must be able to read the repository, and the triage creator account must be able to push when configured separately for implementation PR creation.
+Yes, after auth succeeds. Reviewer accounts must be able to read the repository. The editor account must be able to push for editor operations. Triage agent accounts must be able to read the repository, and the triage creator account must be able to push when implementation PR creation is enabled.
 
 ### Why can validation pass without an editor?
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -95,11 +95,11 @@ If at least one config exists, Magi validates the merged effective config and re
     "editor": { "ref": "account-4" }
   },
   "triage": {
-    "account": "account-5",
+    "reporter": "product",
     "agents": [
-      { "ref": "account-1" },
-      { "ref": "account-2" },
-      { "ref": "account-3" }
+      { "ref": "account-1", "id": "product" },
+      { "ref": "account-2", "id": "maintainer" },
+      { "ref": "account-3", "id": "support" }
     ]
   }
 }
@@ -161,15 +161,16 @@ Entries with `ref` are expanded from `agents.refs`. Fields set alongside `ref` o
 | `review.output`                        | Both    | No                               | `.magi/runs/pr`                                      | Directory for PR run artifacts. PR #123 is stored under `<dir>/123/<runId>`.                                         |
 | `review.worktree`                      | Both    | No                               | `.magi/worktrees/pr`                                 | Directory for temporary PR worktrees. PR #123 is stored under `<dir>/pr-123`.                                        |
 | `triage`                               | Both    | Yes (`/magi:triage`)             | -                                                    | Issue triage configuration.                                                                                          |
-| `triage.account`                       | Both    | Yes (`/magi:triage`)             | -                                                    | GitHub account used to post triage comments, close issues and linked PRs, remove labels, and create PRs by default.  |
 | `triage.agents`                        | Both    | Yes (`/magi:triage`)             | -                                                    | Dedicated issue triage agents. Odd-length array of at least 3 agents.                                                |
 | `triage.agents[].id`                   | Both    | No                               | `voter-1`, ...                                       | Triage agent key used for output files and session tracking.                                                         |
 | `triage.agents[].model`                | Both    | Yes                              | -                                                    | Full OpenCode model ID used by the triage agent.                                                                     |
+| `triage.agents[].account`              | Both    | Yes                              | -                                                    | GitHub account used by the triage agent. Accounts must be unique after ref expansion.                                |
 | `triage.agents[].options`              | Both    | No                               | -                                                    | OpenCode provider/model options injected for this triage agent.                                                      |
 | `triage.agents[].permissions`          | Both    | No                               | [json](/src/permissions/common.json)                 | OpenCode permission overrides for this triage agent.                                                                 |
 | `triage.agents[].persona`              | Both    | No                               | -                                                    | Triage vote perspective for this agent.                                                                              |
+| `triage.reporter`                      | Both    | No                               | Selected from issue number                           | Resolved triage agent key used for comments and triage mutations.                                                    |
 | `triage.creator`                       | Both    | Yes (`triage.automation.create`) | -                                                    | Agent used to create implementation PRs from accepted issues.                                                        |
-| `triage.creator.account`               | Both    | No                               | `triage.account`                                     | GitHub account used to create PRs when different from `triage.account`.                                              |
+| `triage.creator.account`               | Both    | Yes (`triage.automation.create`) | -                                                    | GitHub account used to push implementation branches and open PRs.                                                    |
 | `triage.creator.model`                 | Both    | Yes (`triage.automation.create`) | -                                                    | Full OpenCode model ID used by the PR creator agent.                                                                 |
 | `triage.creator.options`               | Both    | No                               | -                                                    | OpenCode provider/model options injected for the PR creator agent.                                                   |
 | `triage.creator.permissions`           | Both    | No                               | [json](/src/permissions/editor.json)                 | OpenCode permission overrides for the PR creator agent.                                                              |
@@ -189,8 +190,8 @@ Entries with `ref` are expanded from `agents.refs`. Fields set alongside `ref` o
 | `triage.safety.requiredLabels`         | Both    | No                               | `["triage"]`                                         | Labels required before initial triage runs.                                                                          |
 | `triage.safety.blockedLabels`          | Both    | No                               | `[]`                                                 | Labels that prevent triage from running.                                                                             |
 | `triage.safety.allowAuthors`           | Both    | No                               | `[]`                                                 | If set, only issues created by these GitHub logins can be triaged.                                                   |
-| `triage.safety.allowMentionActors`     | Both    | No                               | `[]`                                                 | GitHub logins allowed to trigger reconsideration by mentioning `triage.account`.                                     |
-| `triage.safety.allowMentionRoles`      | Both    | No                               | `["AUTHOR", "OWNER", "MEMBER", "COLLABORATOR"]`      | GitHub author associations allowed to trigger reconsideration by mentioning `triage.account`.                        |
+| `triage.safety.allowMentionActors`     | Both    | No                               | `[]`                                                 | GitHub logins allowed to trigger reconsideration by mentioning the reporter triage agent account.                    |
+| `triage.safety.allowMentionRoles`      | Both    | No                               | `["AUTHOR", "OWNER", "MEMBER", "COLLABORATOR"]`      | GitHub author associations allowed to trigger reconsideration by mentioning the reporter triage agent account.       |
 | `triage.concurrency.runs`              | Both    | No                               | `3`                                                  | Maximum issues processed concurrently.                                                                               |
 | `triage.prompts`                       | Both    | No                               | -                                                    | Triage prompt template file path overrides.                                                                          |
 | `triage.prompts.existingPr`            | Both    | No                               | [md](/docs/prompts/triage/existing-pr.md)            | Task template override for checking whether related pull requests handle the issue.                                  |
@@ -272,17 +273,24 @@ Supported actions are `allow`, `ask`, and `deny`. Pattern objects are order-sens
 - Reviewers must be an odd number of at least 3.
 - Reviewer keys must be unique. The key is `id` when provided, otherwise `reviewer-1`, `reviewer-2`, and so on.
 - Reviewer `account` values must be unique.
+- Triage agents must be an odd number of at least 3.
+- Triage agent keys must be unique after ref expansion. The key is `id` when provided, otherwise `voter-1`, `voter-2`, and so on.
+- Triage agent `account` values must be unique after ref expansion.
+- `triage.reporter`, when configured, must match a resolved triage agent key.
 - Each configured account must be logged in for GitHub CLI: `gh auth token --user <account>`.
 - `merge.editor` is required when running `/magi:merge`, but not when running only `/magi:review`.
+- `triage.creator` and `triage.creator.account` are required when `triage.automation.create` is `true`.
 - Permission values must be `allow`, `ask`, `deny`, or an object of pattern-to-action rules.
 
 ## GitHub Permissions
 
-Each reviewer account must be able to read the target repository and post PR reviews or comments. Each editor account must be able to reply to comments, resolve review threads, push to the PR branch, and merge or close the PR when `/magi:merge` reaches that step.
+Each reviewer account must be able to read the target repository and post PR reviews or comments. Each triage agent account must be able to read the target repository; the reporter triage agent account is also used for triage comments and issue or linked-PR mutations. Each editor account must be able to reply to comments, resolve review threads, push to the PR branch, and merge or close the PR when `/magi:merge` reaches that step. The triage creator account must be able to push when implementation PR creation automation is enabled.
 
 When auth validation runs, Magi checks repository-level permissions through GitHub's repository API:
 
 - Reviewer accounts must have `.permissions.pull`.
+- Triage agent accounts must have `.permissions.pull`.
 - Editor accounts must have `.permissions.push`.
+- Triage creator accounts must have `.permissions.push`.
 
 This is an early sanity check, not a complete guarantee. Branch protection, merge queue rules, fork PR branch permissions, review dismissal policies, and other repository rules can still reject pushes, merges, review posts, or thread resolution at runtime.


### PR DESCRIPTION
Closes #240

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Documents implemented `/magi:triage` sync and timeout flags plus triage validation, reporter, authentication, and repository permission requirements.

## Current behavior (updates)

The triage and validation docs omitted implemented flags and still described the old `triage.account` model in key places.

## New behavior

The docs now list `--sync` and `--timeout <seconds>`, explain triage agent count/key/account validation, document `triage.reporter`, and clarify read/push permission checks for triage agents and creator accounts.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change. Tests were not run.