### PR TITLE
fix(review): suppress sync progress notifications

### DIFF
--- a/.changeset/sync-progress-notifications.md
+++ b/.changeset/sync-progress-notifications.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Suppress progress notifications during synchronous Magi runs.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -105,6 +105,7 @@ export interface State {
   reviewers?: { [key: string]: ReviewerState }
   sessionId: string
   status: Status
+  sync: boolean
   text?: string
   updatedAt: string
   voters?: { [key: string]: AgentState }
@@ -376,7 +377,8 @@ export class Magi {
     const state = merge<State>(prev, next)
     const values = [this.createStateFile(state)]
 
-    if (next.text) values.push(this.notify(prev.sessionId, next.text))
+    if (!state.sync && next.text)
+      values.push(this.notify(prev.sessionId, next.text))
 
     await Promise.all(values)
 

--- a/src/tools/merge/action.ts
+++ b/src/tools/merge/action.ts
@@ -19,11 +19,10 @@ export async function editCycles(
       return verdict
     },
     {
-      error: (e, count) => {
+      error: async (e, count) => {
         if (e !== error) throw e
 
-        this.magi.notify(
-          this.state.sessionId,
+        await this.notify(
           `Attempt ${count} failed to edit cycles for ${this.getLink()}. Retrying...`,
         )
       },

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -68,8 +68,7 @@ export async function edit(this: Merge): Promise<boolean> {
     },
     {
       error: (_, count) =>
-        this.magi.notify(
-          this.state.sessionId,
+        this.notify(
           `Attempt ${count} failed to edit ${this.getLink()}. Retrying...`,
         ),
       retries: this.config.output.repairAttempts,
@@ -83,8 +82,7 @@ export async function edit(this: Merge): Promise<boolean> {
     text: `Finished editing ${this.getLink()}.`,
   })
 
-  await this.magi.notify(
-    this.state.sessionId,
+  await this.notify(
     filterEmpty([
       `Editor ${output.mode === "EDITED" ? "edited" : "replied to"} ${this.getLink()}.`,
       output.commitSha
@@ -225,8 +223,7 @@ export async function resolveConflict(this: Merge): Promise<void> {
     },
     {
       error: (_, count) =>
-        this.magi.notify(
-          this.state.sessionId,
+        this.notify(
           `Attempt ${count} failed to resolve conflicts for ${this.getLink()}. Retrying...`,
         ),
       retries: this.config.output.repairAttempts,

--- a/src/tools/merge/merge.ts
+++ b/src/tools/merge/merge.ts
@@ -56,8 +56,8 @@ export class Merge extends Review {
     const state = await magi.createState(
       join(config.review.output, number.toString()),
       {
+        ...options,
         command: "merge",
-        dryRun: options.dryRun,
         editor,
         operator,
         pr: { number, url },

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -95,10 +95,7 @@ export async function postReviews(this: Review): Promise<void> {
       })
 
       if (!findings.length) {
-        this.magi.notify(
-          this.state.sessionId,
-          `Finished posting reviews for ${this.getLink()}.`,
-        )
+        await this.notify(`Finished posting reviews for ${this.getLink()}.`)
 
         return
       }
@@ -120,10 +117,7 @@ export async function postReviews(this: Review): Promise<void> {
       if (!this.state.operator?.sessionId)
         throw new MagiError("blocked", "Reporter session ID not found.")
 
-      await this.magi.notify(
-        this.state.sessionId,
-        `Generating comment for ${this.getLink()} by operator.`,
-      )
+      await this.notify(`Generating comment for ${this.getLink()} by operator.`)
 
       const contents = JSON.stringify(
         reviewers.flatMap<PullRequestFinding | string>(([, { outputs }]) => {
@@ -167,8 +161,7 @@ export async function postReviews(this: Review): Promise<void> {
         },
         {
           error: (_, count) =>
-            this.magi.notify(
-              this.state.sessionId,
+            this.notify(
               `Attempt ${count} failed to post comment for ${this.getLink()} by operator. Retrying...`,
             ),
           retries: this.config.output.repairAttempts,
@@ -178,10 +171,7 @@ export async function postReviews(this: Review): Promise<void> {
       if (!output)
         throw new MagiError("blocked", "Invalid output for operator.")
 
-      await this.magi.notify(
-        this.state.sessionId,
-        `Generated comment for ${this.getLink()} by operator.`,
-      )
+      await this.notify(`Generated comment for ${this.getLink()} by operator.`)
 
       params.body = output
     }

--- a/src/tools/review/check.ts
+++ b/src/tools/review/check.ts
@@ -185,8 +185,7 @@ export async function classifyChecks(this: Review): Promise<void> {
         if (!sessionId)
           throw new Error(`No session ID found for reviewer ${id}.`)
 
-        await this.magi.notify(
-          this.state.sessionId,
+        await this.notify(
           `Classifying CI checks for ${this.getLink()} with reviewer ${id}.`,
         )
 
@@ -205,8 +204,7 @@ export async function classifyChecks(this: Review): Promise<void> {
           },
           {
             error: (_, count) =>
-              this.magi.notify(
-                this.state.sessionId,
+              this.notify(
                 `Attempt ${count} failed to classify CI checks for ${this.getLink()} with reviewer ${id}. Retrying...`,
               ),
             retries: this.config.output.repairAttempts,
@@ -247,8 +245,7 @@ export async function classifyChecks(this: Review): Promise<void> {
           .map(([id, { comment }]) => `- ${id}: ${comment}`),
       }
 
-      await this.magi.notify(
-        this.state.sessionId,
+      await this.notify(
         filterEmpty([
           scope
             ? `Check ${name} for ${this.getLink()} was classified as in scope by majority vote.`
@@ -299,10 +296,7 @@ export async function rerunChecks(this: Review): Promise<void> {
   } else {
     await retry(
       async () => {
-        await this.magi.notify(
-          this.state.sessionId,
-          `Rerunning checks ${label} for ${this.getLink()}.`,
-        )
+        await this.notify(`Rerunning checks ${label} for ${this.getLink()}.`)
         await Promise.all(
           checks.failed
             .filter(({ scope }) => !scope)
@@ -341,8 +335,7 @@ export async function rerunChecks(this: Review): Promise<void> {
       },
       {
         error: (_, count) =>
-          this.magi.notify(
-            this.state.sessionId,
+          this.notify(
             `Attempt ${count} failed to rerun checks ${label} for ${this.getLink()}. Retrying...`,
           ),
         retries: this.config.review.checks.retryFailedJobs,
@@ -363,7 +356,7 @@ export async function rerunChecks(this: Review): Promise<void> {
       : undefined,
   ]).join("\n")
 
-  if (message) await this.magi.notify(this.state.sessionId, message)
+  if (message) await this.notify(message)
 
   this.state = await this.magi.updateState(this.state.output, {
     pr: { checks },

--- a/src/tools/review/review.ts
+++ b/src/tools/review/review.ts
@@ -73,8 +73,8 @@ export class Review {
     const state = await magi.createState(
       join(config.review.output, number.toString()),
       {
+        ...options,
         command: "review",
-        dryRun: options.dryRun,
         operator,
         pr: { number, url },
         repo: quote(`${config.github.owner}/${config.github.repo}`),
@@ -112,6 +112,10 @@ export class Review {
   public postReviews = postReviews
   public automate = automate
   public createReport = createReport
+
+  public async notify(text: string): Promise<void> {
+    if (!this.state.sync) await this.magi.notify(this.state.sessionId, text)
+  }
 
   public async cleanup(): Promise<void> {
     if (this.state.worktree?.path)

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -49,8 +49,7 @@ export async function review(this: Review): Promise<void> {
             this.state.reviewers[id]!
 
           if (status === "skip") {
-            this.magi.notify(
-              this.state.sessionId,
+            await this.notify(
               `Skipping review for ${this.getLink()} with reviewer ${id}.`,
             )
 
@@ -70,8 +69,7 @@ export async function review(this: Review): Promise<void> {
             const rereview = status !== "initial"
             const label = rereview ? "rereview" : "review"
 
-            await this.magi.notify(
-              this.state.sessionId,
+            await this.notify(
               `Running ${label} for ${this.getLink()} with reviewer ${id}.`,
             )
 
@@ -194,8 +192,7 @@ export async function review(this: Review): Promise<void> {
               },
               {
                 error: (_, count) =>
-                  this.magi.notify(
-                    this.state.sessionId,
+                  this.notify(
                     `Attempt ${count} failed to ${label} for ${this.getLink()} with reviewer ${id}. Retrying...`,
                   ),
                 retries: this.config.output.repairAttempts,
@@ -337,8 +334,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
           )
           const repairMessage = await prompt.repair()
 
-          await this.magi.notify(
-            this.state.sessionId,
+          await this.notify(
             `Reconsidering close verdict for ${this.getLink()} with reviewer ${id}.`,
           )
 
@@ -365,8 +361,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
             },
             {
               error: (_, count) =>
-                this.magi.notify(
-                  this.state.sessionId,
+                this.notify(
                   `Attempt ${count} failed to reconsider close verdict for ${this.getLink()} with reviewer ${id}. Retrying...`,
                 ),
               retries: this.config.output.repairAttempts,
@@ -464,8 +459,7 @@ async function collectAcceptedFindings(
               `No session ID found for reviewer ${id}.`,
             )
 
-          await this.magi.notify(
-            this.state.sessionId,
+          await this.notify(
             `Validating review findings for ${this.getLink()} with reviewer ${id}.`,
           )
 
@@ -525,8 +519,7 @@ async function collectAcceptedFindings(
             },
             {
               error: (_, count) =>
-                this.magi.notify(
-                  this.state.sessionId,
+                this.notify(
                   `Attempt ${count} failed to validate review findings for ${this.getLink()} with reviewer ${id}. Retrying...`,
                 ),
               retries: this.config.output.repairAttempts,
@@ -571,8 +564,7 @@ async function collectAcceptedFindings(
 
       if (agrees >= threshold) accepted.add(key)
 
-      await this.magi.notify(
-        this.state.sessionId,
+      await this.notify(
         filterEmpty([
           `Finding ${reviewer} #${index + 1} for ${this.getLink()} was ${agrees >= threshold ? "accepted" : "rejected"} by majority vote.`,
           `Finding: ${finding.path}:${finding.line}\n${finding.body}`,
@@ -634,8 +626,7 @@ async function notifyVerdictChanges(
 
       if (!prevVerdict || !nextVerdict || prevVerdict === nextVerdict) return
 
-      await this.magi.notify(
-        this.state.sessionId,
+      await this.notify(
         `Reviewer ${id} verdict changed from ${prevVerdict} to ${nextVerdict} for ${this.getLink()} ${reason}.`,
       )
     }),

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -17,7 +17,7 @@ export async function loop<T>(
 }
 
 export interface RetryOptions {
-  error?: (e: unknown, count: number) => void
+  error?: (e: unknown, count: number) => Promise<void> | void
   retries?: number
 }
 
@@ -31,7 +31,7 @@ export async function retry<T = void>(
     try {
       return await callback(count)
     } catch (e) {
-      error?.(e, count)
+      await error?.(e, count)
 
       count += 1
     }


### PR DESCRIPTION
Closes #348

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Suppress Magi progress notifications while review and merge commands run synchronously.

## Current behavior (updates)

Synchronous runs still send progress notifications into the parent OpenCode session, causing repeated completion summaries after the command finishes.

## New behavior

Synchronous runs keep progress in state and return the final report once, while asynchronous runs continue notifying progress to the parent session.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification:

- `pnpm format:check`
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
