### PR TITLE
ci(review): force typecheck failure for verification

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,7 +59,7 @@ jobs:
         uses: ./.github/composite-actions/setup
 
       - name: Run typecheck
-        run: pnpm typecheck
+        run: exit 1
 
   format:
     name: Format


### PR DESCRIPTION
Closes #305

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Temporary validation PR for CI failure classification in the refactored review command preparation phases.

## Current behavior (updates)

The review command needs live validation for failed required CI checks before review context fetching.

## New behavior

Intentionally changes the Typecheck workflow step to fail so the review command can classify and handle failed CI.

## Is this a breaking change (Yes/No):

No

## Additional Information

This PR intentionally fails CI for validation and should be closed after verification.
