### PR TITLE
feat(output): save raw agent outputs

### DIFF
--- a/.changeset/raw-agent-output-artifacts.md
+++ b/.changeset/raw-agent-output-artifacts.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Save raw review and merge agent outputs as run artifacts.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -35,6 +35,7 @@ import {
   createExec,
   filterEmpty,
   isArray,
+  isNumber,
   isObject,
   merge,
   quote,
@@ -376,6 +377,25 @@ export class Magi {
       join(state.output, "state.json"),
       `${JSON.stringify(state, null, 2)}\n`,
     )
+  }
+
+  public async createAgentFile(
+    output: string,
+    phase: string,
+    id: string,
+    content: string,
+    attempt = 1,
+    cycle?: number,
+  ): Promise<void> {
+    const segments = [output, "agents", phase, id]
+
+    if (isNumber(cycle)) segments.push(cycle.toString())
+    if (isNumber(attempt)) segments.push(attempt.toString())
+
+    const path = segments.join("/") + ".md"
+
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, content)
   }
 
   public async updateState(

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -30,6 +30,7 @@ export async function edit(this: Merge): Promise<boolean> {
   if (!threads.length)
     throw new MagiError("blocked", "No editable review threads found.")
 
+  const cycle = (this.state.editor!.outputs?.length ?? 0) + 1
   const prompt = await Prompt.init(this.magi, this.config, "merge/edit")
   const taskMessage = await prompt.create(
     this.config.merge.prompts?.edit,
@@ -51,6 +52,9 @@ export async function edit(this: Merge): Promise<boolean> {
         this.state.editor!.sessionId!,
         count === 1 ? taskMessage : repairMessage,
       )
+
+      await this.createAgentFile("edit", "editor", raw, count, cycle)
+
       const parsed = prompt.parse(raw)
 
       if (!prompt.validate<EditPromptOutput>(parsed))
@@ -168,6 +172,7 @@ export async function resolveConflict(this: Merge): Promise<void> {
   if (!conflictedFiles.length)
     throw new MagiError("blocked", "No merge conflicts found in worktree.")
 
+  const cycle = (this.state.editor!.outputs?.length ?? 0) + 1
   const prompt = await Prompt.init(this.magi, this.config, "merge/conflict")
   const taskMessage = await prompt.create(
     undefined,
@@ -189,6 +194,9 @@ export async function resolveConflict(this: Merge): Promise<void> {
         this.state.editor!.sessionId!,
         count === 1 ? taskMessage : repairMessage,
       )
+
+      await this.createAgentFile("conflict", "editor", raw, count, cycle)
+
       const parsed = prompt.parse(raw)
 
       if (!prompt.validate<{ [key: string]: never }>(parsed))

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -152,6 +152,9 @@ export async function postReviews(this: Review): Promise<void> {
             this.state.operator!.sessionId!,
             count === 1 ? taskMessage : repairMessage,
           )
+
+          await this.createAgentFile("comment", "operator", raw, count)
+
           const parsed = prompt.parse(raw)
 
           if (!prompt.validate<{ comment: string }>(parsed))

--- a/src/tools/review/check.ts
+++ b/src/tools/review/check.ts
@@ -65,7 +65,8 @@ export async function checkPr(this: Review): Promise<void> {
 
   if (this.config.review.safety.requiredLabels.length) {
     const missingLabels = this.config.review.safety.requiredLabels.filter(
-      (label) => !metadata.labels.some(({ name }) => name === label),
+      (label) =>
+        !metadata.labels.some(({ name }: { name: string }) => name === label),
     )
 
     if (missingLabels.length)
@@ -195,6 +196,9 @@ export async function classifyChecks(this: Review): Promise<void> {
               sessionId,
               count === 1 ? taskMessage : repairMessage,
             )
+
+            await this.createAgentFile("ci-classification", id, raw, count)
+
             const parsed = prompt.parse(raw)
 
             if (!prompt.validate<CiClassificationOutput>(parsed))
@@ -380,7 +384,10 @@ export async function getMetadata(
     }),
   ])
 
-  return { files: files.map(({ filename }) => filename), metadata: data }
+  return {
+    files: files.map(({ filename }: { filename: string }) => filename),
+    metadata: data,
+  }
 }
 
 async function getChecks(this: Review): Promise<PullRequestChecks> {

--- a/src/tools/review/review.ts
+++ b/src/tools/review/review.ts
@@ -128,6 +128,23 @@ export class Review {
     return `[#${this.state.pr!.number}](${this.state.pr!.url})`
   }
 
+  public async createAgentFile(
+    phase: string,
+    id: string,
+    content: string,
+    attempt?: number,
+    cycle?: number,
+  ): Promise<void> {
+    await this.magi.createAgentFile(
+      this.state.output,
+      phase,
+      id,
+      content,
+      attempt,
+      cycle,
+    )
+  }
+
   public async createSessions(): Promise<void> {
     this.context.abort.throwIfAborted()
 

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -68,6 +68,7 @@ export async function review(this: Review): Promise<void> {
 
             const rereview = status !== "initial"
             const label = rereview ? "rereview" : "review"
+            const cycle = (outputs?.length ?? 0) + 1
 
             await this.notify(
               `Running ${label} for ${this.getLink()} with reviewer ${id}.`,
@@ -177,6 +178,15 @@ export async function review(this: Review): Promise<void> {
                   sessionId,
                   count === 1 ? taskMessage : repairMessage,
                 )
+
+                await this.createAgentFile(
+                  rereview ? "rereview" : "review",
+                  id,
+                  raw,
+                  count,
+                  cycle,
+                )
+
                 const parsed = prompt.parse(raw)
 
                 if (!prompt.validate<ReviewOutput>(parsed))
@@ -317,6 +327,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
               `Missing previous review commit for reviewer ${id}.`,
             )
 
+          const cycle = (outputs?.length ?? 0) + 1
           const sha =
             status === "initial"
               ? this.state.pr.metadata.base.sha
@@ -344,6 +355,15 @@ export async function reconsiderClose(this: Review): Promise<void> {
                 sessionId,
                 count === 1 ? taskMessage : repairMessage,
               )
+
+              await this.createAgentFile(
+                "close-reconsideration",
+                id,
+                raw,
+                count,
+                cycle,
+              )
+
               const parsed = prompt.parse(raw)
 
               if (!prompt.validate<ReviewOutput>(parsed))
@@ -488,6 +508,9 @@ async function collectAcceptedFindings(
                 sessionId,
                 count === 1 ? taskMessage : repairMessage,
               )
+
+              await this.createAgentFile("finding-validation", id, raw, count)
+
               const parsed = prompt.parse(raw)
 
               if (!prompt.validate<FindingValidationOutput>(parsed))


### PR DESCRIPTION
Closes #361

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Save raw review and merge agent outputs as run artifacts for easier debugging.

## Current behavior (updates)

Raw `promptSession()` responses were parsed and validated in-memory, then discarded. Debugging malformed or repaired agent responses required reproducing the run or inspecting session history manually.

## New behavior

Review and merge runs write raw agent responses under each run output directory in `agents/<phase>/<id>/<attempt>.md` or `agents/<phase>/<id>/<cycle>/<attempt>.md`.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Verification:

- `pnpm lint:check`
- `pnpm typecheck`

Documentation was not updated per maintainer direction because this is a debug artifact layout change.
