### PR TITLE
fix(config): default review mode to single

### DIFF
--- a/.changeset/default-single-review-mode.md
+++ b/.changeset/default-single-review-mode.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Default PR review identity mode to single-account posting.

--- a/README.md
+++ b/README.md
@@ -64,20 +64,18 @@ Add the following content to the configuration file.
   "agents": {
     "refs": {
       "account-1": {
-        "model": "openai/gpt-5.5",
-        "account": "account-1"
+        "model": "openai/gpt-5.5"
       },
       "account-2": {
-        "model": "anthropic/claude-opus-4-7",
-        "account": "account-2"
+        "model": "anthropic/claude-opus-4-7"
       },
       "account-3": {
-        "model": "opencode/kimi-k2-6",
-        "account": "account-3"
+        "model": "opencode/kimi-k2-6"
       }
     }
   },
   "review": {
+    "account": "your-account",
     "reviewers": [
       { "ref": "account-1" },
       { "ref": "account-2" },
@@ -87,19 +85,22 @@ Add the following content to the configuration file.
 }
 ```
 
-After `refs` are expanded, `review.reviewers[].account` is the GitHub account used to post reviews and approvals in the default `review.mode: "multi"`. Must be authenticated with `gh auth token --user <account>` and must be unique.
+By default, `review.mode` is `"single"`. Magi uses one `review.account` to post reviewer-originated GitHub mutations while still running multiple logical reviewer agents and preserving majority voting, finding validation, and close reconsideration. The account must be authenticated with `gh auth token --user <account>`.
 
-For individual setups, use `review.mode: "single"` with one `review.account`. Magi still runs an odd number of at least 3 logical reviewer agents and keeps majority voting, finding validation, and close reconsideration, but GitHub branch protection sees only the one configured review account.
+For team setups that need separate GitHub review identities, set `review.mode: "multi"` and configure a unique account for each reviewer.
 
 ```json
 {
   "review": {
-    "mode": "single",
-    "account": "your-account",
+    "mode": "multi",
     "reviewers": [
-      { "id": "general", "model": "openai/gpt-5.5" },
-      { "id": "security", "model": "anthropic/claude-opus-4-7" },
-      { "id": "compat", "model": "opencode/kimi-k2-6" }
+      { "id": "general", "model": "openai/gpt-5.5", "account": "account-1" },
+      {
+        "id": "security",
+        "model": "anthropic/claude-opus-4-7",
+        "account": "account-2"
+      },
+      { "id": "compat", "model": "opencode/kimi-k2-6", "account": "account-3" }
     ]
   }
 }

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -108,31 +108,31 @@ The merge flow also writes the review artifacts listed in [`/magi:review`](revie
 
 Important settings for `/magi:merge`:
 
-| Setting                               | Purpose                                                            |
-| ------------------------------------- | ------------------------------------------------------------------ |
-| `merge.editor`                        | Editor agent, model, persona, permissions, GitHub account, author. |
-| `review.mode`                         | `multi` or `single` GitHub posting identity mode for reviewers.    |
-| `review.account`                      | Shared reviewer posting account for single mode.                   |
-| `review.reviewers`                    | Reviewer agents used for initial review and re-review.             |
-| `merge.automation.close`              | Run `gh pr close` after a close decision.                          |
-| `merge.automation.merge`              | Merge or enqueue the PR after approval.                            |
-| `merge.automation.conflict`           | Resolve one merge queue dequeue conflict with the editor.          |
-| `merge.checks.wait`                   | Wait for required PR checks after editor changes.                  |
-| `review.merge.approvalPolicy`         | Decide readiness by `majority` or `unanimous`.                     |
-| `review.merge.auto`                   | Pass `--auto` to `gh pr merge` outside merge queue mode.           |
-| `review.merge.deleteBranch`           | Delete the PR branch during non-queue merges when configured.      |
-| `merge.maxThreadResolutionCycles`     | Maximum fix/reply attempts per unresolved review thread.           |
-| `review.merge.queue`                  | Enqueue the PR through GitHub GraphQL and poll queue completion.   |
-| `review.merge.method`                 | Merge method: `merge`, `squash`, or `rebase`.                      |
-| `merge.prompts.edit`                  | Editor prompt template.                                            |
-| `merge.prompts.editGuidelines`        | Shared edit guidance file.                                         |
-| `merge.prompts.ciClassification`      | Post-edit failed-check classification prompt template.             |
-| `review.prompts.rereview`             | Re-review prompt template.                                         |
-| `review.prompts.closeReconsideration` | Close reconsideration prompt template used during re-review.       |
-| `review.safety.requiredLabels`        | Required PR labels before merge flow.                              |
-| `review.safety.blockedPaths`          | Changed-file glob patterns that block merge flow.                  |
-| `review.safety.maxChangedFiles`       | Maximum changed file count before merge flow is blocked.           |
-| `review.safety.allowAuthors`          | Allowed PR authors when configured.                                |
+| Setting                               | Purpose                                                                               |
+| ------------------------------------- | ------------------------------------------------------------------------------------- |
+| `merge.editor`                        | Editor agent, model, persona, permissions, GitHub account, author.                    |
+| `review.mode`                         | `multi` or `single` GitHub posting identity mode for reviewers. Defaults to `single`. |
+| `review.account`                      | Shared reviewer posting account for single mode.                                      |
+| `review.reviewers`                    | Reviewer agents used for initial review and re-review.                                |
+| `merge.automation.close`              | Run `gh pr close` after a close decision.                                             |
+| `merge.automation.merge`              | Merge or enqueue the PR after approval.                                               |
+| `merge.automation.conflict`           | Resolve one merge queue dequeue conflict with the editor.                             |
+| `merge.checks.wait`                   | Wait for required PR checks after editor changes.                                     |
+| `review.merge.approvalPolicy`         | Decide readiness by `majority` or `unanimous`.                                        |
+| `review.merge.auto`                   | Pass `--auto` to `gh pr merge` outside merge queue mode.                              |
+| `review.merge.deleteBranch`           | Delete the PR branch during non-queue merges when configured.                         |
+| `merge.maxThreadResolutionCycles`     | Maximum fix/reply attempts per unresolved review thread.                              |
+| `review.merge.queue`                  | Enqueue the PR through GitHub GraphQL and poll queue completion.                      |
+| `review.merge.method`                 | Merge method: `merge`, `squash`, or `rebase`.                                         |
+| `merge.prompts.edit`                  | Editor prompt template.                                                               |
+| `merge.prompts.editGuidelines`        | Shared edit guidance file.                                                            |
+| `merge.prompts.ciClassification`      | Post-edit failed-check classification prompt template.                                |
+| `review.prompts.rereview`             | Re-review prompt template.                                                            |
+| `review.prompts.closeReconsideration` | Close reconsideration prompt template used during re-review.                          |
+| `review.safety.requiredLabels`        | Required PR labels before merge flow.                                                 |
+| `review.safety.blockedPaths`          | Changed-file glob patterns that block merge flow.                                     |
+| `review.safety.maxChangedFiles`       | Maximum changed file count before merge flow is blocked.                              |
+| `review.safety.allowAuthors`          | Allowed PR authors when configured.                                                   |
 
 See [Config](/docs/config.md) for the complete configuration reference.
 

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -106,30 +106,30 @@ Review artifacts are written to the run output directory:
 
 Important settings for `/magi:review`:
 
-| Setting                               | Purpose                                                       |
-| ------------------------------------- | ------------------------------------------------------------- |
-| `review.reviewers`                    | Reviewer agents, models, personas, permissions, and accounts. |
-| `review.mode`                         | `multi` or `single` GitHub posting identity mode.             |
-| `review.account`                      | Shared reviewer posting account for single mode.              |
-| `review.checks.wait`                  | Wait for required PR checks before review.                    |
-| `review.checks.exclude`               | Ignore matching failed checks.                                |
-| `review.checks.retryFailedJobs`       | Retry scope-outside GitHub Actions jobs.                      |
-| `review.concurrency.reviewers`        | Maximum reviewer agents running at once.                      |
-| `review.concurrency.runs`             | Maximum PR runs processed at once.                            |
-| `github.apiRetryAttempts`             | Retry count for GitHub CLI API rate limit errors.             |
-| `review.output`                       | PR run output directory.                                      |
-| `output.repairAttempts`               | Model output repair attempts.                                 |
-| `review.prompts.review`               | Initial review prompt template.                               |
-| `review.prompts.rereview`             | Re-review prompt template.                                    |
-| `review.prompts.reviewGuidelines`     | Shared review guidance file.                                  |
-| `review.prompts.ciClassification`     | Failed-check classification prompt template.                  |
-| `review.prompts.findingValidation`    | Finding validation prompt template.                           |
-| `review.prompts.closeReconsideration` | Close reconsideration prompt template.                        |
-| `review.safety.requiredLabels`        | Required PR labels before review.                             |
-| `review.safety.blockedPaths`          | Changed-file glob patterns that block review.                 |
-| `review.safety.maxChangedFiles`       | Maximum changed file count before review is blocked.          |
-| `review.safety.allowAuthors`          | Allowed PR authors when configured.                           |
-| `review.worktree`                     | Temporary PR worktree base directory.                         |
+| Setting                               | Purpose                                                                 |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| `review.reviewers`                    | Reviewer agents, models, personas, permissions, and accounts.           |
+| `review.mode`                         | `multi` or `single` GitHub posting identity mode. Defaults to `single`. |
+| `review.account`                      | Shared reviewer posting account for single mode.                        |
+| `review.checks.wait`                  | Wait for required PR checks before review.                              |
+| `review.checks.exclude`               | Ignore matching failed checks.                                          |
+| `review.checks.retryFailedJobs`       | Retry scope-outside GitHub Actions jobs.                                |
+| `review.concurrency.reviewers`        | Maximum reviewer agents running at once.                                |
+| `review.concurrency.runs`             | Maximum PR runs processed at once.                                      |
+| `github.apiRetryAttempts`             | Retry count for GitHub CLI API rate limit errors.                       |
+| `review.output`                       | PR run output directory.                                                |
+| `output.repairAttempts`               | Model output repair attempts.                                           |
+| `review.prompts.review`               | Initial review prompt template.                                         |
+| `review.prompts.rereview`             | Re-review prompt template.                                              |
+| `review.prompts.reviewGuidelines`     | Shared review guidance file.                                            |
+| `review.prompts.ciClassification`     | Failed-check classification prompt template.                            |
+| `review.prompts.findingValidation`    | Finding validation prompt template.                                     |
+| `review.prompts.closeReconsideration` | Close reconsideration prompt template.                                  |
+| `review.safety.requiredLabels`        | Required PR labels before review.                                       |
+| `review.safety.blockedPaths`          | Changed-file glob patterns that block review.                           |
+| `review.safety.maxChangedFiles`       | Maximum changed file count before review is blocked.                    |
+| `review.safety.allowAuthors`          | Allowed PR authors when configured.                                     |
+| `review.worktree`                     | Temporary PR worktree base directory.                                   |
 
 See [Config](/docs/config.md) for the complete configuration reference.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -125,7 +125,7 @@ Agent model fields accept either a single `provider/model` string or an ordered 
 | `output`                               | Both    | No                               | -                                                    | Output parsing and repair configuration.                                                                                            |
 | `output.repairAttempts`                | Both    | No                               | `3`                                                  | Number of times to ask a model to repair invalid structured output.                                                                 |
 | `review`                               | Both    | Yes                              | -                                                    | PR review configuration used by `/magi:review` and the review phase of `/magi:merge`.                                               |
-| `review.mode`                          | Both    | No                               | `multi`                                              | GitHub identity mode. `multi` posts with per-reviewer accounts; `single` posts reviewer-originated mutations with `review.account`. |
+| `review.mode`                          | Both    | No                               | `single`                                             | GitHub identity mode. `multi` posts with per-reviewer accounts; `single` posts reviewer-originated mutations with `review.account`. |
 | `review.account`                       | Both    | Yes (`review.mode: "single"`)    | -                                                    | Shared GitHub account used for reviewer-originated review mutations in single mode.                                                 |
 | `review.reviewers`                     | Both    | Yes                              | -                                                    | Odd-length array of at least 3 reviewer agents.                                                                                     |
 | `review.reviewers[].id`                | Both    | No                               | `reviewer-1`, ...                                    | Reviewer key used for run state, output files, and session tracking.                                                                |
@@ -234,16 +234,15 @@ Agent model fields accept either a single `provider/model` string or an ordered 
 
 ## Review Identity Modes
 
-`review.mode` defaults to `multi`, which is recommended when you have multiple GitHub accounts available. In multi mode, every reviewer needs a unique `review.reviewers[].account`, and GitHub sees separate review states from separate accounts.
+`review.mode` defaults to `single`, which lowers setup requirements by using one `review.account` for reviewer-originated GitHub mutations. Magi still runs an odd number of at least 3 logical reviewer agents, validates findings, asks close-minority reviewers to reconsider, and applies the configured majority or unanimous approval policy. Single mode writes hidden review markers to GitHub review bodies and inline comments so later runs can recover logical reviewer state without local `.magi` artifacts.
 
-`review.mode: "single"` lowers setup requirements by using one `review.account` for reviewer-originated GitHub mutations. Magi still runs an odd number of at least 3 logical reviewer agents, validates findings, asks close-minority reviewers to reconsider, and applies the configured majority or unanimous approval policy. Single mode writes hidden review markers to GitHub review bodies and inline comments so later runs can recover logical reviewer state without local `.magi` artifacts.
+`review.mode: "multi"` is recommended when you have multiple GitHub accounts available and need GitHub to see separate review states from separate accounts. In multi mode, every reviewer needs a unique `review.reviewers[].account`.
 
 Single mode provides Magi internal consensus only. It does not satisfy branch protection rules that require approvals from multiple distinct GitHub accounts.
 
 ```json
 {
   "review": {
-    "mode": "single",
     "account": "your-account",
     "reviewers": [
       { "id": "general", "model": "openai/gpt-5.5" },

--- a/schema.json
+++ b/schema.json
@@ -366,7 +366,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "mode": { "enum": ["multi", "single"], "default": "multi" },
+        "mode": { "enum": ["multi", "single"], "default": "single" },
         "account": { "type": "string", "minLength": 1 },
         "reviewers": {
           "type": "array",

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -64,7 +64,7 @@ describe("resolveRepository", () => {
       merge: true,
     })
     expect(repo.reviewAutomation).toEqual({ close: false, merge: true })
-    expect(repo.review).toEqual({ account: undefined, mode: "multi" })
+    expect(repo.review).toEqual({ account: undefined, mode: "single" })
     expect(repo.concurrency).toEqual({ runs: 3, reviewers: 3 })
     expect(repo.checks.exclude).toEqual([])
     expect(repo.checks.waitAfterEdit).toBe(true)
@@ -73,12 +73,11 @@ describe("resolveRepository", () => {
     expect(repo.prompts.review).toBe("global-review.md")
   })
 
-  test("resolves single review account as reviewer posting account", () => {
+  test("resolves default single review account as reviewer posting account", () => {
     const repo = resolveRepository({
       github: { owner: "owner", repo: "repo" },
       review: {
         account: "review-bot",
-        mode: "single",
         reviewers: [
           { id: "general", model: "openai/gpt" },
           { id: "security", model: "openai/gpt" },

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -182,7 +182,9 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
   const editor = config.merge?.editor
   const creator = config.triage?.creator
   const singleReviewAccount =
-    config.review?.mode === "single" ? config.review.account : undefined
+    config.review && config.review.mode !== "multi"
+      ? config.review.account
+      : undefined
 
   return {
     editor: editor
@@ -285,7 +287,7 @@ export function resolveRepository(config: MagiConfig): ResolvedRepository {
     },
     review: {
       account: config.review?.account,
-      mode: config.review?.mode ?? "multi",
+      mode: config.review?.mode ?? "single",
     },
     reviewAutomation: {
       close: config.review?.automation?.close ?? false,

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, test } from "vitest"
 import schema from "../../schema.json" with { type: "json" }
 
 describe("schema", () => {
+  test("declares single as the default review mode", () => {
+    expect(schema.$defs.review.properties.mode.default).toBe("single")
+  })
+
   test("accepts merge conflict automation", () => {
     const ajv = new Ajv2020()
     const validate = ajv.compile(schema)

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -13,6 +13,7 @@ const config: MagiConfig = {
   github: { owner: "owner", repo: "repo" },
   language: "en",
   review: {
+    mode: "multi",
     reviewers: [
       {
         model: "anthropic/claude",
@@ -69,6 +70,7 @@ describe("validateConfig", () => {
       },
       github: { owner: "owner", repo: "repo" },
       review: {
+        mode: "multi",
         reviewers: [
           { ref: "shared", id: "alpha", account: "bot-a" },
           {
@@ -142,6 +144,7 @@ describe("validateConfig", () => {
       agents: { refs: { shared: { model: "openai/gpt" } } },
       github: { owner: "owner", repo: "repo" },
       review: {
+        mode: "multi",
         reviewers: [
           { ref: "missing", account: "bot-a" },
           { ref: 1, account: "bot-b" },
@@ -170,6 +173,7 @@ describe("validateConfig", () => {
       },
       github: { owner: "owner", repo: "repo" },
       review: {
+        mode: "multi",
         reviewers: [
           { model: "openai/gpt", account: "bot-a" },
           { model: "openai/gpt", account: "bot-b" },
@@ -196,6 +200,7 @@ describe("validateConfig", () => {
       },
       github: { owner: "owner", repo: "repo" },
       review: {
+        mode: "multi",
         reviewers: [
           { ref: "creator", account: "bot-a" },
           { model: "openai/gpt", account: "bot-b" },
@@ -248,7 +253,7 @@ describe("validateConfig", () => {
 
   test("allows global config without github", async () => {
     const globalConfig: MagiConfig = {
-      review: { reviewers },
+      review: { mode: "multi", reviewers },
     }
 
     await expect(
@@ -583,7 +588,25 @@ describe("validateConfig", () => {
     )
   })
 
-  test("defaults to multi mode account validation", async () => {
+  test("defaults to single mode account validation", async () => {
+    const result = await validateConfig({
+      ...config,
+      review: {
+        prompts: config.review?.prompts,
+        reviewers: [
+          { id: "general", model: "openai/gpt" },
+          { id: "security", model: "openai/gpt" },
+          { id: "compat", model: "openai/gpt" },
+        ],
+      },
+    })
+
+    expect(result.errors).toContain(
+      "review.account is required when review.mode is single",
+    )
+  })
+
+  test("enforces reviewer accounts in multi mode", async () => {
     const missingAccount = await validateConfig({
       ...config,
       review: {
@@ -940,6 +963,7 @@ describe("validateConfig", () => {
         },
       },
       review: {
+        mode: "multi",
         reviewers: [
           { ref: "shared" },
           { account: "bot-b", model: ["missing/model", "openai/gpt"] },
@@ -1019,6 +1043,7 @@ describe("validateConfig", () => {
         },
       },
       review: {
+        mode: "multi",
         reviewers: [
           { ref: "shared" },
           {

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -558,7 +558,7 @@ function validateReviewerList(
   path: string,
   errors: string[],
   catalog?: ModelCatalog,
-  mode = "multi",
+  mode = "single",
 ): void {
   if (reviewers == null) return
   if (!Array.isArray(reviewers)) {
@@ -665,7 +665,7 @@ function validateResolvedReviewers(
   reviewers: { account: string; key: string }[],
   path: string,
   errors: string[],
-  mode = "multi",
+  mode = "single",
 ): void {
   const keys = new Set<string>()
   const accounts = new Set<string>()
@@ -682,7 +682,7 @@ function validateResolvedReviewers(
 }
 
 function reviewMode(config: MagiConfig): "multi" | "single" {
-  return config.review?.mode === "single" ? "single" : "multi"
+  return config.review?.mode === "multi" ? "multi" : "single"
 }
 
 function validateReviewIdentity(config: MagiConfig, errors: string[]): void {
@@ -694,7 +694,7 @@ function validateReviewIdentity(config: MagiConfig, errors: string[]): void {
 
   validateString(config.review?.account, "review.account", errors)
 
-  if (mode === "single" && !config.review?.account) {
+  if ((mode == null || mode === "single") && !config.review?.account) {
     errors.push("review.account is required when review.mode is single")
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -481,6 +481,7 @@ describe("magi_validate", () => {
 
     await writeConfig(globalPath, {
       review: {
+        mode: "multi",
         reviewers: [
           { account: "bot-a", model: "openai/gpt" },
           { account: "bot-b", model: "openai/gpt" },
@@ -562,6 +563,7 @@ describe("magi_validate", () => {
 
     await writeConfig(globalPath, {
       review: {
+        mode: "multi",
         reviewers: [
           { account: "bot-a", model: "openai/gpt" },
           { account: "bot-b", model: "openai/gpt" },

--- a/src/orchestrator/merge.test.ts
+++ b/src/orchestrator/merge.test.ts
@@ -84,6 +84,7 @@ const repository: ResolvedRepository = {
     method: "squash",
   },
   prompts: {},
+  review: { mode: "multi" },
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }
 

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -471,7 +471,7 @@ async function runRereview(
     worktreePath,
   })
   const artifactDir = outputDir(input)
-  const singleReviewMode = input.repository.review?.mode === "single"
+  const singleReviewMode = input.repository.review?.mode !== "multi"
   const reviewerKeys = input.repository.agents.reviewers.map(
     (reviewer) => reviewer.key,
   )

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -59,6 +59,7 @@ const repository: ResolvedRepository = {
     method: "squash",
   },
   prompts: {},
+  review: { mode: "multi" },
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }
 

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -191,7 +191,7 @@ export interface ReviewFindingMarker {
 function resolvedReviewMode(
   repository: ResolvedRepository,
 ): "multi" | "single" {
-  return repository.review?.mode === "single" ? "single" : "multi"
+  return repository.review?.mode === "multi" ? "multi" : "single"
 }
 
 export function reviewPostingAccount(

--- a/src/orchestrator/scenarios.test.ts
+++ b/src/orchestrator/scenarios.test.ts
@@ -77,6 +77,7 @@ const repository: ResolvedRepository = {
     method: "squash",
   },
   prompts: {},
+  review: { mode: "multi" },
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }
 


### PR DESCRIPTION
Closes #291

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Default `review.mode` to `single` across schema, config resolution, validation, and runtime fallbacks.

## Current behavior (updates)

Omitting `review.mode` resolved to `multi` and validated reviewer-specific GitHub accounts by default.

## New behavior

Omitting `review.mode` resolves to `single`, requires `review.account`, and uses that account for logical reviewers. Explicit `review.mode: "multi"` keeps per-reviewer account behavior.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Tests: `pnpm test src/config/resolve.test.ts src/config/validate.test.ts src/config/schema.test.ts src/orchestrator/review.test.ts src/orchestrator/merge.test.ts`