### PR TITLE
docs(config): remove deprecated triage account example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Add the following content to the configuration file.
     "editor": { "ref": "account-4" }
   },
   "triage": {
-    "account": "account-5",
     "agents": [
       { "ref": "account-1" },
       { "ref": "account-2" },


### PR DESCRIPTION
Closes #269

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Remove the deprecated top-level `triage.account` field from the README configuration example.

## Current behavior (updates)

The README example shows a `triage.account` setting that is no longer supported by the schema.

## New behavior

The README triage example now only documents the supported `triage.agents` configuration.

## Is this a breaking change (Yes/No):

No

## Additional Information

Documentation-only change; no local tests were applicable.