### PR TITLE
fix(triage): fail config validation in actions

### DIFF
--- a/.changeset/triage-validation-fails.md
+++ b/.changeset/triage-validation-fails.md
@@ -2,4 +2,4 @@
 "opencode-magi": patch
 ---
 
-Fail triage command execution when configuration validation fails.
+Fail command execution when configuration validation fails.

--- a/.changeset/triage-validation-fails.md
+++ b/.changeset/triage-validation-fails.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Fail triage command execution when configuration validation fails.

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -7,25 +7,43 @@
       "melchior": {
         "id": "Melchior",
         "account": "melchior-magi",
-        "model": "opencode-go/minimax-m2.7",
-        "options": { "reasoningEffort": "high" }
+        "model": [
+          {
+            "id": "opencode-go/minimax-m2.7",
+            "options": { "reasoningEffort": "high" }
+          }
+        ]
       },
       "balthasar": {
         "id": "Balthasar",
         "account": "balthasar-magi",
-        "model": "opencode-go/deepseek-v4-pro",
-        "options": { "reasoningEffort": "high" }
+        "model": [
+          {
+            "id": "opencode-go/deepseek-v4-pro",
+            "options": { "reasoningEffort": "high" }
+          }
+        ]
       },
       "caspar": {
         "id": "Caspar",
         "account": "caspar-magi",
-        "model": "opencode-go/qwen3.6-plus",
-        "options": { "thinking": { "type": "enabled", "budgetTokens": 16000 } }
+        "model": [
+          {
+            "id": "opencode-go/qwen3.6-plus",
+            "options": {
+              "thinking": { "type": "enabled", "budgetTokens": 16000 }
+            }
+          }
+        ]
       },
       "hirotomoyamada": {
         "account": "hirotomoyamada",
-        "model": "openai/gpt-5.5",
-        "options": { "reasoningEffort": "high" },
+        "model": [
+          {
+            "id": "openai/gpt-5.5",
+            "options": { "reasoningEffort": "high" }
+          }
+        ],
         "author": {
           "name": "hirotomoyamada",
           "email": "hirotomo.yamada@avap.co.jp"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -366,57 +366,79 @@ describe("magi_status", () => {
   })
 })
 
-describe("magi_triage", () => {
-  test("throws when config validation fails", async () => {
-    const directory = await mkdtemp(
-      join(process.env.TMPDIR ?? "/tmp", "magi-triage-"),
-    )
+describe("magi run tools", () => {
+  test.each([
+    ["magi_merge", { prs: "1 --sync" }, "merge.editor is required"],
+    [
+      "magi_review",
+      { prs: "1 --sync" },
+      "review.agents[0].options is not supported",
+    ],
+    [
+      "magi_triage",
+      { issues: "1 --sync" },
+      "review.agents[0].options is not supported",
+    ],
+  ] as const)(
+    "%s throws when config validation fails",
+    async (name, args, error) => {
+      const directory = await mkdtemp(
+        join(process.env.TMPDIR ?? "/tmp", "magi-run-validation-"),
+      )
 
-    try {
-      await writeConfig(join(directory, ".opencode", "magi.json"), {
-        github: { owner: "owner", repo: "repo" },
-        review: {
-          agents: [
-            {
-              account: "bot-a",
-              model: "openai/gpt",
-              options: { reasoningEffort: "high" },
-            },
-            { account: "bot-b", model: "openai/gpt" },
-            { account: "bot-c", model: "openai/gpt" },
-          ],
-        },
-        triage: {
-          agents: [
-            { account: "triage-a", model: "openai/gpt" },
-            { account: "triage-b", model: "openai/gpt" },
-            { account: "triage-c", model: "openai/gpt" },
-          ],
-        },
-      })
-
-      const plugin = await MagiPlugin({
-        client: {
-          config: {
-            providers: async () => ({
-              providers: [{ id: "openai", models: { gpt: {} } }],
-            }),
+      try {
+        await writeConfig(join(directory, ".opencode", "magi.json"), {
+          github: { owner: "owner", repo: "repo" },
+          review: {
+            agents: [
+              {
+                account: "bot-a",
+                model: "openai/gpt",
+                options: { reasoningEffort: "high" },
+              },
+              { account: "bot-b", model: "openai/gpt" },
+              { account: "bot-c", model: "openai/gpt" },
+            ],
           },
-          session: {},
-        },
-        directory,
-      } as never)
+          triage: {
+            agents: [
+              { account: "triage-a", model: "openai/gpt" },
+              { account: "triage-b", model: "openai/gpt" },
+              { account: "triage-c", model: "openai/gpt" },
+            ],
+          },
+        })
 
-      await expect(
-        plugin.tool?.magi_triage.execute(
-          { issues: "1 --sync" } as never,
-          { abort: new AbortController().signal, sessionID: "parent" } as never,
-        ),
-      ).rejects.toThrow("review.agents[0].options is not supported")
-    } finally {
-      await rm(directory, { force: true, recursive: true })
-    }
-  })
+        const plugin = await MagiPlugin({
+          client: {
+            config: {
+              providers: async () => ({
+                providers: [{ id: "openai", models: { gpt: {} } }],
+              }),
+            },
+            session: {},
+          },
+          directory,
+        } as never)
+        const tools = plugin.tool as Record<
+          string,
+          { execute: (args: never, context: never) => Promise<unknown> }
+        >
+
+        await expect(
+          tools[name].execute(
+            args as never,
+            {
+              abort: new AbortController().signal,
+              sessionID: "parent",
+            } as never,
+          ),
+        ).rejects.toThrow(error)
+      } finally {
+        await rm(directory, { force: true, recursive: true })
+      }
+    },
+  )
 })
 
 describe("magi_validate", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,7 +13,20 @@ import {
 import { mergeMagiConfig } from "./config/load"
 import { resolveRepository } from "./config/resolve"
 
-const mockState = vi.hoisted(() => ({ home: "" }))
+const mockState = vi.hoisted(() => ({
+  execAsync: vi.fn(async () => ({ stdout: "" })),
+  home: "",
+}))
+
+vi.mock("node:child_process", async () => {
+  const { promisify } =
+    await vi.importActual<typeof import("node:util")>("node:util")
+  const exec = vi.fn()
+
+  Object.defineProperty(exec, promisify.custom, { value: mockState.execAsync })
+
+  return { exec }
+})
 
 vi.mock("node:os", () => ({
   homedir: () => mockState.home,
@@ -347,6 +360,59 @@ describe("magi_status", () => {
       expect(result).toContain("PR: #96")
       expect(result).toContain("PR: #99")
       expect(result).not.toContain("PR: #100")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+})
+
+describe("magi_triage", () => {
+  test("throws when config validation fails", async () => {
+    const directory = await mkdtemp(
+      join(process.env.TMPDIR ?? "/tmp", "magi-triage-"),
+    )
+
+    try {
+      await writeConfig(join(directory, ".opencode", "magi.json"), {
+        github: { owner: "owner", repo: "repo" },
+        review: {
+          agents: [
+            {
+              account: "bot-a",
+              model: "openai/gpt",
+              options: { reasoningEffort: "high" },
+            },
+            { account: "bot-b", model: "openai/gpt" },
+            { account: "bot-c", model: "openai/gpt" },
+          ],
+        },
+        triage: {
+          agents: [
+            { account: "triage-a", model: "openai/gpt" },
+            { account: "triage-b", model: "openai/gpt" },
+            { account: "triage-c", model: "openai/gpt" },
+          ],
+        },
+      })
+
+      const plugin = await MagiPlugin({
+        client: {
+          config: {
+            providers: async () => ({
+              providers: [{ id: "openai", models: { gpt: {} } }],
+            }),
+          },
+          session: {},
+        },
+        directory,
+      } as never)
+
+      await expect(
+        plugin.tool?.magi_triage.execute(
+          { issues: "1 --sync" } as never,
+          { abort: new AbortController().signal, sessionID: "parent" } as never,
+        ),
+      ).rejects.toThrow("review.agents[0].options is not supported")
     } finally {
       await rm(directory, { force: true, recursive: true })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,11 @@ import { loadConfig, mergeMagiConfig } from "./config/load"
 import { outputBaseDirs } from "./config/output"
 import { worktreeBaseDirs } from "./config/worktree"
 import { resolveRepository } from "./config/resolve"
-import { type ModelCatalog, validateConfig } from "./config/validate"
+import {
+  type ModelCatalog,
+  type ValidationResult,
+  validateConfig,
+} from "./config/validate"
 import { withGitHubApiRetry } from "./github/retry"
 import { mapPool } from "./orchestrator/pool"
 import { MagiRunManager, type MagiRunState } from "./orchestrator/run-manager"
@@ -507,6 +511,10 @@ function issueMarkdownLink(
   return `[#${issue}](${url})`
 }
 
+function validationError(validation: ValidationResult): Error {
+  return new Error(JSON.stringify(validation, null, 2))
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
 }
@@ -840,7 +848,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
             requireTriage: true,
           })
 
-          if (!validation.ok) return JSON.stringify(validation, null, 2)
+          if (!validation.ok) throw validationError(validation)
 
           const repository = resolveRepository(config)
           if (!repository.triage)

--- a/src/index.ts
+++ b/src/index.ts
@@ -726,7 +726,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
             requireModelCatalog: true,
           })
 
-          if (!validation.ok) return JSON.stringify(validation, null, 2)
+          if (!validation.ok) throw validationError(validation)
 
           const repository = resolveRepository(config)
           const sync = parsed.sync || args.sync === true
@@ -784,7 +784,7 @@ export const MagiPlugin: Plugin = async ({ client, directory }) => {
             requireModelCatalog: true,
           })
 
-          if (!validation.ok) return JSON.stringify(validation, null, 2)
+          if (!validation.ok) throw validationError(validation)
 
           const repository = resolveRepository(config)
           const sync = parsed.sync || args.sync === true


### PR DESCRIPTION
Closes # N/A - created without a tracking issue per request.

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes Triage Actions that reported success even when `/magi:triage` only returned a configuration validation error.

## Current behavior (updates)

Triage validation failures were returned as normal tool output, so `opencode run` exited successfully and GitHub Actions marked the step green.

The project Magi config also placed provider options at the agent role level, which is rejected by the current config schema after refs are expanded.

## New behavior

`magi_triage` throws on configuration validation failure, causing command execution and the GitHub Action step to fail instead of silently succeeding.

The project Magi config now places provider options inside model candidate entries, matching the supported schema.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Targeted tests run:

- `pnpm vitest run src/index.test.ts`
- `pnpm vitest run src/config/validate.test.ts`