### PR TITLE
feat(review): add merge conflict prompt context

### DIFF
--- a/.changeset/review-conflict-context.md
+++ b/.changeset/review-conflict-context.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Add merge conflict context to review and re-review prompts.

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -49,15 +49,16 @@ It skips reviewer accounts that already reviewed the current effective head. If 
 8. Wait for required PR checks when `review.checks.wait` is enabled. Optional checks are ignored for review gating.
 9. If checks fail, remove checks matching `review.checks.exclude`, fetch failed job logs, classify each remaining failure as `SCOPE_IN` or `SCOPE_OUT`, rerun only `SCOPE_OUT` GitHub Actions jobs up to `review.checks.retryFailedJobs`, and pass `SCOPE_IN` failure context to reviewers. Dry runs skip the rerun and report it as a planned action.
 10. Create a detached git worktree under `review.worktree` and check out the PR branch.
-11. Run each non-skipped reviewer agent through the reviewer worker pool.
-12. Parse each reviewer response as the fixed review or re-review JSON schema.
-13. Validate each `CHANGES_REQUESTED` finding by asking the other reviewers to vote on it.
-14. Keep only findings that reach finding-level majority.
-15. Reconsider any minority `CLOSE` verdict before posting.
-16. Aggregate active reviewer verdicts plus skipped reviewer verdicts from existing GitHub review state by majority vote.
-17. Post each active reviewer result to GitHub with that reviewer's configured account, unless `--dry-run` is set.
-18. If configured, merge or close the PR according to `review.automation`.
-19. Remove the temporary worktree and recorded worktree branch.
+11. Detect merge conflicts between the PR head and base branch and pass conflicted files plus right-side PR diff line hints to reviewers when conflicts exist.
+12. Run each non-skipped reviewer agent through the reviewer worker pool.
+13. Parse each reviewer response as the fixed review or re-review JSON schema.
+14. Validate each `CHANGES_REQUESTED` finding by asking the other reviewers to vote on it.
+15. Keep only findings that reach finding-level majority.
+16. Reconsider any minority `CLOSE` verdict before posting.
+17. Aggregate active reviewer verdicts plus skipped reviewer verdicts from existing GitHub review state by majority vote.
+18. Post each active reviewer result to GitHub with that reviewer's configured account, unless `--dry-run` is set.
+19. If configured, merge or close the PR according to `review.automation`.
+20. Remove the temporary worktree and recorded worktree branch.
 
 Reviewer verdicts map to GitHub actions:
 
@@ -151,6 +152,8 @@ Each reviewer receives the diff from that reviewer's previous review commit to t
 Each `CHANGES_REQUESTED` finding is validated by the other reviewers. The finding author counts as one approval; with three reviewers, at least one of the other two reviewers must agree for the finding to remain.
 
 Every finding must target a valid right-side line in the PR diff. If the problem does not have an exact changed line, reviewers anchor it to the nearest changed line that represents the cause, responsibility, missing implementation, or affected behavior, such as missing validation, wiring, requirements, tests, documentation, configuration, or a relevant call site.
+
+When the PR conflicts with the base branch, reviewer prompts include `<merge_conflict_context>` with conflicted files, merge-tree excerpts, and `suggestedLine` values when a valid right-side PR diff line is available. Reviewers should request changes for unresolved conflicts that make the PR unsafe or impossible to merge.
 
 ### What GitHub data windows are fetched?
 

--- a/docs/prompts/review/rereview.md
+++ b/docs/prompts/review/rereview.md
@@ -6,7 +6,7 @@ Config key: `review.prompts.rereview`
 
 Built-in template: [`review/rereview.md`](/src/prompts/templates/review/rereview.md)
 
-New findings follow the same inline target rules as initial review findings: every `newFindings[]` item must include `path` and `line`, and `line` must target a valid right-side PR diff line. If the concern has no exact changed line, the reviewer anchors it to the nearest changed line representing the cause, responsibility, missing implementation, or affected behavior.
+New findings follow the same inline target rules as initial review findings: every `newFindings[]` item must include `path` and `line`, and `line` must target a valid right-side PR diff line. If the concern has no exact changed line, the reviewer anchors it to the nearest changed line representing the cause, responsibility, missing implementation, or affected behavior. If `<merge_conflict_context>` is present, reviewers treat unresolved merge conflicts as findings and request changes when the PR is unsafe or impossible to merge.
 
 | Placeholder                       | Meaning                                                                               |
 | --------------------------------- | ------------------------------------------------------------------------------------- |
@@ -18,6 +18,8 @@ New findings follow the same inline target rules as initial review findings: eve
 | `{unresolvedThreads}`             | JSON list of unresolved review threads for the reviewer.                              |
 | `{ciFailureContext}`              | Scope-in CI failure context, when present.                                            |
 | `{ciFailureContextBlock}`         | Full `<ci_failure_context>` block when context exists, otherwise empty.               |
+| `{mergeConflictContext}`          | Merge conflict context for the PR, when conflicts exist.                              |
+| `{mergeConflictContextBlock}`     | Full `<merge_conflict_context>` block when context exists, otherwise empty.           |
 | `{previousReview}`                | Previous GitHub review metadata, when available.                                      |
 | `{previousReviewBlock}`           | Full `<previous_review>` block when previous review metadata exists, otherwise empty. |
 | `{reviewContext}`                 | Rendered PR, related issue, PR comment, and review discussion context.                |

--- a/docs/prompts/review/review.md
+++ b/docs/prompts/review/review.md
@@ -6,15 +6,17 @@ Config key: `review.prompts.review`
 
 Built-in template: [`review/review.md`](/src/prompts/templates/review/review.md)
 
-Review findings must always include `path` and `line`, and `line` must target a valid right-side PR diff line. When a concern does not map exactly to one changed line, the reviewer anchors it to the nearest changed line representing the cause, responsibility, missing implementation, or affected behavior.
+Review findings must always include `path` and `line`, and `line` must target a valid right-side PR diff line. When a concern does not map exactly to one changed line, the reviewer anchors it to the nearest changed line representing the cause, responsibility, missing implementation, or affected behavior. If `<merge_conflict_context>` is present, reviewers treat unresolved merge conflicts as findings and request changes when the PR is unsafe or impossible to merge.
 
-| Placeholder                 | Meaning                                                                 |
-| --------------------------- | ----------------------------------------------------------------------- |
-| `{pr}`                      | Pull request number.                                                    |
-| `{owner}` / `{repo}`        | GitHub repository owner and name.                                       |
-| `{worktreePath}`            | Temporary PR worktree path.                                             |
-| `{baseSha}` / `{headSha}`   | Diff range for the review.                                              |
-| `{jsonEncodedWorktreePath}` | JSON-encoded worktree path for shell snippets.                          |
-| `{ciFailureContext}`        | Scope-in CI failure context, when present.                              |
-| `{ciFailureContextBlock}`   | Full `<ci_failure_context>` block when context exists, otherwise empty. |
-| `{reviewContext}`           | Rendered PR, related issue, PR comment, and review discussion context.  |
+| Placeholder                   | Meaning                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `{pr}`                        | Pull request number.                                                        |
+| `{owner}` / `{repo}`          | GitHub repository owner and name.                                           |
+| `{worktreePath}`              | Temporary PR worktree path.                                                 |
+| `{baseSha}` / `{headSha}`     | Diff range for the review.                                                  |
+| `{jsonEncodedWorktreePath}`   | JSON-encoded worktree path for shell snippets.                              |
+| `{ciFailureContext}`          | Scope-in CI failure context, when present.                                  |
+| `{ciFailureContextBlock}`     | Full `<ci_failure_context>` block when context exists, otherwise empty.     |
+| `{mergeConflictContext}`      | Merge conflict context for the PR, when conflicts exist.                    |
+| `{mergeConflictContextBlock}` | Full `<merge_conflict_context>` block when context exists, otherwise empty. |
+| `{reviewContext}`             | Rendered PR, related issue, PR comment, and review discussion context.      |

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from "vitest"
 import {
   hasPendingThreadReply,
   inlineCommentTargetsForDiff,
+  mergeConflictContextForDiff,
   runReview,
   reviewOutputFromState,
   resolveReviewMode,
@@ -81,7 +82,10 @@ function graphqlResponse(value: unknown): string {
   return JSON.stringify({ data: { repository: { pullRequest: value } } })
 }
 
-function fakeExec(commands: string[]): Exec {
+function fakeExec(
+  commands: string[],
+  options: { diff?: string; mergeTree?: string } = {},
+): Exec {
   return async (command) => {
     commands.push(command)
 
@@ -169,7 +173,9 @@ function fakeExec(commands: string[]): Exec {
     if (command.startsWith("gh pr checkout ")) return ""
     if (command === "git branch --show-current") return "feature"
     if (command.startsWith("git cat-file -e ")) return ""
-    if (command.startsWith("git diff ")) return ""
+    if (command.startsWith("git diff ")) return options.diff ?? ""
+    if (command.startsWith("git merge-base ")) return "merge-base"
+    if (command.startsWith("git merge-tree ")) return options.mergeTree ?? ""
 
     throw new Error(`Unexpected command: ${command}`)
   }
@@ -428,6 +434,49 @@ describe("review", () => {
     )
   })
 
+  test("builds merge conflict context with an inline target", async () => {
+    const commands: { command: string; cwd?: string }[] = []
+    const context = await mergeConflictContextForDiff({
+      baseSha: "base-sha",
+      exec: async (command, options) => {
+        commands.push({ command, cwd: options?.cwd })
+
+        if (command.startsWith("git merge-base ")) return "merge-base"
+
+        return [
+          "changed in both",
+          "  base   100644 1111111111111111111111111111111111111111 src/app.ts",
+          "  our    100644 2222222222222222222222222222222222222222 src/app.ts",
+          "  their  100644 3333333333333333333333333333333333333333 src/app.ts",
+          "@@ -1 +1,5 @@",
+          "+<<<<<<< .our",
+          " head",
+          "+=======",
+          "+base",
+          "+>>>>>>> .their",
+        ].join("\n")
+      },
+      headSha: "head-sha",
+      inlineCommentTargets: new Map([["src/app.ts", new Set([2, 3])]]),
+      worktreePath: "/tmp/worktree",
+    })
+
+    expect(commands).toEqual([
+      {
+        command: "git merge-base 'base-sha' 'head-sha'",
+        cwd: "/tmp/worktree",
+      },
+      {
+        command: "git merge-tree 'merge-base' 'head-sha' 'base-sha'",
+        cwd: "/tmp/worktree",
+      },
+    ])
+    expect(context).toContain("unresolved merge conflicts")
+    expect(context).toContain("path: src/app.ts")
+    expect(context).toContain("suggestedLine: 2")
+    expect(context).toContain("rightSideDiffLines: 2, 3")
+  })
+
   test("restores legacy inline review findings from the posted review body", () => {
     expect(
       reviewOutputFromState({
@@ -584,6 +633,64 @@ describe("review", () => {
         "bot-a",
       ),
     ).toBe(false)
+  })
+
+  test("includes merge conflict context in reviewer prompts", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-review-test-"))
+    const commands: string[] = []
+    const prompts: string[] = []
+    const outputs = [
+      JSON.stringify({
+        followUps: [],
+        newFindings: [],
+        resolve: [],
+        verdict: "MERGE",
+      }),
+      JSON.stringify({ findings: [], verdict: "MERGE" }),
+      JSON.stringify({ findings: [], verdict: "MERGE" }),
+    ]
+
+    try {
+      await runReview({
+        client: fakeClient(outputs, prompts),
+        config: {
+          review: { output: "runs", worktree: "worktrees" },
+        } satisfies MagiConfig,
+        directory,
+        dryRun: true,
+        exec: fakeExec(commands, {
+          diff: [
+            "diff --git a/src/app.ts b/src/app.ts",
+            "--- a/src/app.ts",
+            "+++ b/src/app.ts",
+            "@@ -1 +1,2 @@",
+            " existing",
+            "+added",
+          ].join("\n"),
+          mergeTree: [
+            "changed in both",
+            "  base   100644 1111111111111111111111111111111111111111 src/app.ts",
+            "  our    100644 2222222222222222222222222222222222222222 src/app.ts",
+            "  their  100644 3333333333333333333333333333333333333333 src/app.ts",
+            "@@ -1 +1,5 @@",
+            "+<<<<<<< .our",
+            " existing",
+            "+=======",
+            "+base",
+            "+>>>>>>> .their",
+          ].join("\n"),
+        }),
+        pr: 1,
+        repository,
+      })
+
+      expect(prompts[0]).toContain("<merge_conflict_context>")
+      expect(prompts[0]).toContain("path: src/app.ts")
+      expect(prompts[0]).toContain("suggestedLine: 1")
+      expect(prompts[0]).toContain("treat unresolved merge conflicts")
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
   })
 
   test("reconsiders minority close verdicts from rereview outputs", async () => {

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -433,6 +433,140 @@ export async function inlineCommentTargetsForDiff(input: {
   )
 }
 
+function firstTargetLine(
+  targets: InlineCommentTargets,
+  path: string,
+): number | undefined {
+  const lines = targets.get(path)
+
+  if (!lines?.size) return undefined
+
+  return [...lines].sort((a, b) => a - b)[0]
+}
+
+function mergeInlineCommentTargets(
+  left: InlineCommentTargets,
+  right: InlineCommentTargets,
+): InlineCommentTargets {
+  const merged = new Map<string, Set<number>>()
+
+  for (const [path, lines] of [...left, ...right]) {
+    const targetLines = merged.get(path) ?? new Set<number>()
+
+    for (const line of lines) targetLines.add(line)
+    merged.set(path, targetLines)
+  }
+
+  return merged
+}
+
+function targetLineSummary(
+  targets: InlineCommentTargets,
+  path: string,
+): string {
+  const lines = targets.get(path)
+
+  if (!lines?.size) return "(none)"
+
+  const sorted = [...lines].sort((a, b) => a - b)
+  const shown = sorted.slice(0, 12).join(", ")
+
+  return sorted.length > 12 ? `${shown}, ...` : shown
+}
+
+function indentedExcerpt(lines: string[]): string {
+  return lines
+    .slice(0, 24)
+    .map((line) => `  ${line}`)
+    .join("\n")
+}
+
+function parseMergeConflictSections(output: string): {
+  excerpt: string
+  path: string
+}[] {
+  const conflictHeaders = new Set([
+    "added in both",
+    "changed in both",
+    "removed in local",
+    "removed in remote",
+  ])
+  const sections: { lines: string[]; paths: Set<string> }[] = []
+  let current: { lines: string[]; paths: Set<string> } | undefined
+
+  for (const line of output.split("\n")) {
+    if (!line.trim()) continue
+
+    if (
+      !line.startsWith(" ") &&
+      !line.startsWith("+") &&
+      !line.startsWith("-") &&
+      !line.startsWith("@")
+    ) {
+      current = conflictHeaders.has(line)
+        ? { lines: [line], paths: new Set() }
+        : undefined
+      if (current) sections.push(current)
+      continue
+    }
+
+    if (!current) continue
+
+    current.lines.push(line)
+
+    const path = /^  (?:base|our|their)\s+\d+\s+[0-9a-f]+\s+(.+)$/.exec(
+      line,
+    )?.[1]
+    if (path) current.paths.add(path)
+  }
+
+  return sections.flatMap((section) =>
+    [...section.paths].map((path) => ({
+      excerpt: indentedExcerpt(section.lines),
+      path,
+    })),
+  )
+}
+
+export async function mergeConflictContextForDiff(input: {
+  baseSha: string
+  exec: Exec
+  headSha: string
+  inlineCommentTargets: InlineCommentTargets
+  worktreePath: string
+}): Promise<string> {
+  const mergeBase = (
+    await input.exec(
+      `git merge-base ${shellQuote(input.baseSha)} ${shellQuote(input.headSha)}`,
+      { cwd: input.worktreePath },
+    )
+  ).trim()
+  const output = await input.exec(
+    `git merge-tree ${shellQuote(mergeBase)} ${shellQuote(input.headSha)} ${shellQuote(input.baseSha)}`,
+    { cwd: input.worktreePath },
+  )
+  const conflicts = parseMergeConflictSections(output)
+
+  if (!conflicts.length) return ""
+
+  return [
+    "The PR currently has unresolved merge conflicts with the base branch.",
+    "Treat unresolved conflicts as review findings and request changes when they make the PR unsafe or impossible to merge.",
+    "Use suggestedLine when it is present; it is a valid right-side PR diff line for an inline finding.",
+    ...conflicts.map((conflict) => {
+      const suggestedLine = firstTargetLine(
+        input.inlineCommentTargets,
+        conflict.path,
+      )
+      const suggestedLineText = suggestedLine
+        ? `suggestedLine: ${suggestedLine}`
+        : "suggestedLine: (no right-side PR diff line found)"
+
+      return `<conflict_file>\npath: ${conflict.path}\n${suggestedLineText}\nrightSideDiffLines: ${targetLineSummary(input.inlineCommentTargets, conflict.path)}\nmergeTreeExcerpt:\n${conflict.excerpt}\n</conflict_file>`
+    }),
+  ].join("\n")
+}
+
 function parsePostedFindingLocation(
   location: string,
 ): Pick<Finding, "line" | "path" | "startLine"> | undefined {
@@ -1239,6 +1373,13 @@ export async function runReview(
       toSha: meta.headRefOid,
       worktreePath,
     })
+    const mergeConflictContext = await mergeConflictContextForDiff({
+      baseSha: meta.baseRefOid,
+      exec,
+      headSha: meta.headRefOid,
+      inlineCommentTargets: initialInlineCommentTargets,
+      worktreePath,
+    })
     for (const reviewer of input.repository.agents.reviewers) {
       const assignment = mode.assignments.get(reviewer.account)
       if (assignment?.type !== "skip") continue
@@ -1278,6 +1419,12 @@ export async function runReview(
             toSha: meta.headRefOid,
             worktreePath,
           })
+          const rereviewInlineCommentTargets = mergeConflictContext
+            ? mergeInlineCommentTargets(
+                inlineCommentTargets,
+                initialInlineCommentTargets,
+              )
+            : inlineCommentTargets
 
           const unresolved =
             unresolvedThreadsByAccount.get(reviewer.account) ??
@@ -1292,6 +1439,7 @@ export async function runReview(
             ciFailureContext,
             directory: input.directory,
             headSha: meta.headRefOid,
+            mergeConflictContext,
             pr: input.pr,
             previousReview: previousReviewText(previous),
             previousHeadSha: previous.commit.oid,
@@ -1336,7 +1484,7 @@ export async function runReview(
                 parse: (text) =>
                   parseRereviewOutputWithInlineTargets(
                     text,
-                    inlineCommentTargets,
+                    rereviewInlineCommentTargets,
                   ),
                 permission: reviewer.permission,
                 prompt,
@@ -1381,6 +1529,7 @@ export async function runReview(
           ciFailureContext,
           directory: input.directory,
           headSha: meta.headRefOid,
+          mergeConflictContext,
           pr: input.pr,
           repository: input.repository,
           reviewContext,

--- a/src/orchestrator/scenarios.test.ts
+++ b/src/orchestrator/scenarios.test.ts
@@ -426,6 +426,8 @@ function createExec(
         "+export const value = 1",
       ].join("\n")
     }
+    if (command.startsWith("git merge-base ")) return "merge-base"
+    if (command.startsWith("git merge-tree ")) return ""
     if (
       command.includes("repos/owner/repo/issues/1/comments") &&
       command.includes("--method POST")

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -110,6 +110,8 @@ describe("prompt composer", () => {
       baseSha: "base",
       directory: dir,
       headSha: "head",
+      mergeConflictContext:
+        "<conflict_file>\npath: src/app.ts\nsuggestedLine: 2\n</conflict_file>",
       pr: 1,
       repository,
       reviewContext:
@@ -124,10 +126,16 @@ describe("prompt composer", () => {
     expect(prompt).toContain(
       "<pull_request_context>\nnumber: 1\n</pull_request_context>",
     )
+    expect(prompt).toContain(
+      "<merge_conflict_context>\n<conflict_file>\npath: src/app.ts\nsuggestedLine: 2\n</conflict_file>\n</merge_conflict_context>",
+    )
     expect(prompt.indexOf("Custom review for #1")).toBeLessThan(
       prompt.indexOf("<pull_request_context>"),
     )
     expect(prompt.indexOf("<pull_request_context>")).toBeLessThan(
+      prompt.indexOf("<merge_conflict_context>"),
+    )
+    expect(prompt.indexOf("<merge_conflict_context>")).toBeLessThan(
       prompt.indexOf("<output_contract>"),
     )
     const optionalSessionSections = [
@@ -161,6 +169,8 @@ describe("prompt composer", () => {
       baseSha: "base",
       directory: dir,
       headSha: "head",
+      mergeConflictContext:
+        "<conflict_file>\npath: src/app.ts\nsuggestedLine: 2\n</conflict_file>",
       pr: 1,
       previousHeadSha: "old",
       previousReview: "Previously requested changes for tests.",
@@ -173,6 +183,9 @@ describe("prompt composer", () => {
 
     expect(rereviewPrompt).toContain(
       "<closing_issues>\n(none)\n</closing_issues>",
+    )
+    expect(rereviewPrompt).toContain(
+      "<merge_conflict_context>\n<conflict_file>\npath: src/app.ts\nsuggestedLine: 2\n</conflict_file>\n</merge_conflict_context>",
     )
     expect(rereviewPrompt).toContain(
       "<previous_review>\nPreviously requested changes for tests.\n</previous_review>",

--- a/src/prompts/compose.ts
+++ b/src/prompts/compose.ts
@@ -26,6 +26,7 @@ export interface ReviewPromptInput {
   ciFailureContext?: string
   directory: string
   headSha: string
+  mergeConflictContext?: string
   pr: number
   repository: ResolvedRepository
   reviewContext?: string
@@ -166,6 +167,7 @@ function repositoryValues(
 
 function reviewValues(input: ReviewPromptInput): Record<string, string> {
   const ciFailureContext = input.ciFailureContext?.trim() ?? ""
+  const mergeConflictContext = input.mergeConflictContext?.trim() ?? ""
 
   return {
     ...repositoryValues(input.repository),
@@ -176,6 +178,10 @@ function reviewValues(input: ReviewPromptInput): Record<string, string> {
       : "",
     headSha: input.headSha,
     jsonEncodedWorktreePath: JSON.stringify(input.worktreePath),
+    mergeConflictContext,
+    mergeConflictContextBlock: mergeConflictContext
+      ? `<merge_conflict_context>\n${mergeConflictContext}\n</merge_conflict_context>`
+      : "",
     pr: String(input.pr),
     reviewContext: input.reviewContext ?? "",
     worktreePath: input.worktreePath,
@@ -244,6 +250,14 @@ function previousReviewBlock(previousReview?: string): string {
 
 function reviewContextBlock(reviewContext?: string): string {
   return reviewContext?.trim() ? reviewContext.trim() : ""
+}
+
+function mergeConflictContextBlock(mergeConflictContext?: string): string {
+  const body = mergeConflictContext?.trim()
+
+  return body
+    ? `<merge_conflict_context>\n${body}\n</merge_conflict_context>`
+    : ""
 }
 
 async function reviewGuidelinesBlock(input: {
@@ -320,6 +334,7 @@ export async function composeReviewPrompt(
   return [
     task,
     reviewContextBlock(input.reviewContext),
+    mergeConflictContextBlock(input.mergeConflictContext),
     languageBlock(input.repository.language),
     personaBlock(input.reviewer.persona),
     await reviewGuidelinesBlock({
@@ -347,6 +362,7 @@ export async function composeRereviewPrompt(
   return [
     task,
     reviewContextBlock(input.reviewContext),
+    mergeConflictContextBlock(input.mergeConflictContext),
     input.includeSessionContext === false
       ? ""
       : languageBlock(input.repository.language),

--- a/src/prompts/templates/review/rereview.md
+++ b/src/prompts/templates/review/rereview.md
@@ -13,6 +13,8 @@ Every newFinding must target a valid right-side line in the PR diff.
 If the problem itself does not have an exact changed line, choose the nearest changed line that represents the cause, responsibility, missing implementation, or affected behavior. This includes but is not limited to missing validation, missing wiring, missing requirements, missing tests, missing documentation, affected configuration, or relevant call sites.
 Do not omit line. Do not create file-level or body-only newFindings.
 
+If `<merge_conflict_context>` is present, treat unresolved merge conflicts as review findings. Request changes when a conflict makes the PR unsafe or impossible to merge, and prefer the provided `suggestedLine` when it is present.
+
 {ciFailureContextBlock}
 Do not edit files or perform write operations.
 

--- a/src/prompts/templates/review/review.md
+++ b/src/prompts/templates/review/review.md
@@ -14,4 +14,6 @@ Every finding must target a valid right-side line in the PR diff.
 If the problem itself does not have an exact changed line, choose the nearest changed line that represents the cause, responsibility, missing implementation, or affected behavior. This includes but is not limited to missing validation, missing wiring, missing requirements, missing tests, missing documentation, affected configuration, or relevant call sites.
 Do not omit line. Do not create file-level or body-only findings.
 
+If `<merge_conflict_context>` is present, treat unresolved merge conflicts as review findings. Request changes when a conflict makes the PR unsafe or impossible to merge, and prefer the provided `suggestedLine` when it is present.
+
 {ciFailureContextBlock}


### PR DESCRIPTION
Closes #280

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds merge conflict detection to `/magi:review` and injects `<merge_conflict_context>` into initial review and re-review prompts when conflicts exist.

## Current behavior (updates)

Review prompts included PR, review discussion, and CI failure context, but not explicit merge conflict information.

## New behavior

After the PR worktree and diff targets are ready, review detects conflicts with `git merge-tree`, passes conflicted file context and suggested right-side diff lines to reviewers, and updates the built-in prompt guidance.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tests: `pnpm vitest run src/prompts/compose.test.ts src/orchestrator/review.test.ts`