### PR TITLE
docs(config): document agent permissions

### DIFF
--- a/docs/config.ja.md
+++ b/docs/config.ja.md
@@ -179,6 +179,39 @@ Magiの設定ファイルは、OpenCodeではなくOpenCode Magiによってマ�
 }
 ```
 
+## パーミッション
+
+`agents.permissions`ですべてのエージェントに共通したパーミッションを設定できます。個々とエージェントの`permissions`は、`agents.permissions`をオーバーライドします。
+
+```json
+{
+  "agents": {
+    "permissions": {
+      "read": "allow",
+      "edit": "deny",
+      "bash": {
+        "*": "deny",
+        "git status*": "allow",
+        "git diff*": "allow"
+      }
+    }
+  },
+  "review": {
+    "reviewers": [
+      {
+        "id": "security",
+        "model": "anthropic/claude-opus-4-7",
+        "permissions": {
+          "webfetch": "allow"
+        }
+      }
+    ]
+  }
+}
+```
+
+`allow`、`ask`、`deny`を設定できます。文字列を指定すると対象権限全体に適用され、オブジェクトを指定するとパターンごとに許可・確認・拒否を設定できます。
+
 ## マルチモード
 
 デフォルトでは、シングルモード（`mode: "single"`）です。複数のGitHubアカウントを使用するマルチモードにする場合は、`mode: "multi"`を設定し、各エージェントごとにアカウントを設定します。

--- a/docs/config.ja.md
+++ b/docs/config.ja.md
@@ -181,7 +181,7 @@ Magiの設定ファイルは、OpenCodeではなくOpenCode Magiによってマ�
 
 ## パーミッション
 
-`agents.permissions`ですべてのエージェントに共通したパーミッションを設定できます。個々とエージェントの`permissions`は、`agents.permissions`をオーバーライドします。
+`agents.permissions`ですべてのエージェントに共通したパーミッションを設定できます。個々のエージェントの`permissions`は、`agents.permissions`をオーバーライドします。
 
 ```json
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -179,6 +179,39 @@ Set an `agents.refs` key as `ref` to expand that agent configuration. Fields set
 }
 ```
 
+## Permissions
+
+Set `agents.permissions` to configure permissions shared by all agents. Each agent's `permissions` overrides `agents.permissions`.
+
+```json
+{
+  "agents": {
+    "permissions": {
+      "read": "allow",
+      "edit": "deny",
+      "bash": {
+        "*": "deny",
+        "git status*": "allow",
+        "git diff*": "allow"
+      }
+    }
+  },
+  "review": {
+    "reviewers": [
+      {
+        "id": "security",
+        "model": "anthropic/claude-opus-4-7",
+        "permissions": {
+          "webfetch": "allow"
+        }
+      }
+    ]
+  }
+}
+```
+
+You can set `allow`, `ask`, or `deny`. A string applies to the entire target permission, while an object configures allow, ask, or deny per pattern.
+
 ## Multi Mode
 
 By default, Magi runs in single mode (`mode: "single"`). To use multiple GitHub accounts, set `mode: "multi"` and configure an account for each agent.


### PR DESCRIPTION
Closes: N/A (no issue requested)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Documents agent permission configuration in both English and Japanese config docs.

## Current behavior (updates)

The config docs cover refs, models, and multi mode, but do not explain `agents.permissions` or per-agent `permissions`.

## New behavior

Adds a permissions section with a sample config and the supported `allow`, `ask`, and `deny` values.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validation: `pnpm format:check`