### PR TITLE
ci(workflows): add openrouter secret env

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -49,5 +49,6 @@ jobs:
       - name: Merge
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           opencode run --dir "$GITHUB_WORKSPACE" --command "magi:merge" "${{ github.event.pull_request.number }} --sync"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,5 +49,6 @@ jobs:
       - name: Triage
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           opencode run --dir "$GITHUB_WORKSPACE" --command "magi:triage" "${{ github.event.issue.number }} --sync"


### PR DESCRIPTION
Closes #N/A (no issue per user request)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add the OPENROUTER_API_KEY secret to the merge and triage GitHub workflow environments.

## Current behavior (updates)

The merge and triage workflows only expose OPENCODE_API_KEY to opencode run.

## New behavior

The merge and triage workflows also expose OPENROUTER_API_KEY so configured OpenRouter models can authenticate.

## Is this a breaking change (Yes/No):

No

## Additional Information

No targeted tests were run because this change only updates GitHub Actions environment variables.
