### PR TITLE
fix(clear): prune empty output directories

### DIFF
--- a/.changeset/prune-empty-magi-dirs.md
+++ b/.changeset/prune-empty-magi-dirs.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Prune empty output parent directories after clearing inactive Magi runs.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -25,8 +25,15 @@ import type { DeepPartial, Dict, Exec, PluginInput } from "@/utils"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { print } from "graphql"
 import { randomUUID } from "node:crypto"
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
-import { dirname, isAbsolute, join } from "node:path"
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  rmdir,
+  writeFile,
+} from "node:fs/promises"
+import { dirname, isAbsolute, join, relative } from "node:path"
 import { Octokit } from "octokit"
 import { getConfig, resolvePermissions, validateConfig } from "@/config"
 import { graphql } from "@/graphql"
@@ -538,7 +545,27 @@ export class Magi {
 
   private async deleteOutput(path: string): Promise<number> {
     try {
-      await rm(path, { force: true, recursive: true })
+      const resolvedPath = this.getPath(path)
+
+      await rm(resolvedPath, { force: true, recursive: true })
+
+      let dir = dirname(resolvedPath)
+
+      while (dir !== this.input.directory) {
+        const value = relative(this.input.directory, dir)
+
+        if (!value || value.startsWith("..") || isAbsolute(value)) break
+
+        try {
+          if ((await readdir(dir)).length) break
+
+          await rmdir(dir)
+        } catch {
+          break
+        }
+
+        dir = dirname(dir)
+      }
 
       return 1
     } catch {


### PR DESCRIPTION
Closes #360

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Prune empty output parent directories after inactive Magi run outputs are cleared.

## Current behavior (updates)

`magi_clear` deleted inactive output directories but left empty parent directories such as `.magi`, `.magi/runs`, `.magi/runs/pr`, or `.magi/runs/pr/<number>` behind.

## New behavior

After deleting an inactive run output, `magi_clear` removes empty parent directories up to the project root boundary and stops when a parent still contains files.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification: `pnpm build` passed.