### PR TITLE
chore(test): remove merge validation fixtures

### DIFF
--- a/docs/merge-behind-validation-1.md
+++ b/docs/merge-behind-validation-1.md
@@ -1,4 +1,0 @@
-Merge behind validation fixture 1.
-
-This temporary file validates serialized direct merge automation when the
-branch must be updated before merging.

--- a/docs/merge-behind-validation-2.md
+++ b/docs/merge-behind-validation-2.md
@@ -1,4 +1,0 @@
-Merge behind validation fixture 2.
-
-This temporary file validates repeated base-branch updates while serialized
-direct merge automation is waiting for auto-merge.

--- a/docs/merge-behind-validation-3.md
+++ b/docs/merge-behind-validation-3.md
@@ -1,4 +1,0 @@
-Merge behind validation fixture 3.
-
-This temporary file validates serialized direct merge automation after
-deduplicating stale cancelled checks.

--- a/docs/merge-behind-validation-4.md
+++ b/docs/merge-behind-validation-4.md
@@ -1,4 +1,0 @@
-Merge behind validation fixture 4.
-
-This temporary file validates the second serialized merge after the first
-validation PR updates and merges.

--- a/docs/merge-serial-test-1.md
+++ b/docs/merge-serial-test-1.md
@@ -1,3 +1,0 @@
-# Merge Serial Test 1
-
-Temporary file for validating serialized Magi merge automation.

--- a/docs/merge-serial-test-3.md
+++ b/docs/merge-serial-test-3.md
@@ -1,3 +1,0 @@
-# Merge Serial Test 3
-
-Temporary file for validating serialized Magi merge automation.


### PR DESCRIPTION
Closes #0

## AI used

- [ ] I did not use AI to create this PR.
- [x] I checked the generated content before submitting.

## Description

Remove temporary documentation fixtures that were created for merge automation validation.

## Current behavior (updates)

Temporary merge validation fixture files remain on main after testing.

## New behavior

The temporary fixture files are removed so main no longer contains test artifacts.

## Is this a breaking change (Yes/No):

No

## Additional Information

This only removes temporary validation files.