### PR TITLE
feat(triage): support single mode identity

### DIFF
--- a/.changeset/single-triage-identity.md
+++ b/.changeset/single-triage-identity.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Add single-mode identity support for issue triage.

--- a/schema.json
+++ b/schema.json
@@ -115,7 +115,7 @@
     "triageAgent": {
       "type": "object",
       "if": { "not": { "required": ["ref"] } },
-      "then": { "required": ["model", "account"] },
+      "then": { "required": ["model"] },
       "additionalProperties": false,
       "properties": {
         "ref": { "type": "string", "minLength": 1 },

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -97,6 +97,32 @@ describe("resolveRepository", () => {
     ])
   })
 
+  test("resolves single mode triage accounts from the top-level account", () => {
+    const repo = resolveRepository({
+      account: "magi-bot",
+      github: { owner: "owner", repo: "repo" },
+      mode: "single",
+      triage: {
+        voters: [
+          { id: "product", model: "openai/gpt" },
+          { id: "maintainer", model: "openai/gpt" },
+          { id: "support", model: "openai/gpt" },
+        ],
+        creator: {
+          author: { email: "magi@example.com", name: "Magi Bot" },
+          model: "openai/gpt",
+        },
+      },
+    })
+
+    expect(repo.agents.triage?.map((agent) => agent.account)).toEqual([
+      "magi-bot",
+      "magi-bot",
+      "magi-bot",
+    ])
+    expect(repo.agents.triageCreator?.account).toBe("magi-bot")
+  })
+
   test("resolves default triage categories", () => {
     const repo = resolveRepository({
       github: { owner: "owner", repo: "repo" },

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -183,6 +183,8 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
   const creator = config.triage?.creator
   const singleReviewAccount =
     config.review && config.mode !== "multi" ? config.account : undefined
+  const singleTriageAccount =
+    config.triage && config.mode !== "multi" ? config.account : undefined
 
   return {
     editor: editor
@@ -205,6 +207,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
     triage: (config.triage?.voters ?? []).map<ResolvedTriageAgent>(
       (agent, index) => ({
         ...agent,
+        account: singleTriageAccount ?? agent.account ?? "",
         key: triageAgentKey(agent, index),
         index,
         model: normalizedModel(agent.model),
@@ -214,7 +217,7 @@ export function resolveAgents(config: MagiConfig): ResolvedAgents {
     triageCreator: creator
       ? {
           ...creator,
-          account: creator.account ?? "",
+          account: singleTriageAccount ?? creator.account ?? "",
           model: normalizedModel(creator.model),
           permission: resolveTriageCreatorPermission(agents, creator),
         }

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -266,6 +266,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: [
             { account: "triage-a", model: "openai/gpt" },
@@ -280,10 +281,81 @@ describe("validateConfig", () => {
     expect(result).toMatchObject({ errors: [], ok: true })
   })
 
+  test("accepts single mode triage voters without per-agent accounts", async () => {
+    const result = await validateConfig(
+      {
+        account: "magi-bot",
+        github: { owner: "owner", repo: "repo" },
+        mode: "single",
+        triage: {
+          voters: [
+            { id: "product", model: "openai/gpt" },
+            { id: "maintainer", model: "anthropic/claude" },
+            { id: "support", model: "google/gemini" },
+          ],
+          automation: { create: true },
+          creator: {
+            author: { email: "magi@example.com", name: "Magi Bot" },
+            model: "openai/gpt",
+          },
+        },
+      },
+      { requireReview: false, requireTriage: true },
+    )
+
+    expect(result).toMatchObject({ errors: [], ok: true })
+  })
+
+  test("rejects triage account fields in single mode after agent ref expansion", async () => {
+    const result = await validateConfig(
+      {
+        account: "magi-bot",
+        agents: {
+          refs: {
+            creator: {
+              account: "creator-bot",
+              author: { email: "creator@example.com", name: "Creator Bot" },
+              model: "openai/gpt",
+            },
+            voter: { account: "triage-bot", model: "openai/gpt" },
+          },
+        },
+        github: { owner: "owner", repo: "repo" },
+        mode: "single",
+        triage: {
+          voters: [
+            { ref: "voter", id: "product" },
+            { id: "maintainer", model: "anthropic/claude" },
+            { account: "support-bot", id: "support", model: "google/gemini" },
+          ],
+          reporter: "product",
+          automation: { create: true },
+          creator: { ref: "creator" },
+        },
+      } as unknown as MagiConfig,
+      { requireReview: false, requireTriage: true },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain(
+      "triage.voters[0].account is not supported in single mode",
+    )
+    expect(result.errors).toContain(
+      "triage.voters[2].account is not supported in single mode",
+    )
+    expect(result.errors).toContain(
+      "triage.creator.account is not supported in single mode",
+    )
+    expect(result.errors).toContain(
+      "triage.reporter is not supported in single mode",
+    )
+  })
+
   test("validates triage reporter against resolved triage voter keys", async () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: [
             { account: "triage-a", model: "openai/gpt" },
@@ -298,6 +370,7 @@ describe("validateConfig", () => {
     const generated = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: { voters: triageVoters, reporter: "voter-1" },
       },
       { requireReview: false, requireTriage: true },
@@ -305,6 +378,7 @@ describe("validateConfig", () => {
     const invalid = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: { voters: triageVoters, reporter: "missing" },
       },
       { requireReview: false, requireTriage: true },
@@ -322,6 +396,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           automation: { create: true },
@@ -340,6 +415,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           automation: { merge: true, review: true },
@@ -361,6 +437,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           automation: { pr: true } as unknown as NonNullable<
@@ -379,6 +456,7 @@ describe("validateConfig", () => {
     const valid = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           automation: {
@@ -407,6 +485,7 @@ describe("validateConfig", () => {
     const emptyWhen = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           automation: { label: [{ when: {} }] },
@@ -426,6 +505,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           automation: { clear: ["triage"] } as unknown as NonNullable<
@@ -444,6 +524,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           prompts: {
@@ -462,6 +543,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           prompts: {
@@ -482,6 +564,7 @@ describe("validateConfig", () => {
       const result = await validateConfig(
         {
           github: { owner: "owner", repo: "repo" },
+          mode: "multi",
           triage: {
             voters: triageVoters,
             prompts: {
@@ -526,6 +609,7 @@ describe("validateConfig", () => {
       const result = await validateConfig(
         {
           github: { owner: "owner", repo: "repo" },
+          mode: "multi",
           triage: {
             voters: triageVoters,
             categories,
@@ -546,6 +630,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           categories: [{ id }],
@@ -562,6 +647,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           categories: {} as NonNullable<MagiConfig["triage"]>["categories"],
@@ -1437,6 +1523,7 @@ describe("validateConfig", () => {
     const result = await validateConfig(
       {
         github: { owner: "owner", repo: "repo" },
+        mode: "multi",
         triage: {
           voters: triageVoters,
           automation: { create: true },

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -614,6 +614,7 @@ function validateTriageAgentList(
   path: string,
   errors: string[],
   catalog?: ModelCatalog,
+  mode: "multi" | "single" = "single",
 ): void {
   if (voters == null) return
   if (!Array.isArray(voters)) {
@@ -639,7 +640,10 @@ function validateTriageAgentList(
       errors,
       catalog,
     )
-    if (!agent.account) errors.push(`${path}[${index}].account is required`)
+    if (mode === "multi" && !agent.account)
+      errors.push(`${path}[${index}].account is required`)
+    if (mode === "single" && agent.account)
+      errors.push(`${path}[${index}].account is not supported in single mode`)
     validateString(agent.account, `${path}[${index}].account`, errors)
     validateString(agent.persona, `${path}[${index}].persona`, errors)
     validatePermissionConfig(
@@ -701,6 +705,7 @@ function validateResolvedTriageAgents(
   agents: { account: string; key: string }[],
   path: string,
   errors: string[],
+  mode: "multi" | "single" = "single",
 ): void {
   const keys = new Set<string>()
   const accounts = new Set<string>()
@@ -710,7 +715,7 @@ function validateResolvedTriageAgents(
       errors.push(`${path} has duplicate agent key: ${agent.key}`)
     keys.add(agent.key)
 
-    if (accounts.has(agent.account))
+    if (mode === "multi" && accounts.has(agent.account))
       errors.push(`${path} has duplicate agent account: ${agent.account}`)
     accounts.add(agent.account)
   }
@@ -766,6 +771,7 @@ function validateTriageCreator(
   path: string,
   errors: string[],
   catalog?: ModelCatalog,
+  mode: "multi" | "single" = "single",
 ): void {
   if (!creator) return
   if (!isPlainObject(creator)) {
@@ -775,6 +781,8 @@ function validateTriageCreator(
 
   validateKnownKeys(creator, path, TRIAGE_CREATOR_KEYS, errors)
   if (!creator.model) errors.push(`${path}.model is required`)
+  if (mode === "single" && creator.account)
+    errors.push(`${path}.account is not supported in single mode`)
   validateString(creator.account, `${path}.account`, errors)
   validateAndNormalizeModel(
     creator as ModelTarget,
@@ -1172,6 +1180,7 @@ function validateTriage(
   options: ValidationOptions,
 ): void {
   const triage = config.triage
+  const mode = reviewMode(config)
   if (!triage) return
   if (!isPlainObject(triage)) {
     errors.push("triage must be an object")
@@ -1192,6 +1201,7 @@ function validateTriage(
     "triage.voters",
     errors,
     options.modelCatalog,
+    mode,
   )
   if (Array.isArray(triage.voters)) {
     const resolvedTriageAgents = triage.voters.map((agent, index) => ({
@@ -1206,21 +1216,32 @@ function validateTriage(
       resolvedTriageAgents,
       "triage.resolvedAgents",
       errors,
+      mode,
     )
     if (
+      mode === "multi" &&
       reporter != null &&
       !resolvedTriageAgents.some((agent) => agent.key === reporter)
     ) {
       errors.push(`triage.reporter must match a triage voter key: ${reporter}`)
     }
   }
+  if (mode === "single" && reporter != null) {
+    errors.push("triage.reporter is not supported in single mode")
+  }
   validateString(triage.reporter, "triage.reporter", errors)
-  validateTriageCreator(creator, "triage.creator", errors, options.modelCatalog)
+  validateTriageCreator(
+    creator,
+    "triage.creator",
+    errors,
+    options.modelCatalog,
+    mode,
+  )
   if (automation?.create && !creator)
     errors.push(
       "triage.creator is required when triage.automation.create is true",
     )
-  if (automation?.create && creator && !creator.account)
+  if (mode === "multi" && automation?.create && creator && !creator.account)
     errors.push(
       "triage.creator.account is required when triage.automation.create is true",
     )
@@ -1549,6 +1570,8 @@ export async function validateConfig(
   validateString(config.account, "account", errors)
   validateString(config.language, "language", errors)
 
+  if (config.review || config.triage) validateReviewIdentity(config, errors)
+
   if (config.agents != null && !isPlainObject(config.agents)) {
     errors.push("agents must be an object")
   } else {
@@ -1570,7 +1593,6 @@ export async function validateConfig(
     } else {
       validateKnownKeys(config.review, "review", REVIEW_KEYS, errors)
     }
-    validateReviewIdentity(config, errors)
     if (!config.review.reviewers) errors.push("review.reviewers is required")
     validateReviewerList(
       config.review.reviewers as ReviewerConfig[] | undefined,

--- a/src/orchestrator/triage.test.ts
+++ b/src/orchestrator/triage.test.ts
@@ -15,7 +15,10 @@ import type {
   TriageDuplicateOutput,
 } from "../types"
 import type { ModelClient } from "./model"
-import { DEFAULT_TRIAGE_LABEL_RULES } from "../config/resolve"
+import {
+  DEFAULT_TRIAGE_LABEL_RULES,
+  resolveRepository,
+} from "../config/resolve"
 import {
   chooseDuplicateOutput,
   eligibleMentionReplies,
@@ -422,6 +425,26 @@ function withSingleTriageAgent(
       ...agents,
     },
   }
+}
+
+function singleModeTriageRepository(): ResolvedRepository {
+  return resolveRepository({
+    account: "magi-bot",
+    github: { owner: "owner", repo: "repo" },
+    mode: "single",
+    triage: {
+      voters: [
+        { id: "product", model: "mock/model" },
+        { id: "maintainer", model: "mock/model" },
+        { id: "support", model: "mock/model" },
+      ],
+      automation: { create: true },
+      creator: {
+        author: { email: "magi@example.com", name: "Magi Bot" },
+        model: "mock/model",
+      },
+    },
+  })
 }
 
 describe("triage", () => {
@@ -928,6 +951,74 @@ describe("triage", () => {
         },
       ]),
     )
+  })
+
+  test("uses the top-level account for single mode triage PR mutations", async () => {
+    const result = await runScenario({
+      dryRun: false,
+      issue: issue({ type: "Feature" }),
+      outputs: [
+        vote("YES"),
+        vote("YES"),
+        vote("YES"),
+        JSON.stringify({
+          commitMessage: "fix: address issue #1",
+          commitSha: "abcdef1234567890",
+          filesTouched: ["src/app.ts"],
+          mode: "EDITED",
+          pullRequest: {
+            body: "Closes #1",
+            title: "fix: address issue #1",
+          },
+          responses: [],
+        }),
+      ],
+      repository: singleModeTriageRepository(),
+    })
+
+    expect(result.result.result).toEqual(decision("feature", "accepted"))
+    expect(
+      result.commands.filter((command) => command.startsWith("gh auth token")),
+    ).toEqual(expect.arrayContaining([expect.stringContaining("'magi-bot'")]))
+    expect(
+      result.commands
+        .filter((command) => command.startsWith("gh auth token"))
+        .every((command) => command.includes("'magi-bot'")),
+    ).toBe(true)
+    expect(
+      result.commands.some((command) =>
+        command.includes("--add-assignee 'magi-bot'"),
+      ),
+    ).toBe(true)
+    expect(
+      result.commands.some((command) =>
+        command.includes("--remove-label 'triage'"),
+      ),
+    ).toBe(true)
+    expect(
+      result.commands.some((command) => command.startsWith("git push")),
+    ).toBe(true)
+    expect(
+      result.commands.some((command) => command.startsWith("gh pr create")),
+    ).toBe(true)
+  })
+
+  test("uses the top-level account for single mode ASK comments", async () => {
+    const result = await runScenario({
+      dryRun: false,
+      issue: issue({ type: undefined }),
+      outputs: [vote("ASK"), vote("ASK"), vote("bug")],
+      repository: singleModeTriageRepository(),
+    })
+
+    expect(result.result.result).toEqual(decision(null, "needs_category"))
+    expect(
+      result.commands.filter((command) => command.startsWith("gh auth token")),
+    ).toEqual([
+      expect.stringContaining("'magi-bot'"),
+      expect.stringContaining("'magi-bot'"),
+      expect.stringContaining("'magi-bot'"),
+    ])
   })
 
   test("honors configured repair attempts for triage PR creation", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export interface EditorConfig {
 }
 
 export interface TriageAgentConfig {
-  account: string
+  account?: string
   id?: string
   model: ModelConfig
   permissions?: PermissionConfig
@@ -312,8 +312,9 @@ export interface ResolvedEditor extends Omit<
 
 export interface ResolvedTriageAgent extends Omit<
   TriageAgentConfig,
-  "model" | "options" | "permissions"
+  "account" | "model" | "options" | "permissions"
 > {
+  account: string
   index: number
   key: string
   model: string


### PR DESCRIPTION
Closes #297

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds single-mode identity support for `/magi:triage` using the top-level `account` configuration.

## Current behavior (updates)

Triage required per-voter accounts, used a configured or selected reporter voter for GitHub mutations, and required a separate creator account for PR automation.

## New behavior

In `mode: "single"`, triage voters and the triage creator resolve their GitHub account to the top-level `account`. Single-mode validation rejects `triage.reporter`, `triage.voters[].account`, and `triage.creator.account`, including account fields introduced by `agents.refs` expansion. Multi-mode triage keeps the previous account requirements and reporter behavior.

Targeted tests cover validation, config resolution, schema behavior, and triage orchestration account usage for ASK comments and PR-creation mutations.

## Is this a breaking change (Yes/No):

No. Multi-mode triage behavior is preserved; single-mode triage follows the new top-level identity contract.

## Additional Information

Verification run: `pnpm vitest run src/config/validate.test.ts src/config/resolve.test.ts src/config/schema.test.ts src/orchestrator/triage.test.ts`.