### PR TITLE
docs: add source rules

### DIFF
--- a/.agents/rules/source.md
+++ b/.agents/rules/source.md
@@ -1,0 +1,9 @@
+# Source Rules
+
+When changing or reviewing `src/**`, follow these rules.
+
+## Documentation
+
+Update README or `docs/**` when the change affects user-facing behavior, configuration, commands, prompt customization, generated output, installation, setup, or examples.
+
+If no documentation update is needed, state why in the PR description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ When editing or reviewing files that match a pattern below, read the linked rule
   - `schema.json`
   - `package.json`
   - `README.md`
+- [Source](.agents/rules/source.md):
+  - `src/**/*.{ts,md,json}`
+  - `!src/**/*.test.ts`
 - [Documentation](.agents/rules/documentation.md):
   - `{.agents,docs}/**/*.md`
   - `./*.md`


### PR DESCRIPTION
Closes: N/A (no issue requested)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add source file rules so contributors and agents check documentation updates when changing `src/**`.

## Current behavior (updates)

`src/**` changes only point agents to the changeset rule, so documentation update checks can be missed.

## New behavior

`AGENTS.md` now links `src/**/*.{ts,md,json}` changes to a new Source rule. The rule requires README or `docs/**` updates for user-facing source changes, or a PR description note when documentation is not needed.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tests not run because this is a documentation-only change.