### PR TITLE
fix(review): preserve single-mode reviewer context

### DIFF
--- a/.changeset/single-review-summaries.md
+++ b/.changeset/single-review-summaries.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Improve single-account review summaries and logical reviewer thread routing.

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -37,6 +37,8 @@ Review flags:
 
 In `multi` mode, it skips reviewer accounts that already reviewed the current effective head. In `single` mode, it uses hidden review markers posted by `review.account` to recover current logical reviewer verdicts. If a reviewer reviewed an older effective head, Magi runs that reviewer in re-review mode. If every configured reviewer already reviewed the current effective head, the command aborts instead of posting duplicate reviews.
 
+Single-mode consensus reviews include the logical reviewer verdicts plus visible close-reason or accepted-change-request summaries when the consensus is `CLOSE` or `CHANGES_REQUESTED`. Hidden finding markers on unresolved review threads route re-review context back to the logical reviewer that raised the finding.
+
 ## Flow
 
 1. Fetch PR metadata with `gh pr view`.

--- a/src/orchestrator/merge.test.ts
+++ b/src/orchestrator/merge.test.ts
@@ -930,6 +930,157 @@ describe("merge", () => {
     expect(prompts.join("\n")).toContain("Pass findings to the editor.")
   })
 
+  test("uses review account threads for single-mode merge rereview", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-merge-test-"))
+    const reviewers = [
+      {
+        account: "alpha-bot",
+        index: 0,
+        key: "alpha",
+        model: "test/model",
+        permission: "allow" as const,
+      },
+    ]
+    const mergeRepository: ResolvedRepository = {
+      ...editorRepository,
+      agents: {
+        editor: editorRepository.agents.editor,
+        reviewers,
+      },
+      automation: { ...editorRepository.automation, merge: false },
+      review: { account: "review-bot", mode: "single" },
+    }
+    let rereviewThreads: unknown
+    const marker = (author: string) =>
+      `<!-- opencode-magi:review-finding v=1 mode=single pr=162 reviewer=alpha finding=0 head=review-head -->\n${author}`
+    const exec: Exec = async (command) => {
+      if (command.startsWith("gh pr view")) {
+        return JSON.stringify(
+          prMeta({
+            headRefOid: "edited-head",
+            number: 162,
+          }),
+        )
+      }
+      if (command.startsWith("gh auth token")) return "token"
+      if (command.startsWith("git config ")) return ""
+      if (command.startsWith("git push ")) return ""
+      if (command.startsWith("git cat-file -e ")) return ""
+      if (command.startsWith("git diff ")) {
+        return [
+          "diff --git a/file.ts b/file.ts",
+          "--- a/file.ts",
+          "+++ b/file.ts",
+          "@@ -1 +1,2 @@",
+          " existing",
+          "+added",
+        ].join("\n")
+      }
+      if (command.includes("reviewThreads(first:")) {
+        return JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      comments: {
+                        nodes: [
+                          {
+                            author: { login: "review-bot" },
+                            body: marker("review-bot"),
+                            createdAt: "2026-01-01T00:00:00Z",
+                            databaseId: 1,
+                            line: 1,
+                            path: "file.ts",
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false },
+                      },
+                      id: "thread-review-bot",
+                      isResolved: false,
+                    },
+                    {
+                      comments: {
+                        nodes: [
+                          {
+                            author: { login: "editor-bot" },
+                            body: marker("editor-bot"),
+                            createdAt: "2026-01-01T00:00:01Z",
+                            databaseId: 2,
+                            line: 2,
+                            path: "file.ts",
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false },
+                      },
+                      id: "thread-editor-bot",
+                      isResolved: false,
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
+              },
+            },
+          },
+        })
+      }
+
+      return ""
+    }
+
+    runReviewMock.mockResolvedValueOnce({
+      baseSha: "base-sha",
+      ciReports: [],
+      discardedFindings: [],
+      headSha: "review-head",
+      outputs: {
+        alpha: {
+          findings: [
+            {
+              fix: "Fix the bug.",
+              issue: "Bug remains.",
+              line: 1,
+              path: "file.ts",
+            },
+          ],
+          verdict: "CHANGES_REQUESTED",
+        },
+      },
+      posted: {},
+      pr: 162,
+      report: "review report",
+      sessionIds: {},
+      verdict: "CHANGES_REQUESTED",
+      worktreePath: directory,
+    } satisfies ReviewRunResult)
+    runModelWithRepairMock.mockResolvedValueOnce({
+      raw: "{}",
+      sessionId: "editor-session",
+      value: editOutput(),
+    })
+    composeRereviewPromptMock.mockImplementationOnce(async (input) => {
+      rereviewThreads = JSON.parse(input.unresolvedThreads)
+      throw new Error("stop after rereview prompt")
+    })
+
+    await expect(
+      runMerge({
+        client: { session: { create: vi.fn(), prompt: vi.fn() } },
+        config: {},
+        directory,
+        exec,
+        pr: 162,
+        repository: mergeRepository,
+      }),
+    ).rejects.toThrow("stop after rereview prompt")
+
+    expect(rereviewThreads).toMatchObject([{ threadId: "thread-review-bot" }])
+    expect(rereviewThreads).not.toMatchObject([
+      { threadId: "thread-editor-bot" },
+    ])
+  })
+
   test("treats scope-in CI failures as merge blocking", () => {
     expect(
       hasBlockingCiReports([

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -478,7 +478,6 @@ async function runRereview(
   const singleModeThreads = singleReviewMode
     ? assignThreadsByReviewFindingMarker({
         fallbackReviewerKeys: reviewerKeys,
-        headSha,
         pr: input.pr,
         reviewerKeys,
         threads:

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -531,6 +531,9 @@ describe("review", () => {
     expect(String(payloads[0]?.body)).toContain(
       "Magi single-account review result: CHANGES_REQUESTED.",
     )
+    expect(String(payloads[0]?.body)).toContain(
+      "Accepted change requests:\n- general #1 src/app.ts:40-42: Index can point at the wrong line. Fix: Normalize before indexing.",
+    )
     const comments = payloads[0]?.comments as Record<string, unknown>[]
     expect(comments).toHaveLength(1)
     expect(comments[0]).toMatchObject({
@@ -574,6 +577,9 @@ describe("review", () => {
     expect(payloads[0]?.event).toBe("COMMENT")
     expect(String(payloads[0]?.body)).toContain(
       "Magi single-account review result: CLOSE.",
+    )
+    expect(String(payloads[0]?.body)).toContain(
+      "Close reasons:\n- general: Out of scope.",
     )
     expect(String(payloads[0]?.body)).toContain(
       formatReviewMarker({
@@ -624,6 +630,201 @@ describe("review", () => {
     expect(assigned.security).toEqual([marked, unmarked])
     expect(assigned.general).toEqual([unmarked])
     expect(assigned.compat).toEqual([unmarked])
+  })
+
+  test("routes single-mode rereview threads by logical finding markers", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "magi-review-test-"))
+    const prompts: string[] = []
+    const oldHead = "old-head"
+    const markerFor = (reviewer: string) =>
+      formatReviewFindingMarker({
+        finding: 0,
+        head: oldHead,
+        pr: 1,
+        reviewer,
+      })
+    const exec: Exec = async (command) => {
+      if (command.startsWith("gh pr view ")) {
+        return JSON.stringify({
+          author: { login: "author" },
+          baseRefName: "main",
+          baseRefOid: "base",
+          body: "Review this PR.",
+          changedFiles: 1,
+          headRefName: "feature",
+          headRefOid: "head",
+          isDraft: false,
+          number: 1,
+          state: "OPEN",
+          title: "Feature",
+          url: "https://github.com/owner/repo/pull/1",
+        })
+      }
+
+      if (command.includes("reviews(first: 100")) {
+        return graphqlResponse({
+          reviews: {
+            nodes: [
+              {
+                author: { login: "review-bot" },
+                body: [
+                  formatReviewMarker({
+                    head: oldHead,
+                    pr: 1,
+                    reviewer: "reviewer-1",
+                    verdict: "CHANGES_REQUESTED",
+                  }),
+                  formatReviewMarker({
+                    head: oldHead,
+                    pr: 1,
+                    reviewer: "reviewer-2",
+                    verdict: "CHANGES_REQUESTED",
+                  }),
+                  formatReviewMarker({
+                    head: oldHead,
+                    pr: 1,
+                    reviewer: "reviewer-3",
+                    verdict: "CHANGES_REQUESTED",
+                  }),
+                ].join("\n"),
+                comments: { nodes: [] },
+                commit: { oid: oldHead },
+                state: "COMMENTED",
+                submittedAt: "2026-01-01T00:00:00Z",
+              },
+            ],
+            pageInfo: { hasNextPage: false },
+          },
+        })
+      }
+
+      if (command.includes("commits(first: 100")) {
+        return graphqlResponse({
+          commits: {
+            nodes: [
+              {
+                commit: {
+                  committedDate: "2026-01-02T00:00:00Z",
+                  oid: "head",
+                  parents: { totalCount: 1 },
+                },
+              },
+            ],
+            pageInfo: { hasNextPage: false },
+          },
+        })
+      }
+
+      if (command.includes("reviewThreads(first:")) {
+        return graphqlResponse({
+          reviewThreads: {
+            nodes: ["reviewer-1", "reviewer-2", "reviewer-3"].map(
+              (reviewer, index) => ({
+                comments: {
+                  nodes: [
+                    {
+                      author: { login: "review-bot" },
+                      body: markerFor(reviewer),
+                      createdAt: `2026-01-01T00:00:0${index}Z`,
+                      databaseId: index + 1,
+                      line: index + 1,
+                      path: `src/${reviewer}.ts`,
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
+                id: `thread-${reviewer}`,
+                isResolved: false,
+              }),
+            ),
+            pageInfo: { hasNextPage: false },
+          },
+        })
+      }
+
+      if (command.includes("comments(last:")) {
+        return graphqlResponse({ comments: { nodes: [], totalCount: 0 } })
+      }
+      if (command.includes("changedFiles labels")) {
+        return graphqlResponse({
+          author: { login: "author" },
+          changedFiles: 1,
+          files: {
+            nodes: [{ path: "src/app.ts" }],
+            pageInfo: { hasNextPage: false },
+          },
+          labels: { nodes: [] },
+        })
+      }
+      if (command.includes("closingIssuesReferences")) {
+        return graphqlResponse({ closingIssuesReferences: { nodes: [] } })
+      }
+
+      if (command.startsWith("gh pr checks ")) return "[]"
+      if (command.startsWith("git worktree add ")) return ""
+      if (command.startsWith("gh pr checkout ")) return ""
+      if (command === "git branch --show-current") return "feature"
+      if (command.startsWith("git cat-file -e ")) return ""
+      if (command.startsWith("git diff ")) {
+        return [
+          "diff --git a/src/app.ts b/src/app.ts",
+          "--- a/src/app.ts",
+          "+++ b/src/app.ts",
+          "@@ -1 +1,2 @@",
+          " existing",
+          "+added",
+        ].join("\n")
+      }
+      if (command.startsWith("git merge-base ")) return "merge-base"
+      if (command.startsWith("git merge-tree ")) return ""
+
+      throw new Error(`Unexpected command: ${command}`)
+    }
+
+    try {
+      await runReview({
+        client: fakeClient(
+          [
+            JSON.stringify({
+              followUps: [],
+              newFindings: [],
+              resolve: [],
+              verdict: "MERGE",
+            }),
+            JSON.stringify({
+              followUps: [],
+              newFindings: [],
+              resolve: [],
+              verdict: "MERGE",
+            }),
+            JSON.stringify({
+              followUps: [],
+              newFindings: [],
+              resolve: [],
+              verdict: "MERGE",
+            }),
+          ],
+          prompts,
+        ),
+        config: {
+          review: { output: "runs", worktree: "worktrees" },
+        } satisfies MagiConfig,
+        directory,
+        dryRun: true,
+        exec,
+        pr: 1,
+        repository: singleReviewRepository(),
+      })
+
+      expect(prompts[0]).toContain('"threadId": "thread-reviewer-1"')
+      expect(prompts[0]).not.toContain('"threadId": "thread-reviewer-2"')
+      expect(prompts[1]).toContain('"threadId": "thread-reviewer-2"')
+      expect(prompts[1]).not.toContain('"threadId": "thread-reviewer-3"')
+      expect(prompts[2]).toContain('"threadId": "thread-reviewer-3"')
+      expect(prompts[2]).not.toContain('"threadId": "thread-reviewer-1"')
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
   })
 
   test("builds inline targets from the prompted three-dot diff range", async () => {

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -982,15 +982,37 @@ function singleReviewBody(input: {
   pr: number
   verdict: "CHANGES_REQUESTED" | "CLOSE" | "MERGE"
 }): string {
+  const outputs = Object.entries(input.outputs).sort(([a], [b]) =>
+    a.localeCompare(b),
+  )
+  const closeReasons = outputs.flatMap(([reviewer, output]) =>
+    output.verdict === "CLOSE"
+      ? [`- ${reviewer}: ${output.reason ?? "Close requested."}`]
+      : [],
+  )
+  const acceptedFindings = outputs.flatMap(([reviewer, output]) =>
+    outputFindings(reviewer, output).map(({ finding, index }) => {
+      const line =
+        finding.startLine == null || finding.startLine === finding.line
+          ? String(finding.line)
+          : `${finding.startLine}-${finding.line}`
+
+      return `- ${reviewer} #${index + 1} ${finding.path}:${line}: ${finding.issue} Fix: ${finding.fix}`
+    }),
+  )
   const lines = [
     `Magi single-account review result: ${input.verdict}.`,
     "",
     "Logical reviewer verdicts:",
-    ...Object.entries(input.outputs).map(
-      ([reviewer, output]) => `- ${reviewer}: ${output.verdict}`,
-    ),
+    ...outputs.map(([reviewer, output]) => `- ${reviewer}: ${output.verdict}`),
+    ...(input.verdict === "CLOSE" && closeReasons.length
+      ? ["", "Close reasons:", ...closeReasons]
+      : []),
+    ...(input.verdict === "CHANGES_REQUESTED" && acceptedFindings.length
+      ? ["", "Accepted change requests:", ...acceptedFindings]
+      : []),
     "",
-    ...Object.entries(input.outputs).map(([reviewer, output]) =>
+    ...outputs.map(([reviewer, output]) =>
       formatReviewMarker({
         head: input.headSha,
         pr: input.pr,
@@ -1599,7 +1621,7 @@ export async function runReview(
     },
   )
 
-  if (singleReviewMode && skippedReviewers.length) {
+  if (singleReviewMode) {
     const account = input.repository.review?.account ?? ""
     const threads = await fetchUnresolvedThreads(
       exec,
@@ -1609,16 +1631,19 @@ export async function runReview(
     )
     const assigned = assignThreadsByReviewFindingMarker({
       fallbackReviewerKeys: reviewerKeys,
-      headSha: meta.headRefOid,
       pr: input.pr,
       reviewerKeys,
       threads,
     })
 
-    for (const reviewer of skippedReviewers) {
+    for (const reviewer of input.repository.agents.reviewers) {
       const reviewerThreads = assigned[reviewer.key] ?? []
 
       unresolvedThreadsByReviewer.set(reviewer.key, reviewerThreads)
+      if (preliminaryMode.assignments.get(reviewer.key)?.type !== "skip") {
+        continue
+      }
+
       if (hasPendingThreadReply(reviewerThreads, account)) {
         pendingThreadReplyReviewers.add(reviewer.key)
       }


### PR DESCRIPTION
Closes #289

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes single-account review output and re-review context routing so logical reviewer context remains visible and correctly assigned.

## Current behavior (updates)

Single-mode consensus review bodies only showed verdicts and hidden markers, and active re-review prompts could receive all unresolved threads authored by the shared review account instead of reviewer-specific marker assignments.

## New behavior

Single-mode `CLOSE` consensus bodies include deterministic close reasons by logical reviewer. Single-mode `CHANGES_REQUESTED` consensus bodies include deterministic accepted change request summaries. Single-mode review and merge re-review route unresolved threads by hidden finding markers without filtering out stale-head markers needed for re-review context.

Tests: `pnpm test -- src/orchestrator/review.test.ts src/orchestrator/merge.test.ts`; `pnpm typecheck`

## Is this a breaking change (Yes/No):

No

## Additional Information

Adds a patch changeset for the bug fix.