### PR TITLE
feat(config): promote identity settings

### DIFF
--- a/.changeset/top-level-identity.md
+++ b/.changeset/top-level-identity.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": major
+---
+
+Promote review identity mode and account settings to top-level configuration.

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
   "language": "en",
+  "mode": "multi",
   "github": { "owner": "magi-ai", "repo": "opencode-magi" },
   "agents": {
     "refs": {
@@ -53,7 +54,6 @@
     "permissions": { "webfetch": "allow", "websearch": "allow" }
   },
   "review": {
-    "mode": "multi",
     "reviewers": [
       { "ref": "melchior" },
       { "ref": "balthasar" },

--- a/schema.json
+++ b/schema.json
@@ -5,6 +5,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": { "type": "string" },
+    "account": { "type": "string", "minLength": 1 },
     "agents": {
       "type": "object",
       "additionalProperties": false,
@@ -44,6 +45,7 @@
     },
     "language": { "type": "string" },
     "merge": { "$ref": "#/$defs/merge" },
+    "mode": { "enum": ["multi", "single"], "default": "single" },
     "output": {
       "type": "object",
       "additionalProperties": false,
@@ -366,8 +368,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "mode": { "enum": ["multi", "single"], "default": "single" },
-        "account": { "type": "string", "minLength": 1 },
         "reviewers": {
           "type": "array",
           "minItems": 3,

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -11,6 +11,7 @@ const config: MagiConfig = {
   agents: {},
   github: { owner: "owner", repo: "repo" },
   language: "en",
+  mode: "multi",
   review: {
     reviewers: [
       {
@@ -64,7 +65,8 @@ describe("resolveRepository", () => {
       merge: true,
     })
     expect(repo.reviewAutomation).toEqual({ close: false, merge: true })
-    expect(repo.review).toEqual({ account: undefined, mode: "single" })
+    expect(repo.account).toBeUndefined()
+    expect(repo.mode).toBe("multi")
     expect(repo.concurrency).toEqual({ runs: 3, reviewers: 3 })
     expect(repo.checks.exclude).toEqual([])
     expect(repo.checks.waitAfterEdit).toBe(true)
@@ -76,8 +78,8 @@ describe("resolveRepository", () => {
   test("resolves default single review account as reviewer posting account", () => {
     const repo = resolveRepository({
       github: { owner: "owner", repo: "repo" },
+      account: "review-bot",
       review: {
-        account: "review-bot",
         reviewers: [
           { id: "general", model: "openai/gpt" },
           { id: "security", model: "openai/gpt" },
@@ -86,7 +88,8 @@ describe("resolveRepository", () => {
       },
     })
 
-    expect(repo.review).toEqual({ account: "review-bot", mode: "single" })
+    expect(repo.account).toBe("review-bot")
+    expect(repo.mode).toBe("single")
     expect(repo.agents.reviewers.map((reviewer) => reviewer.account)).toEqual([
       "review-bot",
       "review-bot",

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -182,9 +182,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
   const editor = config.merge?.editor
   const creator = config.triage?.creator
   const singleReviewAccount =
-    config.review && config.review.mode !== "multi"
-      ? config.review.account
-      : undefined
+    config.review && config.mode !== "multi" ? config.account : undefined
 
   return {
     editor: editor
@@ -265,6 +263,8 @@ export function resolveRepository(config: MagiConfig): ResolvedRepository {
       repo: config.github.repo,
     },
     language: config.language,
+    account: config.account,
+    mode: config.mode ?? "single",
     merge: {
       approvalPolicy: config.review?.merge?.approvalPolicy ?? "majority",
       method: config.review?.merge?.method ?? "squash",
@@ -284,10 +284,6 @@ export function resolveRepository(config: MagiConfig): ResolvedRepository {
       rereview: config.review?.prompts?.rereview,
       review: config.review?.prompts?.review,
       reviewGuidelines: config.review?.prompts?.reviewGuidelines,
-    },
-    review: {
-      account: config.review?.account,
-      mode: config.review?.mode ?? "single",
     },
     reviewAutomation: {
       close: config.review?.automation?.close ?? false,

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from "vitest"
 import schema from "../../schema.json" with { type: "json" }
 
 describe("schema", () => {
-  test("declares single as the default review mode", () => {
-    expect(schema.$defs.review.properties.mode.default).toBe("single")
+  test("declares single as the default identity mode", () => {
+    expect(schema.properties.mode.default).toBe("single")
   })
 
   test("accepts merge conflict automation", () => {
@@ -26,9 +26,9 @@ describe("schema", () => {
     expect(
       validate({
         github: { owner: "owner", repo: "repo" },
+        account: "review-bot",
+        mode: "single",
         review: {
-          account: "review-bot",
-          mode: "single",
           reviewers: [
             { id: "general", model: "openai/gpt" },
             { id: "security", model: "openai/gpt" },
@@ -39,14 +39,26 @@ describe("schema", () => {
     ).toBe(true)
   })
 
-  test("rejects unsupported review mode", () => {
+  test("rejects unsupported identity mode", () => {
     const ajv = new Ajv2020()
     const validate = ajv.compile(schema)
 
     expect(
       validate({
         github: { owner: "owner", repo: "repo" },
-        review: { mode: "solo" },
+        mode: "solo",
+      }),
+    ).toBe(false)
+  })
+
+  test("rejects legacy review identity keys", () => {
+    const ajv = new Ajv2020()
+    const validate = ajv.compile(schema)
+
+    expect(
+      validate({
+        github: { owner: "owner", repo: "repo" },
+        review: { account: "review-bot", mode: "single" },
       }),
     ).toBe(false)
   })

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -12,8 +12,8 @@ const config: MagiConfig = {
   },
   github: { owner: "owner", repo: "repo" },
   language: "en",
+  mode: "multi",
   review: {
-    mode: "multi",
     reviewers: [
       {
         model: "anthropic/claude",
@@ -69,8 +69,8 @@ describe("validateConfig", () => {
         },
       },
       github: { owner: "owner", repo: "repo" },
+      mode: "multi",
       review: {
-        mode: "multi",
         reviewers: [
           { ref: "shared", id: "alpha", account: "bot-a" },
           {
@@ -143,8 +143,8 @@ describe("validateConfig", () => {
     const refConfig = {
       agents: { refs: { shared: { model: "openai/gpt" } } },
       github: { owner: "owner", repo: "repo" },
+      mode: "multi",
       review: {
-        mode: "multi",
         reviewers: [
           { ref: "missing", account: "bot-a" },
           { ref: 1, account: "bot-b" },
@@ -172,8 +172,8 @@ describe("validateConfig", () => {
         },
       },
       github: { owner: "owner", repo: "repo" },
+      mode: "multi",
       review: {
-        mode: "multi",
         reviewers: [
           { model: "openai/gpt", account: "bot-a" },
           { model: "openai/gpt", account: "bot-b" },
@@ -199,8 +199,8 @@ describe("validateConfig", () => {
         },
       },
       github: { owner: "owner", repo: "repo" },
+      mode: "multi",
       review: {
-        mode: "multi",
         reviewers: [
           { ref: "creator", account: "bot-a" },
           { model: "openai/gpt", account: "bot-b" },
@@ -253,7 +253,8 @@ describe("validateConfig", () => {
 
   test("allows global config without github", async () => {
     const globalConfig: MagiConfig = {
-      review: { mode: "multi", reviewers },
+      mode: "multi",
+      review: { reviewers },
     }
 
     await expect(
@@ -591,6 +592,7 @@ describe("validateConfig", () => {
   test("defaults to single mode account validation", async () => {
     const result = await validateConfig({
       ...config,
+      mode: undefined,
       review: {
         prompts: config.review?.prompts,
         reviewers: [
@@ -601,9 +603,7 @@ describe("validateConfig", () => {
       },
     })
 
-    expect(result.errors).toContain(
-      "review.account is required when review.mode is single",
-    )
+    expect(result.errors).toContain("account is required when mode is single")
   })
 
   test("enforces reviewer accounts in multi mode", async () => {
@@ -641,9 +641,9 @@ describe("validateConfig", () => {
   test("allows single mode reviewers without accounts", async () => {
     const result = await validateConfig({
       ...config,
+      account: "review-bot",
+      mode: "single",
       review: {
-        account: "review-bot",
-        mode: "single",
         reviewers: [
           { id: "general", model: "openai/gpt" },
           { id: "security", model: "openai/gpt" },
@@ -658,8 +658,8 @@ describe("validateConfig", () => {
   test("requires review account in single mode", async () => {
     const result = await validateConfig({
       ...config,
+      mode: "single",
       review: {
-        mode: "single",
         reviewers: [
           { id: "general", model: "openai/gpt" },
           { id: "security", model: "openai/gpt" },
@@ -668,17 +668,15 @@ describe("validateConfig", () => {
       },
     })
 
-    expect(result.errors).toContain(
-      "review.account is required when review.mode is single",
-    )
+    expect(result.errors).toContain("account is required when mode is single")
   })
 
   test("keeps reviewer count validation in single mode", async () => {
     const result = await validateConfig({
       ...config,
+      account: "review-bot",
+      mode: "single",
       review: {
-        account: "review-bot",
-        mode: "single",
         reviewers: [
           { id: "general", model: "openai/gpt" },
           { id: "security", model: "openai/gpt" },
@@ -827,12 +825,19 @@ describe("validateConfig", () => {
       ...config,
       extra: true,
       github: { ...config.github, unknown: true },
-      review: { ...config.review, unknown: true },
+      review: {
+        ...config.review,
+        account: "review-bot",
+        mode: "single",
+        unknown: true,
+      },
     } as unknown as MagiConfig)
 
     expect(result.ok).toBe(false)
     expect(result.errors).toContain("config.extra is not supported")
     expect(result.errors).toContain("github.unknown is not supported")
+    expect(result.errors).toContain("review.account is not supported")
+    expect(result.errors).toContain("review.mode is not supported")
     expect(result.errors).toContain("review.unknown is not supported")
   })
 
@@ -963,7 +968,6 @@ describe("validateConfig", () => {
         },
       },
       review: {
-        mode: "multi",
         reviewers: [
           { ref: "shared" },
           { account: "bot-b", model: ["missing/model", "openai/gpt"] },
@@ -1043,7 +1047,6 @@ describe("validateConfig", () => {
         },
       },
       review: {
-        mode: "multi",
         reviewers: [
           { ref: "shared" },
           {
@@ -1348,9 +1351,9 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         ...config,
+        account: "review-bot",
+        mode: "single",
         review: {
-          account: "review-bot",
-          mode: "single",
           reviewers: [
             { id: "general", model: "openai/gpt" },
             { id: "security", model: "openai/gpt" },

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -56,11 +56,13 @@ const TRIAGE_CATEGORY_ID_PATTERN = /^[A-Za-z0-9_-]+$/
 const RESERVED_TRIAGE_CATEGORY_IDS = new Set(["ASK", "none"])
 const CONFIG_KEYS = new Set([
   "$schema",
+  "account",
   "agents",
   "clear",
   "github",
   "language",
   "merge",
+  "mode",
   "output",
   "review",
   "triage",
@@ -97,12 +99,10 @@ const TRIAGE_CREATOR_KEYS = new Set([
 const AUTHOR_KEYS = new Set(["email", "name"])
 const GITHUB_KEYS = new Set(["apiRetryAttempts", "host", "owner", "repo"])
 const REVIEW_KEYS = new Set([
-  "account",
   "automation",
   "checks",
   "concurrency",
   "merge",
-  "mode",
   "output",
   "prompts",
   "reviewers",
@@ -682,20 +682,18 @@ function validateResolvedReviewers(
 }
 
 function reviewMode(config: MagiConfig): "multi" | "single" {
-  return config.review?.mode === "multi" ? "multi" : "single"
+  return config.mode === "multi" ? "multi" : "single"
 }
 
 function validateReviewIdentity(config: MagiConfig, errors: string[]): void {
-  const mode = config.review?.mode
+  const mode = config.mode
 
   if (mode != null && mode !== "multi" && mode !== "single") {
-    errors.push("review.mode must be multi or single")
+    errors.push("mode must be multi or single")
   }
 
-  validateString(config.review?.account, "review.account", errors)
-
-  if ((mode == null || mode === "single") && !config.review?.account) {
-    errors.push("review.account is required when review.mode is single")
+  if ((mode == null || mode === "single") && !config.account) {
+    errors.push("account is required when mode is single")
   }
 }
 
@@ -1361,7 +1359,7 @@ async function validateAuth(
   const agents = resolveAgents(config)
 
   if (reviewMode(config) === "single") {
-    if (config.review?.account) accounts.add(config.review.account)
+    if (config.account) accounts.add(config.account)
   } else {
     for (const reviewer of agents.reviewers) accounts.add(reviewer.account)
   }
@@ -1446,8 +1444,8 @@ async function validateRepositoryPermissions(
   const agents = resolveAgents(config)
   const reviewAccounts =
     reviewMode(config) === "single"
-      ? config.review?.account
-        ? [config.review.account]
+      ? config.account
+        ? [config.account]
         : []
       : agents.reviewers.map((reviewer) => reviewer.account)
 
@@ -1548,6 +1546,7 @@ export async function validateConfig(
 
   validateKnownKeys(config, "config", CONFIG_KEYS, errors)
   validateString(config.$schema, "$schema", errors)
+  validateString(config.account, "account", errors)
   validateString(config.language, "language", errors)
 
   if (config.agents != null && !isPlainObject(config.agents)) {

--- a/src/github/commands.test.ts
+++ b/src/github/commands.test.ts
@@ -53,6 +53,7 @@ const repository: ResolvedRepository = {
     mergeQueue: false,
     method: "squash",
   },
+  mode: "multi",
   prompts: {},
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -480,8 +480,8 @@ describe("magi_validate", () => {
     const validateMagiConfigFiles = await loadValidateMagiConfigFiles()
 
     await writeConfig(globalPath, {
+      mode: "multi",
       review: {
-        mode: "multi",
         reviewers: [
           { account: "bot-a", model: "openai/gpt" },
           { account: "bot-b", model: "openai/gpt" },
@@ -562,8 +562,8 @@ describe("magi_validate", () => {
     const validateMagiConfigFiles = await loadValidateMagiConfigFiles()
 
     await writeConfig(globalPath, {
+      mode: "multi",
       review: {
-        mode: "multi",
         reviewers: [
           { account: "bot-a", model: "openai/gpt" },
           { account: "bot-b", model: "openai/gpt" },

--- a/src/orchestrator/ci.test.ts
+++ b/src/orchestrator/ci.test.ts
@@ -27,6 +27,7 @@ const repository: ResolvedRepository = {
     mergeQueue: false,
     method: "squash",
   },
+  mode: "multi",
   prompts: {},
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }

--- a/src/orchestrator/merge.test.ts
+++ b/src/orchestrator/merge.test.ts
@@ -83,8 +83,8 @@ const repository: ResolvedRepository = {
     mergeQueue: false,
     method: "squash",
   },
+  mode: "multi",
   prompts: {},
-  review: { mode: "multi" },
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }
 
@@ -949,7 +949,8 @@ describe("merge", () => {
         reviewers,
       },
       automation: { ...editorRepository.automation, merge: false },
-      review: { account: "review-bot", mode: "single" },
+      account: "review-bot",
+      mode: "single",
     }
     let rereviewThreads: unknown
     const marker = (author: string) =>

--- a/src/orchestrator/merge.ts
+++ b/src/orchestrator/merge.ts
@@ -471,7 +471,7 @@ async function runRereview(
     worktreePath,
   })
   const artifactDir = outputDir(input)
-  const singleReviewMode = input.repository.review?.mode !== "multi"
+  const singleReviewMode = input.repository.mode !== "multi"
   const reviewerKeys = input.repository.agents.reviewers.map(
     (reviewer) => reviewer.key,
   )
@@ -486,7 +486,7 @@ async function runRereview(
                 input.exec,
                 input.repository,
                 input.pr,
-                input.repository.review?.account ?? "",
+                input.repository.account ?? "",
               )
             : Object.values(options.dryRunThreads).flat(),
       })
@@ -746,7 +746,7 @@ async function runRereview(
       ? { consensus: `dry-run:would-post-single-review:${verdict}` }
       : {
           consensus: await (async () => {
-            const account = input.repository.review?.account ?? ""
+            const account = input.repository.account ?? ""
 
             await Promise.all(
               entries.flatMap((entry) =>

--- a/src/orchestrator/review-context.test.ts
+++ b/src/orchestrator/review-context.test.ts
@@ -32,6 +32,7 @@ const repository: ResolvedRepository = {
     mergeQueue: false,
     method: "squash",
   },
+  mode: "multi",
   prompts: {},
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }

--- a/src/orchestrator/review.test.ts
+++ b/src/orchestrator/review.test.ts
@@ -58,15 +58,16 @@ const repository: ResolvedRepository = {
     mergeQueue: false,
     method: "squash",
   },
+  mode: "multi",
   prompts: {},
-  review: { mode: "multi" },
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }
 
 function singleReviewRepository(): ResolvedRepository {
   return {
     ...repository,
-    review: { account: "review-bot", mode: "single" },
+    account: "review-bot",
+    mode: "single",
   }
 }
 

--- a/src/orchestrator/review.ts
+++ b/src/orchestrator/review.ts
@@ -191,16 +191,17 @@ export interface ReviewFindingMarker {
 function resolvedReviewMode(
   repository: ResolvedRepository,
 ): "multi" | "single" {
-  return repository.review?.mode === "multi" ? "multi" : "single"
+  return repository.mode === "multi" ? "multi" : "single"
 }
 
 export function reviewPostingAccount(
   repository: ResolvedRepository,
   reviewer: ResolvedRepository["agents"]["reviewers"][number],
 ): string {
-  return resolvedReviewMode(repository) === "single"
-    ? (repository.review?.account ?? reviewer.account)
-    : reviewer.account
+  if (resolvedReviewMode(repository) !== "single") return reviewer.account
+  if (repository.account) return repository.account
+
+  throw new Error("account is required for single review mode")
 }
 
 function reviewAssignmentKey(
@@ -1056,10 +1057,9 @@ export async function postSingleConsensusReview(input: {
   repository: ResolvedRepository
   verdict: "CHANGES_REQUESTED" | "CLOSE" | "MERGE"
 }): Promise<string> {
-  const account = input.repository.review?.account
+  const account = input.repository.account
 
-  if (!account)
-    throw new Error("review.account is required for single review mode")
+  if (!account) throw new Error("account is required for single review mode")
 
   const body = singleReviewBody(input)
 
@@ -1597,7 +1597,7 @@ export async function runReview(
   )
   const preliminaryMode = singleReviewMode
     ? resolveSingleAccountReviewMode({
-        account: input.repository.review?.account ?? "",
+        account: input.repository.account ?? "",
         current: freshnessTarget,
         pr: input.pr,
         reviewerKeys,
@@ -1622,7 +1622,7 @@ export async function runReview(
   )
 
   if (singleReviewMode) {
-    const account = input.repository.review?.account ?? ""
+    const account = input.repository.account ?? ""
     const threads = await fetchUnresolvedThreads(
       exec,
       input.repository,
@@ -1671,7 +1671,7 @@ export async function runReview(
   const mode = singleReviewMode
     ? pendingThreadReplyReviewers.size
       ? resolveSingleAccountReviewMode({
-          account: input.repository.review?.account ?? "",
+          account: input.repository.account ?? "",
           current: freshnessTarget,
           pendingReviewers: pendingThreadReplyReviewers,
           pr: input.pr,
@@ -2187,7 +2187,7 @@ export async function runReview(
                 consensus: input.dryRun
                   ? `dry-run:would-post-single-review:${verdict}`
                   : await (async () => {
-                      const account = input.repository.review?.account ?? ""
+                      const account = input.repository.account ?? ""
 
                       await Promise.all(
                         Object.values(activeOutputs).flatMap((output) => {
@@ -2270,7 +2270,7 @@ export async function runReview(
         }
 
     const automationAccount = singleReviewMode
-      ? input.repository.review?.account
+      ? input.repository.account
       : input.repository.agents.reviewers[0]?.account
     const enableReviewAutomation = input.enableReviewAutomation ?? true
     if (

--- a/src/orchestrator/run-manager.test.ts
+++ b/src/orchestrator/run-manager.test.ts
@@ -162,6 +162,7 @@ describe("MagiRunManager notifications", () => {
         mergeQueue: false,
         method: "squash",
       },
+      mode: "multi",
       prompts: {},
       safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
     }

--- a/src/orchestrator/safety.test.ts
+++ b/src/orchestrator/safety.test.ts
@@ -28,6 +28,7 @@ const repository: ResolvedRepository = {
     mergeQueue: false,
     method: "squash",
   },
+  mode: "multi",
   prompts: {},
   safety: {
     allowAuthors: ["trusted"],

--- a/src/orchestrator/scenarios.test.ts
+++ b/src/orchestrator/scenarios.test.ts
@@ -77,7 +77,7 @@ const repository: ResolvedRepository = {
     method: "squash",
   },
   prompts: {},
-  review: { mode: "multi" },
+  mode: "multi",
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
 }
 

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -79,6 +79,7 @@ const repository: ResolvedRepository = {
     mergeQueue: false,
     method: "squash",
   },
+  mode: "multi",
   prompts: {},
   safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
   triage: {

--- a/src/prompts/compose.test.ts
+++ b/src/prompts/compose.test.ts
@@ -99,6 +99,7 @@ describe("prompt composer", () => {
         mergeQueue: true,
         maxThreadResolutionCycles: 5,
       },
+      mode: "multi",
       prompts: {
         editGuidelines: editGuidelinesPath,
         review: promptPath,
@@ -343,6 +344,7 @@ describe("prompt composer", () => {
         mergeQueue: false,
         method: "squash",
       },
+      mode: "multi",
       prompts: { ciClassification: promptPath },
       safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
     }
@@ -403,6 +405,7 @@ describe("prompt composer", () => {
         mergeQueue: false,
         method: "squash",
       },
+      mode: "multi",
       prompts: { ciClassificationAfterEdit: promptPath },
       safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
     }
@@ -475,6 +478,7 @@ describe("prompt composer", () => {
         mergeQueue: false,
         method: "squash",
       },
+      mode: "multi",
       prompts: {},
       safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
       triage: {
@@ -560,6 +564,7 @@ describe("prompt composer", () => {
         mergeQueue: false,
         method: "squash",
       },
+      mode: "multi",
       prompts: {},
       safety: { allowAuthors: [], blockedPaths: [], requiredLabels: [] },
       triage: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,12 +195,10 @@ export interface OutputConfig {
 }
 
 export interface ReviewConfig {
-  account?: string
   automation?: AutomationConfig
   checks?: ReviewChecksConfig
   concurrency?: ConcurrencyConfig
   merge?: PullRequestMergeConfig
-  mode?: ReviewIdentityMode
   output?: string
   prompts?: ReviewPromptConfig
   reviewers?: ReviewerConfig[]
@@ -279,11 +277,13 @@ export interface MergeConfig {
 
 export interface MagiConfig {
   $schema?: string
+  account?: string
   agents?: AgentsConfig
   clear?: ClearConfig
   github?: GitHubRepoConfig
   language?: string
   merge?: MergeConfig
+  mode?: ReviewIdentityMode
   output?: OutputConfig
   review?: ReviewConfig
   triage?: TriageConfig
@@ -351,16 +351,14 @@ export interface ResolvedRepository extends RepositoryConfig {
   concurrency: Required<ConcurrencyConfig>
   github: Required<GitHubRepoConfig>
   language?: string
+  account?: string
+  mode: ReviewIdentityMode
   merge: Required<Omit<PullRequestMergeConfig, "queue">> & {
     maxThreadResolutionCycles: number
     mergeQueue: boolean
     queue?: boolean
   }
   prompts: PromptConfig
-  review?: {
-    account?: string
-    mode: ReviewIdentityMode
-  }
   reviewAutomation?: Required<AutomationConfig>
   safety: Required<Omit<SafetyConfig, "maxChangedFiles">> & {
     maxChangedFiles?: number


### PR DESCRIPTION
Closes #294

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Promotes Magi identity settings from `review.mode` and `review.account` to top-level `mode` and `account` for review and merge flows.

## Current behavior (updates)

Review identity mode and single-mode account resolution were configured under `review`, and review/merge orchestration read identity settings from `repository.review`.

## New behavior

`mode` now defaults to `single` at the top level, `account` is validated at the top level when review single mode is used, and `review.mode`/`review.account` are rejected as invalid keys. Review and merge single-mode GitHub mutations now use the resolved top-level account, while multi-mode continues to use each reviewer account.

## Is this a breaking change (Yes/No):

Yes. Existing configs using `review.mode` or `review.account` must move those keys to top-level `mode` and `account`.

## Additional Information

No full documentation update is included because this issue explicitly scopes documentation follow-up to a later issue.

Verification:
- `pnpm exec vitest run src/config/schema.test.ts src/config/validate.test.ts src/config/resolve.test.ts`
- `pnpm exec vitest run src/orchestrator/review.test.ts src/orchestrator/merge.test.ts`
- `pnpm exec vitest run src/index.test.ts src/prompts/compose.test.ts src/orchestrator/run-manager.test.ts src/orchestrator/ci.test.ts src/orchestrator/triage.test.ts src/github/commands.test.ts`
- `pnpm typecheck`