### PR TITLE
fix(review): relay magi notifications

### DIFF
--- a/.changeset/relay-magi-notifications.md
+++ b/.changeset/relay-magi-notifications.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Prompt agents to relay Magi progress and completion notifications to users.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -230,7 +230,18 @@ export class Magi {
 
   public async notify(sessionID: string, text: string): Promise<void> {
     await this.input.client.session.promptAsync({
-      parts: [{ synthetic: true, text, type: "text" }],
+      parts: [
+        {
+          synthetic: true,
+          text: [
+            "Magi notification:",
+            text,
+            "",
+            "Relay this update to the user immediately.",
+          ].join("\n"),
+          type: "text",
+        },
+      ],
       sessionID,
     })
   }


### PR DESCRIPTION
Closes #349

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Wrap Magi notification prompts with an explicit instruction for the receiving agent to relay the update to the user immediately.

## Current behavior (updates)

Magi notifications are sent as synthetic prompt text without a clear instruction that the parent agent should surface them to the user.

## New behavior

Magi notifications include a short header and an explicit relay instruction, making progress and completion updates more likely to be reported to the user.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification:

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint:check`
- pre-commit `lint & typecheck` and `format`
