### PR TITLE
fix(review): restore detached worktree checkout

### DIFF
--- a/.changeset/restore-detached-pr-worktrees.md
+++ b/.changeset/restore-detached-pr-worktrees.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Restore detached PR worktree checkout to avoid branch conflicts during review and merge runs.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -109,7 +109,7 @@ export interface State {
   updatedAt: string
   voters?: { [key: string]: AgentState }
   worktree?: {
-    branch: string
+    branch?: string
     path: string
   }
 }
@@ -466,15 +466,16 @@ export class Magi {
     number: number,
     id: string,
     signal?: AbortSignal,
-  ): Promise<{ branch: string; path: string }> {
+  ): Promise<{ branch?: string; path: string }> {
     const path = this.getPath(join(dir, number.toString(), id))
 
     try {
       await mkdir(dirname(path), { recursive: true })
-      await this.exec(command("git", "worktree", "add", quote(path)), {
-        signal,
-      })
-      await this.exec(command("gh", "pr", "checkout", number), {
+      await this.exec(
+        command("git", "worktree", "add", "--detach", quote(path)),
+        { signal },
+      )
+      await this.exec(command("gh", "pr", "checkout", number, "--detach"), {
         cwd: path,
         signal,
       })
@@ -484,9 +485,7 @@ export class Magi {
         signal,
       })
 
-      if (!branch) throw new Error("Failed to determine worktree branch")
-
-      return { branch, path }
+      return { branch: branch || undefined, path }
     } catch (e) {
       try {
         await this.exec(


### PR DESCRIPTION
Closes #352

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Restore detached checkout for temporary PR worktrees used by review and merge flows.

## Current behavior (updates)

Magi creates a temporary worktree and runs `gh pr checkout` without `--detach`. If the PR head branch is already checked out in another worktree, Git rejects the checkout and the run fails before review or merge work starts.

## New behavior

Magi creates temporary PR worktrees with `git worktree add --detach` and checks out the PR with `gh pr checkout --detach`. Detached worktrees no longer require a current branch name in state.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validated with `pnpm typecheck`. No test file is included by request.
