### PR TITLE
ci(review): delay test job for pending verification

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -87,4 +87,4 @@ jobs:
         uses: ./.github/composite-actions/setup
 
       - name: Run test
-        run: pnpm test
+        run: sleep 45 && pnpm test


### PR DESCRIPTION
Closes #305

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Temporary validation PR for pending CI wait handling.

## Current behavior (updates)

The review command needs live validation that pending required CI is waited on before checks are read.

## New behavior

Temporarily delays the Test workflow job.

## Is this a breaking change (Yes/No):

No

## Additional Information

This PR is for validation only and should be closed after verification.
