### PR TITLE
test(triage): pin non-ASK comment reporter

### DIFF
--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -524,6 +524,13 @@ describe("triage orchestration", () => {
         }),
         JSON.stringify({ reason: "Caspar reason", vote: "YES" }),
       ],
+      repository: {
+        ...repository,
+        triage: {
+          ...repository.triage!,
+          reporter: "Balthasar",
+        },
+      },
     })
     const comment = await readFile(
       join(result.result.outputDir, "comment.md"),


### PR DESCRIPTION
Closes #275

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Pins the triage reporter in the non-ASK decision comment scenario so the expected reason is tied to an explicit reporter instead of the default issue-number reporter selection.

## Current behavior (updates)

The scenario expected Balthasar's reason but relied on the default reporter selection, which can make the test fail if the selected reporter differs.

## New behavior

The scenario explicitly configures `Balthasar` as the triage reporter, making the selected reason deterministic.

No documentation update is needed because this only stabilizes a test fixture.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification: `pnpm vitest run src/orchestrator/triage.test.ts`
