### PR TITLE
fix(clear): ignore assistant-provided cleanup args

### DIFF
--- a/.changeset/prevent-clear-tool-args.md
+++ b/.changeset/prevent-clear-tool-args.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Prevent magi_clear from accepting assistant-provided cleanup selectors or resource flags.

--- a/docs/commands/clear.md
+++ b/docs/commands/clear.md
@@ -35,6 +35,8 @@ It does not post to GitHub.
 
 Important settings for `/magi:clear`:
 
+Cleanup scope and resource selection come only from Magi config. The command does not accept inline cleanup selectors or cleanup flags.
+
 | Setting          | Purpose                                  |
 | ---------------- | ---------------------------------------- |
 | `clear.branch`   | Delete the branch recorded in run state. |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -539,7 +539,7 @@ describe("magi_validate", () => {
 })
 
 describe("magi_clear", () => {
-  test("keeps default cleanup enabled when false flags are defaulted", async () => {
+  test("ignores cleanup args and keeps default cleanup enabled", async () => {
     const home = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "magi-home-"))
     const directory = await mkdtemp(
       join(process.env.TMPDIR ?? "/tmp", "magi-project-"),
@@ -593,6 +593,7 @@ describe("magi_clear", () => {
         },
         directory,
       } as never)
+      expect(plugin.tool?.magi_clear.args).toEqual({})
       const result = await plugin.tool?.magi_clear.execute(
         {
           branch: "false",
@@ -618,7 +619,7 @@ describe("magi_clear", () => {
     }
   })
 
-  test("uses config when false flags are defaulted", async () => {
+  test("ignores cleanup args and uses configured cleanup defaults", async () => {
     const home = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "magi-home-"))
     const directory = await mkdtemp(
       join(process.env.TMPDIR ?? "/tmp", "magi-project-"),
@@ -674,6 +675,7 @@ describe("magi_clear", () => {
         },
         directory,
       } as never)
+      expect(plugin.tool?.magi_clear.args).toEqual({})
       const result = await plugin.tool?.magi_clear.execute(
         {
           branch: "false",

--- a/src/index.ts
+++ b/src/index.ts
@@ -460,34 +460,6 @@ function clearFlag(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined
 }
 
-function clearToolFlag(value: unknown): boolean | undefined {
-  if (value === true || value === "true") return true
-  if (value === "false") return false
-
-  return undefined
-}
-
-function hasBlankSelector(args: { pr?: string; runId?: string }): boolean {
-  return !args.runId?.trim() && !args.pr?.trim()
-}
-
-function hasDefaultedFalseClearFlags(args: {
-  branch?: unknown
-  output?: unknown
-  pr?: string
-  runId?: string
-  session?: unknown
-  worktree?: unknown
-}): boolean {
-  return (
-    hasBlankSelector(args) &&
-    args.branch === "false" &&
-    args.output === "false" &&
-    args.session === "false" &&
-    args.worktree === "false"
-  )
-}
-
 function parseQuestionAnswers(value: string): string[] {
   const trimmed = value.trim()
   if (!trimmed) throw new Error("Specify at least one answer.")
@@ -995,46 +967,22 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
       magi_clear: tool({
         description:
           "Clear all inactive Magi runs by deleting configured sessions, worktrees, branches, and output artifacts.",
-        args: {
-          runId: tool.schema.string().optional(),
-          pr: tool.schema.string().optional(),
-          issue: tool.schema.string().optional(),
-          branch: tool.schema.enum(["true", "false"]).optional(),
-          output: tool.schema.enum(["true", "false"]).optional(),
-          session: tool.schema.enum(["true", "false"]).optional(),
-          worktree: tool.schema.enum(["true", "false"]).optional(),
-        },
-        async execute(args) {
+        args: {},
+        async execute() {
           const loaded = await loadConfig(directory).catch(() => undefined)
           const clear = loaded?.config.clear as ClearConfig | undefined
-          const useConfiguredDefaults = hasDefaultedFalseClearFlags(args)
           const options: ClearConfig = {
-            branch:
-              (useConfiguredDefaults
-                ? undefined
-                : clearToolFlag(args.branch)) ?? clearFlag(clear?.branch),
-            output:
-              (useConfiguredDefaults
-                ? undefined
-                : clearToolFlag(args.output)) ?? clearFlag(clear?.output),
-            session:
-              (useConfiguredDefaults
-                ? undefined
-                : clearToolFlag(args.session)) ?? clearFlag(clear?.session),
-            worktree:
-              (useConfiguredDefaults
-                ? undefined
-                : clearToolFlag(args.worktree)) ?? clearFlag(clear?.worktree),
+            branch: clearFlag(clear?.branch),
+            output: clearFlag(clear?.output),
+            session: clearFlag(clear?.session),
+            worktree: clearFlag(clear?.worktree),
           }
 
           return runManager.clear({
             options,
-            issue: parseOptionalIssue(args.issue),
             outputDir: loaded
               ? outputBaseDirs(directory, loaded.config)
               : undefined,
-            pr: parseOptionalPr(args.pr),
-            runId: args.runId,
             worktreeDir: loaded
               ? worktreeBaseDirs(directory, loaded.config)
               : undefined,


### PR DESCRIPTION
Closes #264

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Prevents `/magi:clear` from accepting assistant-invented cleanup selectors or resource flags through structured tool arguments.

## Current behavior (updates)

`magi_clear` exposed `runId`, `pr`, `issue`, `branch`, `output`, `session`, and `worktree` as structured args, allowing cleanup behavior to differ from plain `/magi:clear` intent.

## New behavior

`magi_clear` exposes no structured args and clears inactive runs using only configured `clear.*` defaults. Tests cover that provided cleanup args cannot change behavior.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Targeted test run: `pnpm vitest run src/index.test.ts`.