### PR TITLE
fix(prompts): allow concise model outputs

### DIFF
--- a/.changeset/empty-review-comments.md
+++ b/.changeset/empty-review-comments.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Allow concise model outputs while accepting explicit empty fields.

--- a/src/prompts/merge/edit/output-contract.md
+++ b/src/prompts/merge/edit/output-contract.md
@@ -19,6 +19,8 @@ Rules:
 - `"ASK"` means you need clarification and did not edit.
 - Do not make changes just because a reviewer requested them; edit only when you understand and agree.
 - Do not push. The orchestrator pushes after validating this envelope.
-- `filesTouched` must include every final changed file.
-- `responses` must include a reply for each thread you addressed.
-- `"REPLIED"` requires `filesTouched` to be empty and at least one `"DISAGREE"` or `"ASK"` response.
+- `filesTouched` is required for `"EDITED"` and must include every final changed file.
+- `responses` is required and must include a reply for each thread you addressed.
+- `"EDITED"` requires at least one response.
+- `"REPLIED"` may omit `filesTouched`. If present, it must be empty.
+- `"REPLIED"` requires at least one `"DISAGREE"` or `"ASK"` response.

--- a/src/prompts/merge/edit/validate.json
+++ b/src/prompts/merge/edit/validate.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "required": ["mode", "filesTouched", "responses"],
+  "required": ["mode", "responses"],
   "additionalProperties": false,
   "properties": {
     "mode": { "enum": ["EDITED", "REPLIED"] },
@@ -28,8 +28,11 @@
     {
       "if": { "properties": { "mode": { "const": "EDITED" } } },
       "then": {
-        "required": ["commitSha", "commitMessage"],
-        "properties": { "filesTouched": { "type": "array", "minItems": 1 } }
+        "required": ["commitSha", "commitMessage", "filesTouched"],
+        "properties": {
+          "filesTouched": { "type": "array", "minItems": 1 },
+          "responses": { "type": "array", "minItems": 1 }
+        }
       }
     },
     {

--- a/src/prompts/review/close-reconsideration/output-contract.md
+++ b/src/prompts/review/close-reconsideration/output-contract.md
@@ -11,7 +11,8 @@ Return exactly one JSON object and nothing else. Do not wrap it in markdown.
 Rules:
 
 - `"verdict"` must be `"APPROVED"` or `"CHANGES_REQUESTED"`.
-- `"APPROVED"` requires an empty `"findings"` array.
+- `"APPROVED"` may omit `"findings"`. If present, it must be empty.
+- `"APPROVED"` may omit `"comment"`. If present, it must be an empty string.
 - `"CHANGES_REQUESTED"` requires `"comment"` and at least one `"finding"`.
 - `"comment"` for `"CHANGES_REQUESTED"` must be a concise prose review summary, not a bullet list of findings.
 - `"CLOSED"` is not allowed in this reconsideration step.

--- a/src/prompts/review/close-reconsideration/validate.json
+++ b/src/prompts/review/close-reconsideration/validate.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "required": ["verdict", "findings"],
+  "required": ["verdict"],
   "additionalProperties": false,
   "properties": {
     "verdict": { "enum": ["APPROVED", "CHANGES_REQUESTED"] },
@@ -18,20 +18,26 @@
         }
       }
     },
-    "comment": { "type": "string", "minLength": 1 }
+    "comment": { "type": "string" }
   },
   "allOf": [
     {
       "if": { "properties": { "verdict": { "const": "APPROVED" } } },
       "then": {
-        "properties": { "findings": { "type": "array", "maxItems": 0 } }
+        "properties": {
+          "findings": { "type": "array", "maxItems": 0 },
+          "comment": { "const": "" }
+        }
       }
     },
     {
       "if": { "properties": { "verdict": { "const": "CHANGES_REQUESTED" } } },
       "then": {
-        "required": ["comment"],
-        "properties": { "findings": { "type": "array", "minItems": 1 } }
+        "required": ["comment", "findings"],
+        "properties": {
+          "findings": { "type": "array", "minItems": 1 },
+          "comment": { "type": "string", "minLength": 1 }
+        }
       }
     }
   ]

--- a/src/prompts/review/rereview/output-contract.md
+++ b/src/prompts/review/rereview/output-contract.md
@@ -15,11 +15,12 @@ Rules:
 - `"verdict"` must be `"APPROVED"`, `"CHANGES_REQUESTED"`, or `"CLOSED"`.
 - `"resolves"` contains threads that should be resolved because the issue is fixed or the user's explanation is acceptable.
 - Each `"resolves"` item must use the exact `"commentId"` and `"threadId"` from `<unresolved_threads>`.
-- Use an empty `"resolves"` array when no thread should be resolved.
-- `"APPROVED"` requires empty `"followUps"` and `"newFindings"` arrays.
+- Omit `"resolves"` when no thread should be resolved.
+- `"APPROVED"` may omit `"followUps"` and `"newFindings"`. If present, they must be empty.
+- `"APPROVED"` may omit `"comment"`. If present, it must be an empty string.
 - `"CHANGES_REQUESTED"` requires `"comment"` and at least one `"followUp"` or `"newFinding"`.
 - `"comment"` for `"CHANGES_REQUESTED"` must be a concise prose review summary, not a bullet list of findings.
-- `"CLOSED"` requires `"comment"` and empty `"followUps"` and `"newFindings"` arrays.
+- `"CLOSED"` requires `"comment"` and may omit `"followUps"` and `"newFindings"`. If present, they must be empty.
 - `"line"` is required and must target a valid right-side line inside the latest PR diff hunk.
 - `"startLine"` is optional and must also target a valid right-side line inside the same latest PR diff hunk range.
 - Omit `"startLine"` for single-line findings.

--- a/src/prompts/review/rereview/validate.json
+++ b/src/prompts/review/rereview/validate.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "required": ["verdict", "resolves", "followUps", "newFindings"],
+  "required": ["verdict"],
   "additionalProperties": false,
   "properties": {
     "verdict": { "enum": ["APPROVED", "CHANGES_REQUESTED", "CLOSED"] },
@@ -42,7 +42,7 @@
         }
       }
     },
-    "comment": { "type": "string", "minLength": 1 }
+    "comment": { "type": "string" }
   },
   "allOf": [
     {
@@ -50,7 +50,8 @@
       "then": {
         "properties": {
           "followUps": { "type": "array", "maxItems": 0 },
-          "newFindings": { "type": "array", "maxItems": 0 }
+          "newFindings": { "type": "array", "maxItems": 0 },
+          "comment": { "const": "" }
         }
       }
     },
@@ -59,11 +60,16 @@
       "then": {
         "required": ["comment"],
         "anyOf": [
-          { "properties": { "followUps": { "type": "array", "minItems": 1 } } },
           {
+            "required": ["followUps"],
+            "properties": { "followUps": { "type": "array", "minItems": 1 } }
+          },
+          {
+            "required": ["newFindings"],
             "properties": { "newFindings": { "type": "array", "minItems": 1 } }
           }
-        ]
+        ],
+        "properties": { "comment": { "type": "string", "minLength": 1 } }
       }
     },
     {
@@ -72,7 +78,8 @@
         "required": ["comment"],
         "properties": {
           "followUps": { "type": "array", "maxItems": 0 },
-          "newFindings": { "type": "array", "maxItems": 0 }
+          "newFindings": { "type": "array", "maxItems": 0 },
+          "comment": { "type": "string", "minLength": 1 }
         }
       }
     }

--- a/src/prompts/review/review/output-contract.md
+++ b/src/prompts/review/review/output-contract.md
@@ -11,10 +11,11 @@ Return exactly one JSON object and nothing else. Do not wrap it in markdown.
 Rules:
 
 - `"verdict"` must be `"APPROVED"`, `"CHANGES_REQUESTED"`, or `"CLOSED"`.
-- `"APPROVED"` requires an empty `"findings"` array.
+- `"APPROVED"` may omit `"findings"`. If present, it must be empty.
+- `"APPROVED"` may omit `"comment"`. If present, it must be an empty string.
 - `"CHANGES_REQUESTED"` requires `"comment"` and at least one `"finding"`.
 - `"comment"` for `"CHANGES_REQUESTED"` must be a concise prose review summary, not a bullet list of findings.
-- `"CLOSED"` requires `"comment"` and an empty `"findings"` array.
+- `"CLOSED"` requires `"comment"` and may omit `"findings"`. If present, `"findings"` must be empty.
 - `"path"` must be repository-relative.
 - `"line"` is required and must target a valid right-side line inside the PR diff hunk.
 - `"startLine"` is optional and must also target a valid right-side line inside the same PR diff hunk range.

--- a/src/prompts/review/review/validate.json
+++ b/src/prompts/review/review/validate.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "required": ["verdict", "findings"],
+  "required": ["verdict"],
   "additionalProperties": false,
   "properties": {
     "verdict": { "enum": ["APPROVED", "CHANGES_REQUESTED", "CLOSED"] },
@@ -18,27 +18,36 @@
         }
       }
     },
-    "comment": { "type": "string", "minLength": 1 }
+    "comment": { "type": "string" }
   },
   "allOf": [
     {
       "if": { "properties": { "verdict": { "const": "APPROVED" } } },
       "then": {
-        "properties": { "findings": { "type": "array", "maxItems": 0 } }
+        "properties": {
+          "findings": { "type": "array", "maxItems": 0 },
+          "comment": { "const": "" }
+        }
       }
     },
     {
       "if": { "properties": { "verdict": { "const": "CHANGES_REQUESTED" } } },
       "then": {
-        "required": ["comment"],
-        "properties": { "findings": { "type": "array", "minItems": 1 } }
+        "required": ["comment", "findings"],
+        "properties": {
+          "findings": { "type": "array", "minItems": 1 },
+          "comment": { "type": "string", "minLength": 1 }
+        }
       }
     },
     {
       "if": { "properties": { "verdict": { "const": "CLOSED" } } },
       "then": {
         "required": ["comment"],
-        "properties": { "findings": { "type": "array", "maxItems": 0 } }
+        "properties": {
+          "findings": { "type": "array", "maxItems": 0 },
+          "comment": { "type": "string", "minLength": 1 }
+        }
       }
     }
   ]

--- a/src/prompts/triage/create/output-contract.md
+++ b/src/prompts/triage/create/output-contract.md
@@ -22,6 +22,7 @@ Rules:
 - Use REPLIED when you only replied without code changes.
 - For EDITED, pullRequest.title and pullRequest.body must be non-empty and follow the repository's PR conventions.
 - Do not push or create the PR. The orchestrator pushes and creates the PR using pullRequest exactly as provided.
-- filesTouched must include every final changed file.
-- responses may be empty when no review threads were addressed.
-- REPLIED requires filesTouched to be empty and at least one DISAGREE or ASK response.
+- filesTouched is required for EDITED and must include every final changed file.
+- responses may be omitted when no review threads were addressed.
+- REPLIED may omit filesTouched. If present, it must be empty.
+- REPLIED requires at least one DISAGREE or ASK response.

--- a/src/prompts/triage/create/validate.json
+++ b/src/prompts/triage/create/validate.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "required": ["mode", "filesTouched", "responses"],
+  "required": ["mode"],
   "additionalProperties": false,
   "properties": {
     "mode": { "enum": ["EDITED", "REPLIED"] },
@@ -37,13 +37,19 @@
     {
       "if": { "properties": { "mode": { "const": "EDITED" } } },
       "then": {
-        "required": ["commitSha", "commitMessage", "pullRequest"],
+        "required": [
+          "commitSha",
+          "commitMessage",
+          "filesTouched",
+          "pullRequest"
+        ],
         "properties": { "filesTouched": { "type": "array", "minItems": 1 } }
       }
     },
     {
       "if": { "properties": { "mode": { "const": "REPLIED" } } },
       "then": {
+        "required": ["responses"],
         "not": {
           "anyOf": [
             { "required": ["commitSha"] },

--- a/src/prompts/triage/signal/output-contract.md
+++ b/src/prompts/triage/signal/output-contract.md
@@ -16,4 +16,4 @@ The object must match this shape:
 Rules:
 
 - Return only configured signal IDs that apply.
-- Return an empty signals array when none apply.
+- Omit `"signals"` when none apply.

--- a/src/prompts/triage/signal/validate.json
+++ b/src/prompts/triage/signal/validate.json
@@ -1,6 +1,5 @@
 {
   "type": "object",
-  "required": ["signals"],
   "additionalProperties": false,
   "properties": {
     "signals": {

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -9,6 +9,10 @@ import { Prompt } from "@/prompts"
 import { getMetadata } from "@/tools/review/check"
 import { command, filterDuplicates, filterEmpty, quote, retry } from "@/utils"
 
+type EditPromptOutput = Omit<EditOutput, "filesTouched"> & {
+  filesTouched?: string[]
+}
+
 export async function edit(this: Merge): Promise<boolean> {
   this.context.abort.throwIfAborted()
 
@@ -49,22 +53,27 @@ export async function edit(this: Merge): Promise<boolean> {
       )
       const parsed = prompt.parse(raw)
 
-      if (!prompt.validate<EditOutput>(parsed))
+      if (!prompt.validate<EditPromptOutput>(parsed))
         throw new Error("Invalid output for editor.")
 
-      if (parsed.mode === "EDITED") {
+      const output: EditOutput = {
+        ...parsed,
+        filesTouched: parsed.filesTouched ?? [],
+      }
+
+      if (output.mode === "EDITED") {
         const head = await this.exec(command("git", "rev-parse", "HEAD"), {
           cwd: this.state.worktree!.path,
           signal: this.context.abort,
         })
 
-        if (head !== parsed.commitSha)
+        if (head !== output.commitSha)
           throw new Error(
-            `Editor reported commit ${parsed.commitSha}, but worktree HEAD is ${head}.`,
+            `Editor reported commit ${output.commitSha}, but worktree HEAD is ${head}.`,
           )
       }
 
-      return parsed
+      return output
     },
     {
       error: (_, count) =>


### PR DESCRIPTION
Closes #354

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Relax model output schemas and prompt contracts so valid concise outputs do not need to include explicit empty fields.

## Current behavior (updates)

Some prompt validators require empty arrays or reject empty approved review comments, which can trigger repair retries or block runs even when the model output is semantically valid.

## New behavior

Approved review outputs may omit empty arrays and may omit `comment`; if `comment` is present for approved reviews, it must be an empty string. Editor and triage prompt schemas also avoid requiring empty arrays where omission is sufficient.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification:

- JSON parse check for updated `validate.json` files
- pre-commit `lint & typecheck` and `format`
