### PR TITLE
docs(docs): fix language switch links

### DIFF
--- a/AI_POLICY.ja.md
+++ b/AI_POLICY.ja.md
@@ -1,5 +1,5 @@
 <p align='center'>
-  <a href='./README.md'>English</a> | 日本語
+  <a href='AI_POLICY.md'>English</a> | 日本語
 </p>
 
 # AI利用ポリシー

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,5 +1,5 @@
 <p align='center'>
-  English | <a href='./README.ja.md'>日本語</a>
+  English | <a href='AI_POLICY.ja.md'>日本語</a>
 </p>
 
 # AI Usage Policy

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,5 +1,5 @@
 <p align='center'>
-  <a href='./README.md'>English</a> | 日本語
+  <a href='CONTRIBUTING.md'>English</a> | 日本語
 </p>
 
 # OpenCode Magiへの貢献

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <p align='center'>
-  English | <a href='./README.ja.md'>日本語</a>
+  English | <a href='CONTRIBUTING.ja.md'>日本語</a>
 </p>
 
 # Contributing to OpenCode Magi


### PR DESCRIPTION
Closes #346

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix incorrect language switch links in root documentation headers.

## Current behavior (updates)

`AI_POLICY*` and `CONTRIBUTING*` language switch headers link to `README*` files.

## New behavior

Those headers now link to their matching English or Japanese counterpart files.

## Is this a breaking change (Yes/No):

No

## Additional Information

The `docs/` tree was audited and no additional incorrect language switch targets were found.
