### PR TITLE
fix(github): wait for required pr checks

### DIFF
--- a/.changeset/required-pr-checks.md
+++ b/.changeset/required-pr-checks.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Wait only for required pull request checks during CI gating.

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -22,6 +22,7 @@ import {
   repoSpecifier,
   searchDuplicateIssues,
   shellQuote,
+  watchChecks,
   waitForAutoMerge,
   waitForMergeQueue,
 } from "./commands"
@@ -534,6 +535,44 @@ describe("GitHub command helpers", () => {
     )
 
     expect(result).toEqual([])
+  })
+
+  test("fetches only required pull request checks when requested", async () => {
+    let command = ""
+
+    await fetchPullRequestChecks(
+      async (value) => {
+        command = value
+
+        return "[]"
+      },
+      repository,
+      1,
+      { requiredOnly: true },
+    )
+
+    expect(command).toBe(
+      "gh pr checks 1 --repo 'owner/repo' --json name,state,bucket,link,workflow --required",
+    )
+  })
+
+  test("watches only required pull request checks when requested", async () => {
+    let command = ""
+
+    await watchChecks(
+      async (value) => {
+        command = value
+
+        return ""
+      },
+      repository,
+      1,
+      { requiredOnly: true },
+    )
+
+    expect(command).toBe(
+      "gh pr checks 1 --repo 'owner/repo' --watch --required",
+    )
   })
 
   test("keeps other pull request check failures fatal", async () => {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -96,7 +96,12 @@ export interface PullRequestCheck {
 }
 
 export interface FetchPullRequestChecksOptions {
+  requiredOnly?: boolean
   tolerateMissingChecks?: boolean
+}
+
+export interface WatchChecksOptions {
+  requiredOnly?: boolean
 }
 
 export interface IssueComment {
@@ -1141,9 +1146,12 @@ export async function watchChecks(
   exec: Exec,
   repository: ResolvedRepository,
   pr: number,
+  options: WatchChecksOptions = {},
 ): Promise<void> {
+  const requiredFlag = options.requiredOnly ? " --required" : ""
+
   await exec(
-    `gh pr checks ${pr} --repo ${shellQuote(repoSpecifier(repository))} --watch`,
+    `gh pr checks ${pr} --repo ${shellQuote(repoSpecifier(repository))} --watch${requiredFlag}`,
   )
 }
 
@@ -1162,10 +1170,11 @@ export async function fetchPullRequestChecks(
   options: FetchPullRequestChecksOptions = {},
 ): Promise<PullRequestCheck[]> {
   let raw: string
+  const requiredFlag = options.requiredOnly ? " --required" : ""
 
   try {
     raw = await exec(
-      `gh pr checks ${pr} --repo ${shellQuote(repoSpecifier(repository))} --json name,state,bucket,link,workflow`,
+      `gh pr checks ${pr} --repo ${shellQuote(repoSpecifier(repository))} --json name,state,bucket,link,workflow${requiredFlag}`,
     )
   } catch (error) {
     if (

--- a/src/orchestrator/ci.test.ts
+++ b/src/orchestrator/ci.test.ts
@@ -308,6 +308,42 @@ describe("check handling", () => {
     expect(progress).toContain("CI checks passed")
   })
 
+  test("uses required checks for CI waiting and classification", async () => {
+    const commands: string[] = []
+
+    const result = await waitForChecksWithClassification({
+      client: {
+        session: {
+          create: async () => ({ id: "session" }),
+          prompt: async () => {
+            throw new Error("optional checks should not be classified")
+          },
+        },
+      },
+      directory: ".",
+      exec: async (command) => {
+        commands.push(command)
+
+        if (command.includes("--watch")) return ""
+        if (command.includes("--json")) return "[]"
+
+        return ""
+      },
+      pr: 1,
+      repairAttempts: 0,
+      repository,
+      wait: true,
+    })
+
+    expect(result?.report.failed).toEqual([])
+    expect(commands).toContain(
+      "gh pr checks 1 --repo 'owner/repo' --watch --required",
+    )
+    expect(commands).toContain(
+      "gh pr checks 1 --repo 'owner/repo' --json name,state,bucket,link,workflow --required",
+    )
+  })
+
   test("classifies existing failures without waiting when wait is false", async () => {
     const commands: string[] = []
     const failed = [check()]
@@ -506,15 +542,8 @@ describe("check handling", () => {
     expect(result?.ciFailureContext).toContain("new head failure")
   })
 
-  test("keeps polling when target-head checks are not reported yet", async () => {
+  test("does not keep polling when no required checks are reported", async () => {
     let checksCalls = 0
-    const passed = {
-      bucket: "pass",
-      link: "https://github.com/owner/repo/actions/runs/2/job/456",
-      name: "Test",
-      state: "SUCCESS",
-      workflow: "CI",
-    }
 
     const result = await waitForChecksWithClassification({
       client: {
@@ -532,13 +561,9 @@ describe("check handling", () => {
         }
         if (command.includes("--json")) {
           checksCalls += 1
-          if (checksCalls === 1) {
-            throw Object.assign(new Error("Command failed"), {
-              stderr: "no checks reported on the 'feature-branch' branch",
-            })
-          }
-
-          return JSON.stringify([passed])
+          throw Object.assign(new Error("Command failed"), {
+            stderr: "no checks reported on the 'feature-branch' branch",
+          })
         }
 
         return ""
@@ -551,7 +576,7 @@ describe("check handling", () => {
       waitPollIntervalMs: 0,
     })
 
-    expect(checksCalls).toBe(2)
+    expect(checksCalls).toBe(1)
     expect(result?.report.failed).toEqual([])
     expect(result?.ciFailureContext).toBe("")
   })

--- a/src/orchestrator/ci.ts
+++ b/src/orchestrator/ci.ts
@@ -45,7 +45,6 @@ interface CiFailureEvidence {
 interface TargetChecks {
   blocking: PullRequestCheck[]
   hasAnyActionCheck: boolean
-  hasAnyCheck: boolean
   hasPending: boolean
   hasTargetActionCheck: boolean
 }
@@ -382,7 +381,7 @@ async function checksForHead(input: {
     input.exec,
     input.repository,
     input.pr,
-    { tolerateMissingChecks: Boolean(input.headSha) },
+    { requiredOnly: true, tolerateMissingChecks: Boolean(input.headSha) },
   )
   const targetChecks: PullRequestCheck[] = []
   let hasAnyActionCheck = false
@@ -415,7 +414,6 @@ async function checksForHead(input: {
       (check) => isFailedCheck(check) || isCancelledCheck(check),
     ),
     hasAnyActionCheck,
-    hasAnyCheck: checks.length > 0,
     hasPending: targetChecks.some(isPendingCheck),
     hasTargetActionCheck,
   }
@@ -718,7 +716,9 @@ export async function waitForChecksWithClassification(input: {
 
     for (let attempt = 0; ; attempt += 1) {
       try {
-        await watchChecks(input.exec, input.repository, input.pr)
+        await watchChecks(input.exec, input.repository, input.pr, {
+          requiredOnly: true,
+        })
       } catch {
         // gh exits non-zero for pending checks too; re-read check state below.
       }
@@ -726,8 +726,8 @@ export async function waitForChecksWithClassification(input: {
       const target = await readTargetChecks()
       const waitingForTargetHead =
         Boolean(input.headSha) &&
-        (!target.hasAnyCheck ||
-          (target.hasAnyActionCheck && !target.hasTargetActionCheck))
+        target.hasAnyActionCheck &&
+        !target.hasTargetActionCheck
 
       if (!waitingForTargetHead && !target.hasPending) {
         await assignBlockingChecks(target.blocking)
@@ -834,7 +834,11 @@ export async function waitForChecksWithClassification(input: {
     try {
       await input.onProgress?.("waiting for rerun CI checks")
       await watchRerunRuns(input.exec, input.repository, rerunnable)
-      if (input.wait) await watchChecks(input.exec, input.repository, input.pr)
+      if (input.wait) {
+        await watchChecks(input.exec, input.repository, input.pr, {
+          requiredOnly: true,
+        })
+      }
     } catch {
       // Re-read the PR checks below so stale failed checks are not trusted.
     }

--- a/src/orchestrator/scenarios.test.ts
+++ b/src/orchestrator/scenarios.test.ts
@@ -362,6 +362,7 @@ function createExec(
     issueComments?: IssueComment[]
     labels?: string[]
     relatedPullRequests?: RelatedPullRequest[]
+    requiredChecks?: PullRequestCheck[]
     reviews?: PullRequestReview[]
     triageIssue?: IssueMeta
     threads?: ReviewThread[]
@@ -396,7 +397,11 @@ function createExec(
     }
     if (command.startsWith("gh pr checks 7") && command.includes("--json")) {
       checksRead += 1
-      return JSON.stringify(checksRead === 1 ? (input.checks ?? []) : [])
+      const checks = command.includes("--required")
+        ? (input.requiredChecks ?? input.checks ?? [])
+        : (input.checks ?? [])
+
+      return JSON.stringify(checksRead === 1 ? checks : [])
     }
     if (command.startsWith("gh run view")) return "Error: stale test failure"
     if (command.startsWith("gh run rerun")) return ""
@@ -558,6 +563,7 @@ async function runReviewScenario(input: {
   labels?: string[]
   outputs: string[]
   repository?: ResolvedRepository
+  requiredChecks?: PullRequestCheck[]
   reviews?: PullRequestReview[]
   threads?: ReviewThread[]
 }) {
@@ -567,6 +573,7 @@ async function runReviewScenario(input: {
   const exec = createExec({
     checks: input.checks,
     labels: input.labels,
+    requiredChecks: input.requiredChecks,
     reviews: input.reviews,
     threads: input.threads,
   })
@@ -595,12 +602,17 @@ async function runMergeScenario(input: {
   dryRun?: boolean
   outputs: string[]
   repository?: ResolvedRepository
+  requiredChecks?: PullRequestCheck[]
   reviews?: PullRequestReview[]
 }) {
   const directory = await mkdtemp(join(tmpdir(), "magi-merge-scenario-"))
   temporaryDirs.push(directory)
   const model = createModelClient([...input.outputs])
-  const exec = createExec({ checks: input.checks, reviews: input.reviews })
+  const exec = createExec({
+    checks: input.checks,
+    requiredChecks: input.requiredChecks,
+    reviews: input.reviews,
+  })
   const progress: unknown[] = []
   const result = await runMerge({
     client: model.client,
@@ -665,6 +677,16 @@ function ciCheck(): PullRequestCheck {
     name: "test",
     state: "FAILURE",
     workflow: "CI",
+  }
+}
+
+function pendingMergeCheck(): PullRequestCheck {
+  return {
+    bucket: "pending",
+    link: "https://github.com/owner/repo/actions/runs/999/job/888",
+    name: "Merge",
+    state: "IN_PROGRESS",
+    workflow: "Merge",
   }
 }
 
@@ -998,6 +1020,30 @@ describe("scenario: /magi:merge", () => {
     expect(
       result.commands.some((command) => command.includes("enqueuePullRequest")),
     ).toBe(false)
+  })
+
+  test("does not wait on a non-required pending Merge check", async () => {
+    const result = await runMergeScenario({
+      checks: [pendingMergeCheck()],
+      outputs: [
+        reviewOutput("MERGE"),
+        reviewOutput("MERGE"),
+        reviewOutput("MERGE"),
+      ],
+      repository: {
+        ...repository,
+        checks: { ...repository.checks, waitBeforeReview: true },
+      },
+      requiredChecks: [],
+    })
+
+    expect(result.result.status).toBe("merged")
+    expect(
+      result.commands.filter((command) => command.startsWith("gh pr checks 7")),
+    ).toEqual([
+      "gh pr checks 7 --repo 'owner/repo' --watch --required",
+      "gh pr checks 7 --repo 'owner/repo' --json name,state,bucket,link,workflow --required",
+    ])
   })
 
   test("enqueues an approved PR when merge queue is required", async () => {


### PR DESCRIPTION
Closes #253

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Change CI gating to wait on required pull request checks only.

## Current behavior (updates)

`magi:review` and post-edit `magi:merge` CI gating used `gh pr checks` without `--required`, so optional orchestration checks such as the `Merge` workflow could be included in the wait set.

## New behavior

GitHub check helpers now support a `requiredOnly` option, and CI gating calls `gh pr checks --required` for both watch and fetch paths. Optional pending checks are ignored for gating, while required failures, cancellations, classification, and rerun behavior continue to use the required-check set.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Targeted tests passed: `pnpm vitest run src/github/commands.test.ts src/orchestrator/ci.test.ts src/orchestrator/scenarios.test.ts`.