### PR TITLE
feat(config): support model candidate arrays

### DIFF
--- a/.changeset/model-candidate-arrays.md
+++ b/.changeset/model-candidate-arrays.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Support ordered model candidate arrays with per-model options in Magi config.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ Add the following content to the configuration file.
 
 Entries with `ref` are expanded from `agents.refs`. Fields set alongside `ref` override fields from the preset.
 
+`model` can be a single `provider/model` string or an ordered candidate array. Candidate arrays are resolved during validation against OpenCode's model catalog; the first available model is selected. Put provider-specific options on object candidates, not on the agent role.
+
+```json
+{
+  "model": [
+    "anthropic/claude-sonnet-4-5",
+    {
+      "id": "openai/gpt-5.1",
+      "options": { "reasoningEffort": "high" }
+    }
+  ]
+}
+```
+
 After refs are expanded, `review.agents[].account` is the GitHub account used to post reviews and approvals. Must be authenticated with `gh auth token --user <account>` and must be unique. `merge.editor.account` is used by `/magi:merge` to push fixes, close PRs, and merge PRs.
 
 #### Validate config

--- a/schema.json
+++ b/schema.json
@@ -60,8 +60,7 @@
       "additionalProperties": false,
       "properties": {
         "id": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "model": { "type": "string", "minLength": 1 },
-        "options": { "type": "object", "additionalProperties": true },
+        "model": { "$ref": "#/$defs/modelConfig" },
         "account": { "type": "string", "minLength": 1 },
         "author": {
           "type": "object",
@@ -83,8 +82,7 @@
       "properties": {
         "ref": { "type": "string", "minLength": 1 },
         "id": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "model": { "type": "string", "minLength": 1 },
-        "options": { "type": "object", "additionalProperties": true },
+        "model": { "$ref": "#/$defs/modelConfig" },
         "account": { "type": "string", "minLength": 1 },
         "permissions": { "$ref": "#/$defs/permissions" },
         "persona": { "type": "string" }
@@ -97,8 +95,7 @@
       "additionalProperties": false,
       "properties": {
         "ref": { "type": "string", "minLength": 1 },
-        "model": { "type": "string", "minLength": 1 },
-        "options": { "type": "object", "additionalProperties": true },
+        "model": { "$ref": "#/$defs/modelConfig" },
         "account": { "type": "string", "minLength": 1 },
         "author": {
           "type": "object",
@@ -121,9 +118,8 @@
       "properties": {
         "ref": { "type": "string", "minLength": 1 },
         "id": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "model": { "type": "string", "minLength": 1 },
+        "model": { "$ref": "#/$defs/modelConfig" },
         "account": { "type": "string", "minLength": 1 },
-        "options": { "type": "object", "additionalProperties": true },
         "permissions": { "$ref": "#/$defs/permissions" },
         "persona": { "type": "string" }
       }
@@ -136,8 +132,7 @@
       "properties": {
         "ref": { "type": "string", "minLength": 1 },
         "account": { "type": "string", "minLength": 1 },
-        "model": { "type": "string", "minLength": 1 },
-        "options": { "type": "object", "additionalProperties": true },
+        "model": { "$ref": "#/$defs/modelConfig" },
         "author": {
           "type": "object",
           "required": ["name", "email"],
@@ -149,6 +144,30 @@
         },
         "permissions": { "$ref": "#/$defs/permissions" },
         "persona": { "type": "string" }
+      }
+    },
+    "modelConfig": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "type": "string", "minLength": 1 },
+              { "$ref": "#/$defs/modelCandidate" }
+            ]
+          }
+        }
+      ]
+    },
+    "modelCandidate": {
+      "type": "object",
+      "required": ["id"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "options": { "type": "object", "additionalProperties": true }
       }
     },
     "automation": {

--- a/src/config/load.test.ts
+++ b/src/config/load.test.ts
@@ -12,7 +12,6 @@ const config: MagiConfig = {
       {
         model: "anthropic/claude",
         account: "bot-a",
-        options: { thinking: { type: "enabled", budgetTokens: 16000 } },
       },
       { id: "security", model: "anthropic/claude", account: "bot-b" },
       { id: "compat", model: "openai/gpt", account: "bot-c" },

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -11,7 +11,6 @@ const config: MagiConfig = {
       {
         model: "anthropic/claude",
         account: "bot-a",
-        options: { thinking: { type: "enabled", budgetTokens: 16000 } },
       },
       { id: "security", model: "anthropic/claude", account: "bot-b" },
       { id: "compat", model: "openai/gpt", account: "bot-c" },

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -53,6 +53,14 @@ export function validateReviewerId(id: string): boolean {
   return ID_PATTERN.test(id)
 }
 
+function normalizedModel(model: unknown): string {
+  if (typeof model !== "string") {
+    throw new Error("model must be normalized before resolving agents")
+  }
+
+  return model
+}
+
 function clonePermissionValue(
   value: PermissionRuleConfig,
 ): PermissionRuleConfig {
@@ -151,6 +159,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
     editor: editor
       ? {
           ...editor,
+          model: normalizedModel(editor.model),
           permission: resolveEditorPermission(agents, editor),
         }
       : undefined,
@@ -159,6 +168,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
         ...reviewer,
         key: reviewerKey(reviewer, index),
         index,
+        model: normalizedModel(reviewer.model),
         permission: resolveReviewerPermission(agents, reviewer),
       }),
     ),
@@ -167,6 +177,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
         ...agent,
         key: triageAgentKey(agent, index),
         index,
+        model: normalizedModel(agent.model),
         permission: resolveTriageAgentPermission(agents, agent),
       }),
     ),
@@ -174,6 +185,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
       ? {
           ...creator,
           account: creator.account ?? "",
+          model: normalizedModel(creator.model),
           permission: resolveTriageCreatorPermission(agents, creator),
         }
       : undefined,

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -107,14 +107,16 @@ describe("validateConfig", () => {
 
     expect(result).toMatchObject({ errors: [], ok: true })
     expect(refConfig.agents?.refs).toBeUndefined()
-    expect(refConfig.review?.agents?.[0]).toEqual({
+    expect(refConfig.review?.agents?.[0]).toMatchObject({
       account: "bot-a",
       id: "alpha",
       model: "openai/gpt",
-      options: { reasoningEffort: "high" },
       persona: "Shared persona",
     })
-    expect(refConfig.review?.agents?.[1].options).toEqual({
+    expect(repository.agents.reviewers[0].options).toEqual({
+      reasoningEffort: "high",
+    })
+    expect(repository.agents.reviewers[1].options).toEqual({
       thinking: { type: "enabled" },
     })
     expect(refConfig.review?.agents?.[1].model).toBe("anthropic/claude")

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -17,7 +17,6 @@ const config: MagiConfig = {
       {
         model: "anthropic/claude",
         account: "bot-a",
-        options: { thinking: { type: "enabled", budgetTokens: 16000 } },
       },
       { id: "security", model: "anthropic/claude", account: "bot-b" },
       { id: "compat", model: "openai/gpt", account: "bot-c" },
@@ -52,8 +51,13 @@ describe("validateConfig", () => {
       agents: {
         refs: {
           shared: {
-            model: "openai/gpt",
-            options: { reasoningEffort: "high" },
+            model: [
+              "missing/model",
+              {
+                id: "openai/gpt",
+                options: { reasoningEffort: "high" },
+              },
+            ],
             persona: "Shared persona",
           },
           editor: {
@@ -71,7 +75,13 @@ describe("validateConfig", () => {
             ref: "shared",
             id: "beta",
             account: "bot-b",
-            options: { reasoningEffort: "low" },
+            model: [
+              "missing/model",
+              {
+                id: "anthropic/claude",
+                options: { thinking: { type: "enabled" } },
+              },
+            ],
           },
           { ref: "shared", id: "gamma", account: "bot-c" },
         ],
@@ -90,6 +100,7 @@ describe("validateConfig", () => {
     } as unknown as MagiConfig
 
     const result = await validateConfig(refConfig, {
+      modelCatalog: { anthropic: ["claude"], openai: ["gpt"] },
       requireTriage: true,
     })
     const repository = resolveRepository(refConfig)
@@ -104,8 +115,9 @@ describe("validateConfig", () => {
       persona: "Shared persona",
     })
     expect(refConfig.review?.agents?.[1].options).toEqual({
-      reasoningEffort: "low",
+      thinking: { type: "enabled" },
     })
+    expect(refConfig.review?.agents?.[1].model).toBe("anthropic/claude")
     expect(refConfig.review?.agents?.[0]).not.toHaveProperty("ref")
     expect(repository.agents.reviewers[0]).toMatchObject({
       account: "bot-a",
@@ -717,7 +729,113 @@ describe("validateConfig", () => {
     expect(result.errors).toContain(error)
   })
 
-  test("rejects non-object model options", async () => {
+  test("accepts model candidate arrays and normalizes the selected options", async () => {
+    const candidateConfig = {
+      ...config,
+      agents: {
+        refs: {
+          shared: {
+            account: "bot-a",
+            model: [
+              "missing/model",
+              {
+                id: "anthropic/claude",
+                options: {
+                  thinking: { budget_tokens: 12000, type: "enabled" },
+                },
+              },
+            ],
+          },
+        },
+      },
+      review: {
+        agents: [
+          { ref: "shared" },
+          { account: "bot-b", model: ["missing/model", "openai/gpt"] },
+          {
+            account: "bot-c",
+            model: [
+              {
+                id: "openai/gpt",
+                options: { reasoningEffort: "high" },
+              },
+            ],
+          },
+        ],
+      },
+      merge: {
+        editor: {
+          account: "bot-c",
+          author: { email: "bot-c@example.com", name: "Bot C" },
+          model: ["missing/model", "openai/gpt"],
+        },
+      },
+      triage: {
+        agents: [
+          { account: "triage-a", model: ["missing/model", "openai/gpt"] },
+          { account: "triage-b", model: ["anthropic/claude"] },
+          { account: "triage-c", model: ["google/gemini"] },
+        ],
+        creator: {
+          account: "creator-bot",
+          author: { email: "creator@example.com", name: "Creator Bot" },
+          model: [
+            {
+              id: "openai/gpt",
+              options: { reasoningEffort: "low" },
+            },
+          ],
+        },
+      },
+    } as unknown as MagiConfig
+
+    const result = await validateConfig(candidateConfig, {
+      modelCatalog: {
+        anthropic: ["claude"],
+        google: ["gemini"],
+        openai: ["gpt"],
+      },
+      requireTriage: true,
+    })
+
+    expect(result).toMatchObject({ errors: [], ok: true })
+    expect(candidateConfig.review?.agents?.[0]).toMatchObject({
+      model: "anthropic/claude",
+      options: { thinking: { budget_tokens: 12000, type: "enabled" } },
+    })
+    expect(candidateConfig.review?.agents?.[1]).toMatchObject({
+      model: "openai/gpt",
+    })
+    expect(candidateConfig.review?.agents?.[1]).not.toHaveProperty("options")
+    expect(candidateConfig.triage?.creator).toMatchObject({
+      model: "openai/gpt",
+      options: { reasoningEffort: "low" },
+    })
+  })
+
+  test("rejects model candidate arrays with no usable model", async () => {
+    const result = await validateConfig(
+      {
+        ...config,
+        review: {
+          ...config.review,
+          agents: [
+            { account: "bot-a", model: ["missing/model"] },
+            { account: "bot-b", model: "openai/gpt" },
+            { account: "bot-c", model: "openai/gpt" },
+          ],
+        },
+      } as unknown as MagiConfig,
+      { modelCatalog: { openai: ["gpt"] } },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain(
+      "review.agents[0].model must contain at least one usable OpenCode model candidate (review.agents[0].model[0] uses unknown OpenCode provider: missing)",
+    )
+  })
+
+  test("rejects role-level model options", async () => {
     const result = await validateConfig({
       ...config,
       review: {
@@ -731,8 +849,31 @@ describe("validateConfig", () => {
     })
 
     expect(result.ok).toBe(false)
+    expect(result.errors).toContain("review.agents[0].options is not supported")
+  })
+
+  test("rejects non-object model candidate options", async () => {
+    const result = await validateConfig(
+      {
+        ...config,
+        review: {
+          ...config.review,
+          agents: [
+            {
+              account: "bot-a",
+              model: [{ id: "openai/gpt", options: "high" }],
+            },
+            { account: "bot-b", model: "openai/gpt" },
+            { account: "bot-c", model: "openai/gpt" },
+          ],
+        },
+      } as unknown as MagiConfig,
+      { modelCatalog: { openai: ["gpt"] } },
+    )
+
+    expect(result.ok).toBe(false)
     expect(result.errors).toContain(
-      "review.agents[0].options must be an object",
+      "review.agents[0].model[0].options must be an object",
     )
   })
 

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -2,6 +2,7 @@ import type {
   EditorConfig,
   Exec,
   MagiConfig,
+  ModelOptions,
   PermissionConfig,
   ReviewerConfig,
   TriageAgentConfig,
@@ -17,7 +18,12 @@ import { access } from "node:fs/promises"
 import { homedir } from "node:os"
 import { isAbsolute, join } from "node:path"
 import schema from "../../schema.json" with { type: "json" }
-import { resolveAgents, validateReviewerId } from "./resolve"
+import {
+  resolveAgents,
+  reviewerKey,
+  triageAgentKey,
+  validateReviewerId,
+} from "./resolve"
 
 export type ModelCatalog = Record<string, readonly string[]>
 
@@ -26,6 +32,7 @@ export interface ValidationOptions {
   directory?: string
   exec?: Exec
   modelCatalog?: ModelCatalog
+  requireModelCatalog?: boolean
   requireEditor?: boolean
   requireGithub?: boolean
   requireReview?: boolean
@@ -61,7 +68,6 @@ const REVIEWER_KEYS = new Set([
   "account",
   "id",
   "model",
-  "options",
   "permissions",
   "persona",
 ])
@@ -69,7 +75,6 @@ const EDITOR_KEYS = new Set([
   "account",
   "author",
   "model",
-  "options",
   "permissions",
   "persona",
 ])
@@ -77,7 +82,6 @@ const TRIAGE_AGENT_KEYS = new Set([
   "account",
   "id",
   "model",
-  "options",
   "permissions",
   "persona",
 ])
@@ -85,7 +89,6 @@ const TRIAGE_CREATOR_KEYS = new Set([
   "account",
   "author",
   "model",
-  "options",
   "permissions",
   "persona",
 ])
@@ -179,8 +182,10 @@ const TRIAGE_PROMPT_KEYS = new Set([
   "existingPr",
   "reconsider",
 ])
+const MODEL_CANDIDATE_KEYS = new Set(["id", "options"])
 
 type AgentRefUse = Record<string, unknown> & { ref?: unknown }
+type ModelTarget = { model?: unknown; options?: unknown }
 
 function githubHost(config: MagiConfig): string {
   return config.github?.host ?? "github.com"
@@ -385,37 +390,126 @@ function validatePermissionConfig(
   }
 }
 
-function validateModel(
-  model: string | undefined,
+function modelValidationError(
+  model: string,
   path: string,
-  errors: string[],
   catalog?: ModelCatalog,
-): void {
-  if (!model) return
-
+): string | undefined {
   const slash = model.indexOf("/")
 
-  if (slash <= 0 || slash === model.length - 1) {
-    errors.push(
-      `${path} must be a full OpenCode model ID in provider/model form`,
-    )
-    return
-  }
+  if (slash <= 0 || slash === model.length - 1)
+    return `${path} must be a full OpenCode model ID in provider/model form`
 
-  if (!catalog) return
+  if (!catalog) return undefined
 
   const providerId = model.slice(0, slash)
   const modelId = model.slice(slash + 1)
   const models = catalog[providerId]
 
-  if (!models) {
-    errors.push(`${path} uses unknown OpenCode provider: ${providerId}`)
+  if (!models) return `${path} uses unknown OpenCode provider: ${providerId}`
+
+  if (!models.includes(modelId))
+    return `${path} uses unknown OpenCode model: ${model}`
+
+  return undefined
+}
+
+function validateModelId(
+  model: string,
+  path: string,
+  errors: string[],
+  catalog?: ModelCatalog,
+): boolean {
+  const error = modelValidationError(model, path, catalog)
+
+  if (error) {
+    errors.push(error)
+    return false
+  }
+
+  return true
+}
+
+function readModelCandidate(
+  value: unknown,
+  path: string,
+  errors: string[],
+): { id: string; options?: ModelOptions } | undefined {
+  if (typeof value === "string") return { id: value }
+
+  if (!isPlainObject(value)) {
+    errors.push(`${path} must be a string or an object`)
+    return undefined
+  }
+
+  validateKnownKeys(value, path, MODEL_CANDIDATE_KEYS, errors)
+
+  if (typeof value.id !== "string") {
+    errors.push(`${path}.id must be a string`)
+    return undefined
+  }
+
+  if (value.options != null && !isPlainObject(value.options)) {
+    errors.push(`${path}.options must be an object`)
+    return undefined
+  }
+
+  return { id: value.id, options: value.options as ModelOptions | undefined }
+}
+
+function validateAndNormalizeModel(
+  target: ModelTarget,
+  path: string,
+  errors: string[],
+  catalog?: ModelCatalog,
+): void {
+  const model = target.model
+
+  if (typeof model === "string") {
+    validateModelId(model, path, errors, catalog)
     return
   }
 
-  if (!models.includes(modelId)) {
-    errors.push(`${path} uses unknown OpenCode model: ${model}`)
+  if (!Array.isArray(model)) {
+    if (model != null) errors.push(`${path} must be a string or an array`)
+    return
   }
+
+  if (!model.length) {
+    errors.push(`${path} must contain at least one model candidate`)
+    return
+  }
+
+  if (!catalog) {
+    errors.push(`${path} requires an OpenCode model catalog`)
+    return
+  }
+
+  const candidateErrors: string[] = []
+
+  for (const [index, value] of model.entries()) {
+    const candidatePath = `${path}[${index}]`
+    const candidate = readModelCandidate(value, candidatePath, errors)
+    if (!candidate) continue
+
+    const idPath = isPlainObject(value) ? `${candidatePath}.id` : candidatePath
+    const error = modelValidationError(candidate.id, idPath, catalog)
+
+    if (!error) {
+      target.model = candidate.id
+      if (candidate.options) target.options = candidate.options
+      else delete target.options
+      return
+    }
+
+    candidateErrors.push(error)
+  }
+
+  errors.push(
+    `${path} must contain at least one usable OpenCode model candidate${
+      candidateErrors.length ? ` (${candidateErrors.join("; ")})` : ""
+    }`,
+  )
 }
 
 function validateReviewerList(
@@ -443,13 +537,15 @@ function validateReviewerList(
 
     validateKnownKeys(reviewer, `${path}[${index}]`, REVIEWER_KEYS, errors)
     if (!reviewer.model) errors.push(`${path}[${index}].model is required`)
-    validateString(reviewer.model, `${path}[${index}].model`, errors)
-    validateModel(reviewer.model, `${path}[${index}].model`, errors, catalog)
+    validateAndNormalizeModel(
+      reviewer as ModelTarget,
+      `${path}[${index}].model`,
+      errors,
+      catalog,
+    )
     if (!reviewer.account) errors.push(`${path}[${index}].account is required`)
     validateString(reviewer.account, `${path}[${index}].account`, errors)
     validateString(reviewer.persona, `${path}[${index}].persona`, errors)
-    if (reviewer.options != null && !isPlainObject(reviewer.options))
-      errors.push(`${path}[${index}].options must be an object`)
     validatePermissionConfig(
       reviewer.permissions,
       `${path}[${index}].permissions`,
@@ -494,13 +590,15 @@ function validateTriageAgentList(
 
     validateKnownKeys(agent, `${path}[${index}]`, TRIAGE_AGENT_KEYS, errors)
     if (!agent.model) errors.push(`${path}[${index}].model is required`)
-    validateString(agent.model, `${path}[${index}].model`, errors)
-    validateModel(agent.model, `${path}[${index}].model`, errors, catalog)
+    validateAndNormalizeModel(
+      agent as ModelTarget,
+      `${path}[${index}].model`,
+      errors,
+      catalog,
+    )
     if (!agent.account) errors.push(`${path}[${index}].account is required`)
     validateString(agent.account, `${path}[${index}].account`, errors)
     validateString(agent.persona, `${path}[${index}].persona`, errors)
-    if (agent.options != null && !isPlainObject(agent.options))
-      errors.push(`${path}[${index}].options must be an object`)
     validatePermissionConfig(
       agent.permissions,
       `${path}[${index}].permissions`,
@@ -572,14 +670,15 @@ function validateEditor(
 
   if (!editor.model) errors.push(`${path}.model is required`)
   validateKnownKeys(editor, path, EDITOR_KEYS, errors)
-  validateString(editor.model, `${path}.model`, errors)
+  validateAndNormalizeModel(
+    editor as ModelTarget,
+    `${path}.model`,
+    errors,
+    catalog,
+  )
   validateString(editor.account, `${path}.account`, errors)
   validateString(editor.persona, `${path}.persona`, errors)
-  validateModel(editor.model, `${path}.model`, errors, catalog)
   if (!editor.account) errors.push(`${path}.account is required`)
-  if (editor.options != null && !isPlainObject(editor.options)) {
-    errors.push(`${path}.options must be an object`)
-  }
   validatePermissionConfig(editor.permissions, `${path}.permissions`, errors)
   const author = editor.author
   if (!author || !isPlainObject(author)) {
@@ -617,12 +716,13 @@ function validateTriageCreator(
   validateKnownKeys(creator, path, TRIAGE_CREATOR_KEYS, errors)
   if (!creator.model) errors.push(`${path}.model is required`)
   validateString(creator.account, `${path}.account`, errors)
-  validateString(creator.model, `${path}.model`, errors)
+  validateAndNormalizeModel(
+    creator as ModelTarget,
+    `${path}.model`,
+    errors,
+    catalog,
+  )
   validateString(creator.persona, `${path}.persona`, errors)
-  validateModel(creator.model, `${path}.model`, errors, catalog)
-  if (creator.options != null && !isPlainObject(creator.options)) {
-    errors.push(`${path}.options must be an object`)
-  }
   validatePermissionConfig(creator.permissions, `${path}.permissions`, errors)
 
   const author = creator.author
@@ -946,7 +1046,14 @@ function validateTriage(
     options.modelCatalog,
   )
   if (Array.isArray(triage.agents)) {
-    const resolvedTriageAgents = resolveAgents(config).triage ?? []
+    const resolvedTriageAgents = triage.agents.map((agent, index) => ({
+      account:
+        agent && typeof agent === "object" && typeof agent.account === "string"
+          ? agent.account
+          : "",
+      key:
+        agent && typeof agent === "object" ? triageAgentKey(agent, index) : "",
+    }))
     validateResolvedTriageAgents(
       resolvedTriageAgents,
       "triage.resolvedAgents",
@@ -1144,13 +1251,13 @@ async function validateWorktreeConfig(
   options: ValidationOptions,
   errors: string[],
 ): Promise<void> {
-  const agents = resolveAgents(config)
   const checkEditor = Boolean(
-    agents.editor && (options.requireEditor || options.requireWorktreeConfig),
+    config.merge?.editor &&
+    (options.requireEditor || options.requireWorktreeConfig),
   )
   const checkTriageCreator = Boolean(
     config.triage?.automation?.create &&
-    agents.triageCreator &&
+    config.triage?.creator &&
     (options.requireTriage || options.requireWorktreeConfig),
   )
 
@@ -1274,6 +1381,10 @@ export async function validateConfig(
   if (!config || typeof config !== "object")
     errors.push("config must be an object")
 
+  if (options.requireModelCatalog && !options.modelCatalog) {
+    errors.push("OpenCode model catalog could not be loaded")
+  }
+
   expandAgentRefs(config, errors)
 
   if (config && typeof config === "object") validateJsonSchema(config, errors)
@@ -1310,7 +1421,18 @@ export async function validateConfig(
     )
     if (Array.isArray(config.review.agents)) {
       validateResolvedReviewers(
-        resolveAgents(config).reviewers,
+        config.review.agents.map((reviewer, index) => ({
+          account:
+            reviewer &&
+            typeof reviewer === "object" &&
+            typeof reviewer.account === "string"
+              ? reviewer.account
+              : "",
+          key:
+            reviewer && typeof reviewer === "object"
+              ? reviewerKey(reviewer, index)
+              : "",
+        })),
         "review.resolvedAgents",
         errors,
       )

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,8 @@ async function writeConfig(path: string, config: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(config, null, 2)}\n`)
 }
 
+const modelCatalog = { openai: ["gpt"] }
+
 describe("parsePrs", () => {
   test("parses PR numbers and URLs", () => {
     expect(parsePrs("7581 #7582")).toEqual([7581, 7582])
@@ -366,6 +368,7 @@ describe("magi_validate", () => {
 
     const result = await validateMagiConfigFiles(directory, {
       checkAuth: false,
+      modelCatalog,
     })
 
     expect(result).toContain("Magi config validation: failed")
@@ -404,6 +407,7 @@ describe("magi_validate", () => {
 
     const result = await validateMagiConfigFiles(directory, {
       checkAuth: false,
+      modelCatalog,
     })
 
     expect(result).toContain("Magi config validation: passed")
@@ -445,6 +449,7 @@ describe("magi_validate", () => {
 
     const result = await validateMagiConfigFiles(directory, {
       checkAuth: false,
+      modelCatalog,
       exec: async (command) => {
         if (command.startsWith("git config --bool --get")) return "false"
 
@@ -479,6 +484,7 @@ describe("magi_validate", () => {
 
     const result = await validateMagiConfigFiles(directory, {
       checkAuth: false,
+      modelCatalog,
     })
 
     expect(result).toContain("Magi config validation: passed")
@@ -501,6 +507,7 @@ describe("magi_validate", () => {
 
     const result = await validateMagiConfigFiles(directory, {
       checkAuth: false,
+      modelCatalog,
     })
 
     expect(result).toContain("Magi config validation: failed")
@@ -528,6 +535,7 @@ describe("magi_validate", () => {
 
     const result = await validateMagiConfigFiles(directory, {
       checkAuth: false,
+      modelCatalog,
     })
 
     expect(result).toContain(
@@ -535,6 +543,33 @@ describe("magi_validate", () => {
     )
     expect(result).not.toContain("github.owner is required")
     expect(result).not.toContain("github.repo is required")
+  })
+
+  test("reports when the OpenCode model catalog cannot be loaded", async () => {
+    const home = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "magi-home-"))
+    const directory = await mkdtemp(
+      join(process.env.TMPDIR ?? "/tmp", "magi-project-"),
+    )
+    mockState.home = home
+    const globalPath = join(home, ".config", "opencode", "magi.json")
+    const validateMagiConfigFiles = await loadValidateMagiConfigFiles()
+
+    await writeConfig(globalPath, {
+      review: {
+        agents: [
+          { account: "bot-a", model: "openai/gpt" },
+          { account: "bot-b", model: "openai/gpt" },
+          { account: "bot-c", model: "openai/gpt" },
+        ],
+      },
+    })
+
+    const result = await validateMagiConfigFiles(directory, {
+      checkAuth: false,
+    })
+
+    expect(result).toContain("Magi config validation: failed")
+    expect(result).toContain("OpenCode model catalog could not be loaded")
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -623,6 +623,7 @@ export async function validateMagiConfigFiles(
         : undefined,
       modelCatalog: options.modelCatalog,
       requireGithub: hasProjectConfig && Boolean(mergedConfig.review?.agents),
+      requireModelCatalog: true,
       requireWorktreeConfig: true,
     })
 
@@ -681,6 +682,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
           ?.list({ query: { directory } })
           .then(extractModelCatalog),
       )
+      .catch(() => undefined)
 
     return modelCatalogPromise
   }
@@ -741,6 +743,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
             exec: retryingExec,
             modelCatalog: await modelCatalog(),
             requireEditor: true,
+            requireModelCatalog: true,
           })
 
           if (!validation.ok) return JSON.stringify(validation, null, 2)
@@ -798,6 +801,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
             directory,
             exec: retryingExec,
             modelCatalog: await modelCatalog(),
+            requireModelCatalog: true,
           })
 
           if (!validation.ok) return JSON.stringify(validation, null, 2)
@@ -857,6 +861,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
             exec: retryingExec,
             modelCatalog: await modelCatalog(),
             requireEditor: config.triage?.automation?.merge === true,
+            requireModelCatalog: true,
             requireReview:
               config.triage?.automation?.review === true ||
               config.triage?.automation?.merge === true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface ReviewerConfig {
   account: string
   id?: string
   model: ModelConfig
-  options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
   ref?: string
@@ -42,7 +41,6 @@ export interface EditorConfig {
     name: string
   }
   model: ModelConfig
-  options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
   ref?: string
@@ -52,7 +50,6 @@ export interface TriageAgentConfig {
   account: string
   id?: string
   model: ModelConfig
-  options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
   ref?: string
@@ -65,7 +62,6 @@ export interface TriageCreatorConfig {
     name: string
   }
   model: ModelConfig
-  options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
   ref?: string
@@ -79,7 +75,6 @@ export interface AgentRefConfig {
   }
   id?: string
   model?: ModelConfig
-  options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
 }
@@ -267,38 +262,42 @@ export interface MagiConfig {
 
 export interface ResolvedReviewer extends Omit<
   ReviewerConfig,
-  "model" | "permissions"
+  "model" | "options" | "permissions"
 > {
   index: number
   key: string
   model: string
+  options?: ModelOptions
   permission: PermissionConfig
 }
 
 export interface ResolvedEditor extends Omit<
   EditorConfig,
-  "model" | "permissions"
+  "model" | "options" | "permissions"
 > {
   model: string
+  options?: ModelOptions
   permission: PermissionConfig
 }
 
 export interface ResolvedTriageAgent extends Omit<
   TriageAgentConfig,
-  "model" | "permissions"
+  "model" | "options" | "permissions"
 > {
   index: number
   key: string
   model: string
+  options?: ModelOptions
   permission: PermissionConfig
 }
 
 export interface ResolvedTriageCreator extends Omit<
   TriageCreatorConfig,
-  "model" | "permissions"
+  "model" | "options" | "permissions"
 > {
   account: string
   model: string
+  options?: ModelOptions
   permission: PermissionConfig
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,13 @@ export type Verdict = "CHANGES_REQUESTED" | "CLOSE" | "MERGE"
 
 export type ModelOptions = Record<string, unknown>
 
+export interface ModelCandidateConfig {
+  id: string
+  options?: ModelOptions
+}
+
+export type ModelConfig = string | (string | ModelCandidateConfig)[]
+
 export type PermissionAction = "allow" | "ask" | "deny"
 
 export type PermissionRuleConfig =
@@ -21,7 +28,7 @@ export interface OpenCodePermissionRule {
 export interface ReviewerConfig {
   account: string
   id?: string
-  model: string
+  model: ModelConfig
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
@@ -34,7 +41,7 @@ export interface EditorConfig {
     email: string
     name: string
   }
-  model: string
+  model: ModelConfig
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
@@ -44,7 +51,7 @@ export interface EditorConfig {
 export interface TriageAgentConfig {
   account: string
   id?: string
-  model: string
+  model: ModelConfig
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
@@ -57,7 +64,7 @@ export interface TriageCreatorConfig {
     email: string
     name: string
   }
-  model: string
+  model: ModelConfig
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
@@ -71,7 +78,7 @@ export interface AgentRefConfig {
     name?: string
   }
   id?: string
-  model?: string
+  model?: ModelConfig
   options?: ModelOptions
   permissions?: PermissionConfig
   persona?: string
@@ -258,30 +265,40 @@ export interface MagiConfig {
   triage?: TriageConfig
 }
 
-export interface ResolvedReviewer extends Omit<ReviewerConfig, "permissions"> {
+export interface ResolvedReviewer extends Omit<
+  ReviewerConfig,
+  "model" | "permissions"
+> {
   index: number
   key: string
+  model: string
   permission: PermissionConfig
 }
 
-export interface ResolvedEditor extends Omit<EditorConfig, "permissions"> {
+export interface ResolvedEditor extends Omit<
+  EditorConfig,
+  "model" | "permissions"
+> {
+  model: string
   permission: PermissionConfig
 }
 
 export interface ResolvedTriageAgent extends Omit<
   TriageAgentConfig,
-  "permissions"
+  "model" | "permissions"
 > {
   index: number
   key: string
+  model: string
   permission: PermissionConfig
 }
 
 export interface ResolvedTriageCreator extends Omit<
   TriageCreatorConfig,
-  "permissions"
+  "model" | "permissions"
 > {
   account: string
+  model: string
   permission: PermissionConfig
 }
 


### PR DESCRIPTION
Closes #261

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds ordered model candidate arrays to Magi config and normalizes the first OpenCode catalog-valid candidate into the effective agent config, including per-candidate model options.

## Current behavior (updates)

Agent roles accepted a single `model` string and role-level `options`, so provider-specific options could not be tied to fallback model choices.

## New behavior

`review.agents[]`, `merge.editor`, `triage.agents[]`, `triage.creator`, and `agents.refs` accept `model` as either a string or an ordered array of string/object candidates. Validation requires a loaded OpenCode model catalog in normal command and `magi_validate` paths, selects the first usable candidate, and rejects role-level `options` in favor of object candidate options.

## Is this a breaking change (Yes/No):

Yes. Role-level `options` is no longer supported for agent roles; move provider-specific options into object model candidates.

## Additional Information

Tests: `pnpm vitest run src/config/validate.test.ts src/config/resolve.test.ts src/index.test.ts`