### PR TITLE
ci(review): force failure for repair verification

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,7 +59,7 @@ jobs:
         uses: ./.github/composite-actions/setup
 
       - name: Run typecheck
-        run: pnpm typecheck
+        run: exit 1
 
   format:
     name: Format


### PR DESCRIPTION
Closes #305

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Temporary validation PR for CI classification repair prompt handling.

## Current behavior (updates)

The review command needs live validation for invalid classifier output followed by repair prompt retry.

## New behavior

Intentionally fails the Typecheck workflow step so classifier repair can be exercised.

## Is this a breaking change (Yes/No):

No

## Additional Information

This PR intentionally fails CI for validation and should be closed after verification.
