### PR TITLE
fix(review): render missing automation as none

### DIFF
--- a/.changeset/fix-review-automation-none.md
+++ b/.changeset/fix-review-automation-none.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Render missing review automation as none in reports.

--- a/src/tools/review/report.test.ts
+++ b/src/tools/review/report.test.ts
@@ -1,0 +1,44 @@
+import type { Review } from "./review"
+import { describe, expect, it } from "vitest"
+import { createMetaContent } from "./report"
+
+describe("createMetaContent", () => {
+  test("renders missing automation as none", () => {
+    const report = createMetaContent.call(
+      {
+        config: { mode: "multi" },
+        getLink: () => "[#1](https://github.com/magi-ai/opencode-magi/pull/1)",
+        state: {
+          dryRun: false,
+          pr: {
+            number: 1,
+            url: "https://github.com/magi-ai/opencode-magi/pull/1",
+          },
+        },
+      } as unknown as Review,
+      { status: "completed" },
+    )
+
+    expect(report).toContain("- **Automation**: none")
+  })
+
+  test("renders automation values in title case", () => {
+    const report = createMetaContent.call(
+      {
+        config: { mode: "multi" },
+        getLink: () => "[#1](https://github.com/magi-ai/opencode-magi/pull/1)",
+        state: {
+          dryRun: false,
+          pr: {
+            automation: "MERGED",
+            number: 1,
+            url: "https://github.com/magi-ai/opencode-magi/pull/1",
+          },
+        },
+      } as unknown as Review,
+      { status: "completed" },
+    )
+
+    expect(report).toContain("- **Automation**: Merged")
+  })
+})

--- a/src/tools/review/report.test.ts
+++ b/src/tools/review/report.test.ts
@@ -1,5 +1,5 @@
 import type { Review } from "./review"
-import { describe, expect, it } from "vitest"
+import { describe, expect, test } from "vitest"
 import { createMetaContent } from "./report"
 
 describe("createMetaContent", () => {

--- a/src/tools/review/report.ts
+++ b/src/tools/review/report.ts
@@ -58,7 +58,7 @@ export function createMetaContent(
     `- **Mode**: ${toTitleCase(this.config.mode)}`,
     `- **Dry run**: ${this.state.dryRun ? "Yes" : "No"}`,
     `- **Status**: ${toTitleCase(input.status)}`,
-    `- **Automation**: ${toTitleCase(this.state.pr?.automation?.toLocaleLowerCase() ?? "NONE")}`,
+    `- **Automation**: ${this.state.pr?.automation ? toTitleCase(this.state.pr.automation.toLocaleLowerCase()) : "none"}`,
   ]
 
   if (this.state.pr?.verdict)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts"],
   },


### PR DESCRIPTION
Closes #356

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix the review report Automation row so missing automation renders as `none` instead of `N O N E`.

## Current behavior (updates)

Missing `state.pr.automation` falls back to `NONE` and is passed through `toTitleCase`, which renders `N O N E`.

## New behavior

Missing automation renders as `none`; existing automation values still render in title case.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Added focused report formatting tests.
- Added the Vitest `@` alias so source tests can import modules that use the repository path alias.
- No documentation update is needed because this corrects an unintended report formatting typo and no documented example changes.
- Verified with `pnpm test`.
