### PR TITLE
chore(review): add ci out scenario fixture

### DIFF
--- a/magi-review-scenario-ci-out.txt
+++ b/magi-review-scenario-ci-out.txt
@@ -2,3 +2,5 @@ This file is a harmless scenario fixture for exercising magi:review when the
 base branch has an unrelated CI failure.
 
 The pull request itself should not introduce the failing check.
+
+This extra line retriggers CI while main has an unrelated lint failure.

--- a/magi-review-scenario-ci-out.txt
+++ b/magi-review-scenario-ci-out.txt
@@ -1,0 +1,4 @@
+This file is a harmless scenario fixture for exercising magi:review when the
+base branch has an unrelated CI failure.
+
+The pull request itself should not introduce the failing check.


### PR DESCRIPTION
Closes #314

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a harmless fixture file for out-of-scope CI failure scenario testing.

## Current behavior (updates)

No scenario fixture exists for unrelated CI failure validation.

## New behavior

A small text fixture is available for a PR that should not introduce CI failures.

## Is this a breaking change (Yes/No):

No

## Additional Information

This PR is intentionally created for live magi:review testing.