### PR TITLE
chore(test): remove leftover dummy fixtures

### DIFF
--- a/magi-e2e-dry-run.md
+++ b/magi-e2e-dry-run.md
@@ -1,3 +1,0 @@
-Magi merge dry-run e2e scenario.
-
-This disposable file exists only to exercise the `/magi:merge --dry-run` flow.

--- a/magi-e2e-edit.md
+++ b/magi-e2e-edit.md
@@ -1,3 +1,0 @@
-Magi merge editor e2e scenario.
-
-Edited by magi e2e.


### PR DESCRIPTION
Closes #344

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Removes leftover dummy fixture files that were merged during merge command end-to-end validation.

## Current behavior (updates)

`magi-e2e-dry-run.md` and `magi-e2e-edit.md` still exist on `main` after the dummy test PRs were merged.

## New behavior

The leftover dummy fixture files are removed from the repository.

## Is this a breaking change (Yes/No):

No

## Additional Information

Source PRs: #323 and #327.
