### PR TITLE
feat(config): support single model objects

### DIFF
--- a/.changeset/smart-model-object.md
+++ b/.changeset/smart-model-object.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Support single model objects with per-model options in Magi config.

--- a/README.md
+++ b/README.md
@@ -154,17 +154,14 @@ Add the following content to the configuration file.
 
 Entries with `ref` are expanded from `agents.refs`. Fields set alongside `ref` override fields from the preset.
 
-`model` can be a single `provider/model` string or an ordered candidate array. Candidate arrays are resolved during validation against OpenCode's model catalog; the first available model is selected. Put provider-specific options on object candidates, not on the agent role.
+`model` can be a single `provider/model` string, a single object with `id` and `options`, or an ordered candidate array. Candidate arrays are resolved during validation against OpenCode's model catalog; the first available model is selected. Put provider-specific options on model objects, not on the agent role.
 
 ```json
 {
-  "model": [
-    "anthropic/claude-sonnet-4-5",
-    {
-      "id": "openai/gpt-5.1",
-      "options": { "reasoningEffort": "high" }
-    }
-  ]
+  "model": {
+    "id": "openai/gpt-5.1",
+    "options": { "reasoningEffort": "high" }
+  }
 }
 ```
 

--- a/schema.json
+++ b/schema.json
@@ -149,6 +149,7 @@
     "modelConfig": {
       "oneOf": [
         { "type": "string", "minLength": 1 },
+        { "$ref": "#/$defs/modelCandidate" },
         {
           "type": "array",
           "minItems": 1,

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -817,6 +817,82 @@ describe("validateConfig", () => {
     })
   })
 
+  test("accepts model objects and normalizes options", async () => {
+    const objectConfig = {
+      ...config,
+      agents: {
+        refs: {
+          shared: {
+            account: "bot-a",
+            model: {
+              id: "anthropic/claude",
+              options: { thinking: { budget_tokens: 12000, type: "enabled" } },
+            },
+          },
+        },
+      },
+      review: {
+        reviewers: [
+          { ref: "shared" },
+          {
+            account: "bot-b",
+            model: { id: "openai/gpt", options: { reasoningEffort: "high" } },
+          },
+          { account: "bot-c", model: "google/gemini" },
+        ],
+      },
+      merge: {
+        editor: {
+          account: "bot-c",
+          author: { email: "bot-c@example.com", name: "Bot C" },
+          model: { id: "openai/gpt", options: { reasoningEffort: "low" } },
+        },
+      },
+      triage: {
+        voters: [
+          { account: "triage-a", model: { id: "openai/gpt" } },
+          { account: "triage-b", model: "anthropic/claude" },
+          { account: "triage-c", model: "google/gemini" },
+        ],
+        creator: {
+          account: "creator-bot",
+          author: { email: "creator@example.com", name: "Creator Bot" },
+          model: { id: "openai/gpt", options: { reasoningEffort: "low" } },
+        },
+      },
+    } as unknown as MagiConfig
+
+    const result = await validateConfig(objectConfig, {
+      modelCatalog: {
+        anthropic: ["claude"],
+        google: ["gemini"],
+        openai: ["gpt"],
+      },
+      requireTriage: true,
+    })
+    const repository = resolveRepository(objectConfig)
+
+    expect(result).toMatchObject({ errors: [], ok: true })
+    expect(objectConfig.review?.reviewers?.[0]).toMatchObject({
+      model: "anthropic/claude",
+      options: { thinking: { budget_tokens: 12000, type: "enabled" } },
+    })
+    expect(objectConfig.review?.reviewers?.[1]).toMatchObject({
+      model: "openai/gpt",
+      options: { reasoningEffort: "high" },
+    })
+    expect(objectConfig.triage?.voters?.[0]).toMatchObject({
+      model: "openai/gpt",
+    })
+    expect(objectConfig.triage?.voters?.[0]).not.toHaveProperty("options")
+    expect(repository.agents.editor?.options).toEqual({
+      reasoningEffort: "low",
+    })
+    expect(repository.agents.triageCreator?.options).toEqual({
+      reasoningEffort: "low",
+    })
+  })
+
   test("rejects model candidate arrays with no usable model", async () => {
     const result = await validateConfig(
       {
@@ -880,6 +956,31 @@ describe("validateConfig", () => {
     expect(result.ok).toBe(false)
     expect(result.errors).toContain(
       "review.reviewers[0].model[0].options must be an object",
+    )
+  })
+
+  test("rejects non-object model object options", async () => {
+    const result = await validateConfig(
+      {
+        ...config,
+        review: {
+          ...config.review,
+          reviewers: [
+            {
+              account: "bot-a",
+              model: { id: "openai/gpt", options: "high" },
+            },
+            { account: "bot-b", model: "openai/gpt" },
+            { account: "bot-c", model: "openai/gpt" },
+          ],
+        },
+      } as unknown as MagiConfig,
+      { modelCatalog: { openai: ["gpt"] } },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain(
+      "review.reviewers[0].model.options must be an object",
     )
   })
 

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -471,8 +471,24 @@ function validateAndNormalizeModel(
     return
   }
 
+  if (isPlainObject(model)) {
+    const candidate = readModelCandidate(model, path, errors)
+
+    if (
+      candidate &&
+      validateModelId(candidate.id, `${path}.id`, errors, catalog)
+    ) {
+      target.model = candidate.id
+      if (candidate.options) target.options = candidate.options
+      else delete target.options
+    }
+
+    return
+  }
+
   if (!Array.isArray(model)) {
-    if (model != null) errors.push(`${path} must be a string or an array`)
+    if (model != null)
+      errors.push(`${path} must be a string, an object, or an array`)
     return
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,10 @@ export interface ModelCandidateConfig {
   options?: ModelOptions
 }
 
-export type ModelConfig = string | (string | ModelCandidateConfig)[]
+export type ModelConfig =
+  | string
+  | ModelCandidateConfig
+  | (string | ModelCandidateConfig)[]
 
 export type PermissionAction = "allow" | "ask" | "deny"
 


### PR DESCRIPTION
Closes #278

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Allows `model` config to use a single object with `id` and `options` anywhere model candidate arrays are supported.

## Current behavior (updates)

Single-model configs could be strings, and configs with options had to use a one-item candidate array.

## New behavior

Single model objects now pass schema validation, normalize to `model: string` with `options`, and are documented in README.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Added validation coverage for accepted object syntax and invalid object options.
- Tests: `pnpm vitest run src/config/validate.test.ts`