### PR TITLE
fix(triage): make decision comments natural

### DIFF
--- a/.changeset/natural-triage-comments.md
+++ b/.changeset/natural-triage-comments.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Make non-ASK triage comments read like natural issue comments.

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -32,7 +32,7 @@ Triage flags:
 
 `/magi:triage` triages GitHub issues with dedicated `triage.agents`. It does not reuse `review.agents`.
 
-Magi fetches bounded issue relationship data, asks triage agents to vote on existing PRs, duplicate issues, issue kind, and bug or feature decisions, then posts comments according to the final result unless the run is a clear-only linked PR case or is blocked by a safety gate. `ASK` comments come from each non-empty `ASK` vote body and use that voting agent's account. Non-`ASK` result comments are generated from the decision summary and use the selected reporter account. Configure `triage.reporter` to choose the reporter by resolved triage agent key; otherwise Magi selects one from the issue number.
+Magi fetches bounded issue relationship data, asks triage agents to vote on existing PRs, duplicate issues, issue kind, and bug or feature decisions, then posts comments according to the final result unless the run is a clear-only linked PR case or is blocked by a safety gate. `ASK` comments come from each non-empty `ASK` vote body and use that voting agent's account. Non-`ASK` result comments use the selected reason when one is available, otherwise a natural fallback, and are posted by the selected reporter account. Configure `triage.reporter` to choose the reporter by resolved triage agent key; otherwise Magi selects one from the issue number.
 
 ## Flow
 
@@ -64,7 +64,7 @@ Triage results:
 
 ## Outputs
 
-Magi may post issue comments, close issues, close related open PRs, remove configured labels, create an implementation PR, or start review/merge automation for that PR depending on the final result and automation settings. `ASK` results may post multiple comments through the `ASK`-voting agent accounts. Non-`ASK` results may post one decision comment through the selected reporter account. Clear-only related PR runs do not post a comment or close the issue or related PRs.
+Magi may post issue comments, close issues, close related open PRs, remove configured labels, create an implementation PR, or start review/merge automation for that PR depending on the final result and automation settings. `ASK` results may post multiple comments through the `ASK`-voting agent accounts. Non-`ASK` results may post one natural decision comment through the selected reporter account. Clear-only related PR runs do not post a comment or close the issue or related PRs.
 
 Triage artifacts are written to the issue run output directory:
 

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -513,6 +513,52 @@ describe("triage orchestration", () => {
     ).toHaveLength(3)
   })
 
+  test("scenario: /magi:triage posts natural non-ASK comments from selected reasons", async () => {
+    const result = await runScenario({
+      issue: issue({ type: "Feature" }),
+      outputs: [
+        JSON.stringify({ reason: "Melchior reason", vote: "YES" }),
+        JSON.stringify({
+          reason: "This is ready for implementation.",
+          vote: "YES",
+        }),
+        JSON.stringify({ reason: "Caspar reason", vote: "YES" }),
+      ],
+    })
+    const comment = await readFile(
+      join(result.result.outputDir, "comment.md"),
+      "utf8",
+    )
+    const visibleComment = comment.split("<!-- opencode-magi:triage")[0].trim()
+
+    expect(visibleComment).toBe("This is ready for implementation.")
+    expect(visibleComment).not.toContain("Magi triage decision:")
+    expect(visibleComment).not.toContain("Reason:")
+    expect(visibleComment).not.toContain("Action:")
+    expect(comment).toContain("<!-- opencode-magi:triage")
+  })
+
+  test("scenario: /magi:triage uses a natural fallback for non-ASK comments without reasons", async () => {
+    const result = await runScenario({
+      issue: issue({ type: "Feature" }),
+      outputs: [
+        JSON.stringify({ reason: " ", vote: "YES" }),
+        JSON.stringify({ reason: " ", vote: "YES" }),
+        JSON.stringify({ reason: " ", vote: "YES" }),
+      ],
+    })
+    const comment = await readFile(
+      join(result.result.outputDir, "comment.md"),
+      "utf8",
+    )
+    const visibleComment = comment.split("<!-- opencode-magi:triage")[0].trim()
+
+    expect(visibleComment).toBe("Magi accepted this feature issue.")
+    expect(visibleComment).not.toContain("Magi triage decision:")
+    expect(visibleComment).not.toContain("Action:")
+    expect(comment).toContain("<!-- opencode-magi:triage")
+  })
+
   test("asks without category details when category is unclear", async () => {
     const result = await runScenario({
       issue: issue({ type: undefined }),

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -929,11 +929,35 @@ function decisionCommentBody(input: {
   result: FinalResult
 }): string {
   const reason = input.reason?.trim()
-  const result = JSON.stringify(input.result)
 
   return reason
-    ? `Magi triage decision: ${result}\n\nReason: ${reason}`
-    : `Magi triage decision: ${result}\n\nAction: ${input.action}`
+    ? reason
+    : decisionCommentFallback({ action: input.action, result: input.result })
+}
+
+function decisionCommentFallback(input: {
+  action: string
+  result: FinalResult
+}): string {
+  if (input.result.disposition === "accepted") {
+    const category = input.result.category
+      ? `${input.result.category} issue`
+      : "issue"
+    return input.action === "PR"
+      ? `Magi accepted this ${category} and will prepare an implementation pull request.`
+      : `Magi accepted this ${category}.`
+  }
+  if (input.result.disposition === "rejected") {
+    const category = input.result.category
+      ? `${input.result.category} issue`
+      : "issue"
+    return `Magi does not plan to act on this ${category}.`
+  }
+  if (input.result.disposition === "duplicate") {
+    return "Magi marked this issue as a duplicate."
+  }
+
+  return "Magi completed triage for this issue."
 }
 
 function agentForKey(


### PR DESCRIPTION
Closes #260

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Make non-ASK `/magi:triage` issue comments use natural visible text while preserving the hidden `opencode-magi:triage` marker for state tracking.

## Current behavior (updates)

Non-ASK triage comments exposed internal boilerplate such as `Magi triage decision:`, `Reason:`, and `Action:` in public issue comments.

## New behavior

Non-ASK triage comments now show the selected natural reason by itself, or a natural fallback when no usable reason is selected. The hidden marker remains present. Targeted triage tests cover both paths.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validation: `pnpm vitest run src/orchestrator/triage.test.ts`