### PR TITLE
fix(github): narrow fetch issue fallback

### DIFF
--- a/.changeset/narrow-fetch-issue-fallback.md
+++ b/.changeset/narrow-fetch-issue-fallback.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Limit fetchIssue CLI fallback to issue type schema errors.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -137,13 +137,17 @@ describe("GitHub command helpers", () => {
     })
   })
 
-  test("falls back to gh issue view without issue type when GraphQL is unavailable", async () => {
+  test("falls back to gh issue view without issue type when issueType is unavailable", async () => {
     const commands: string[] = []
 
     const result = await fetchIssue(
       async (value) => {
         commands.push(value)
-        if (value.includes("graphql")) throw new Error("unsupported field")
+        if (value.includes("graphql")) {
+          throw new Error(
+            'GraphQL: Cannot query field "issueType" on type "Issue".',
+          )
+        }
 
         return JSON.stringify({
           author: { login: "author" },
@@ -164,6 +168,42 @@ describe("GitHub command helpers", () => {
       "--json number,title,body,url,state,author,labels",
     )
     expect(result.type).toBeUndefined()
+  })
+
+  test("surfaces non-issueType GraphQL command failures", async () => {
+    const commands: string[] = []
+
+    await expect(
+      fetchIssue(
+        async (value) => {
+          commands.push(value)
+          throw new Error("authentication required")
+        },
+        repository,
+        56,
+      ),
+    ).rejects.toThrow("authentication required")
+
+    expect(commands).toHaveLength(1)
+    expect(commands[0]).toContain("gh api graphql")
+  })
+
+  test("surfaces malformed GraphQL issue responses", async () => {
+    const commands: string[] = []
+
+    await expect(
+      fetchIssue(
+        async (value) => {
+          commands.push(value)
+          return "not json"
+        },
+        repository,
+        56,
+      ),
+    ).rejects.toThrow()
+
+    expect(commands).toHaveLength(1)
+    expect(commands[0]).toContain("gh api graphql")
   })
 
   test("searches duplicate issue candidates by title and excludes the current issue", async () => {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -229,6 +229,37 @@ function errorText(error: unknown): string {
     .join("\n")
 }
 
+function isIssueTypeUnavailableText(text: string): boolean {
+  return (
+    /cannot query field ["']?issueType["']? on type ["']?Issue["']?/i.test(
+      text,
+    ) ||
+    /field ["']?issueType["']?.*(does not exist|doesn't exist|is not defined|not found).*type ["']?Issue["']?/i.test(
+      text,
+    ) ||
+    /undefinedField.*issueType/i.test(text) ||
+    /issueType.*unsupported field|unsupported field.*issueType/i.test(text)
+  )
+}
+
+function isIssueTypeUnavailableError(error: unknown): boolean {
+  return isIssueTypeUnavailableText(errorText(error))
+}
+
+function isIssueTypeUnavailableGraphqlResponse(data: {
+  errors?: { message?: string; type?: string }[]
+}): boolean {
+  return (
+    data.errors?.some((error) =>
+      isIssueTypeUnavailableText(
+        [error.message, error.type]
+          .filter((item): item is string => typeof item === "string")
+          .join("\n"),
+      ),
+    ) ?? false
+  )
+}
+
 async function localCommitExists(
   exec: Exec,
   worktreePath: string,
@@ -534,43 +565,56 @@ export async function fetchIssue(
   issue: number,
 ): Promise<IssueMeta> {
   const query = `query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { number title body url state author { login } labels(first: 100) { nodes { name } } issueType { name } } } }`
+  let raw: string
 
   try {
-    const raw = await exec(
+    raw = await exec(
       `gh api${ghHostOption(repository)} graphql -f query=${shellQuote(query)} -F owner=${shellQuote(repository.github.owner)} -F repo=${shellQuote(repository.github.repo)} -F issue=${issue}`,
     )
-    const data = JSON.parse(raw) as {
-      data?: {
-        repository?: {
-          issue?: {
-            author?: { login?: string }
-            body?: string
-            issueType?: { name?: string } | null
-            labels?: { nodes?: { name: string }[] }
-            number: number
-            state: string
-            title: string
-            url: string
-          }
+  } catch (error) {
+    if (isIssueTypeUnavailableError(error)) {
+      return fetchIssueWithCli(exec, repository, issue)
+    }
+
+    throw error
+  }
+
+  const data = JSON.parse(raw) as {
+    data?: {
+      repository?: {
+        issue?: {
+          author?: { login?: string }
+          body?: string
+          issueType?: { name?: string } | null
+          labels?: { nodes?: { name: string }[] }
+          number: number
+          state: string
+          title: string
+          url: string
         }
       }
     }
-    const graphqlIssue = data.data?.repository?.issue
+    errors?: { message?: string; type?: string }[]
+  }
+  const graphqlIssue = data.data?.repository?.issue
 
-    if (!graphqlIssue) throw new Error(`Could not fetch issue #${issue}`)
-
-    return {
-      author: graphqlIssue.author?.login ?? "",
-      body: graphqlIssue.body ?? "",
-      labels: graphqlIssue.labels?.nodes?.map((label) => label.name) ?? [],
-      number: graphqlIssue.number,
-      state: graphqlIssue.state,
-      title: graphqlIssue.title,
-      type: graphqlIssue.issueType?.name,
-      url: graphqlIssue.url,
+  if (!graphqlIssue) {
+    if (isIssueTypeUnavailableGraphqlResponse(data)) {
+      return fetchIssueWithCli(exec, repository, issue)
     }
-  } catch {
-    return fetchIssueWithCli(exec, repository, issue)
+
+    throw new Error(`Could not fetch issue #${issue}`)
+  }
+
+  return {
+    author: graphqlIssue.author?.login ?? "",
+    body: graphqlIssue.body ?? "",
+    labels: graphqlIssue.labels?.nodes?.map((label) => label.name) ?? [],
+    number: graphqlIssue.number,
+    state: graphqlIssue.state,
+    title: graphqlIssue.title,
+    type: graphqlIssue.issueType?.name,
+    url: graphqlIssue.url,
   }
 }
 

--- a/src/orchestrator/review-context.test.ts
+++ b/src/orchestrator/review-context.test.ts
@@ -286,7 +286,7 @@ describe("review context", () => {
     expect(snapshot.referencedIssues).toEqual([])
     expect(
       commands.filter((command) => command.startsWith("gh issue view ")),
-    ).toHaveLength(5)
+    ).toHaveLength(0)
   })
 
   test("detects closing and referenced issue relationships", () => {


### PR DESCRIPTION
Closes #243

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Limits fetchIssue() fallback to the known GitHub GraphQL issueType schema-unavailable case.

## Current behavior (updates)

Any GraphQL request, parsing, or response validation failure was caught and retried through gh issue view without issue type metadata.

## New behavior

fetchIssue() only falls back when the GraphQL failure explicitly indicates issueType is unavailable. Other GraphQL command failures and malformed responses surface to the caller. Added focused tests and a patch changeset.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm vitest run src/github/commands.test.ts`.