### PR TITLE
ci(workflows): specify opencode run model

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -51,4 +51,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          opencode run --dir "$GITHUB_WORKSPACE" --command "magi:merge" "${{ github.event.pull_request.number }} --sync"
+          opencode run --dir "$GITHUB_WORKSPACE" --model "openai/gpt-5.5" --command "magi:merge" "${{ github.event.pull_request.number }} --sync"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -51,4 +51,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          opencode run --dir "$GITHUB_WORKSPACE" --command "magi:triage" "${{ github.event.issue.number }} --sync"
+          opencode run --dir "$GITHUB_WORKSPACE" --model "openai/gpt-5.5" --command "magi:triage" "${{ github.event.issue.number }} --sync"


### PR DESCRIPTION
Closes: N/A (no issue requested)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Specify the OpenCode model used by the triage and merge GitHub Actions commands.

## Current behavior (updates)

The triage and merge workflows run `opencode run` without an explicit model, so OpenCode can use its default command model before Magi configuration is loaded.

## New behavior

The triage and merge workflows pass `--model "openai/gpt-5.5"` when invoking Magi commands, matching the intended OpenAI model for the command runner.

## Is this a breaking change (Yes/No):

No.

## Additional Information

No local tests were run because this only changes GitHub Actions command invocations.