### PR TITLE
fix(review): notify background run start

### DIFF
--- a/.changeset/notify-background-run-start.md
+++ b/.changeset/notify-background-run-start.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Notify users when background Magi runs start.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -239,19 +239,9 @@ export class Magi {
 
   public async notify(sessionID: string, text: string): Promise<void> {
     await this.input.client.session.promptAsync({
-      parts: [
-        {
-          synthetic: true,
-          text: [
-            "Magi notification:",
-            text,
-            "",
-            "Relay this update to the user immediately.",
-          ].join("\n"),
-          type: "text",
-        },
-      ],
+      parts: [{ synthetic: true, text, type: "text" }],
       sessionID,
+      system: "Report the update to the user immediately.",
     })
   }
 
@@ -372,8 +362,12 @@ export class Magi {
       updatedAt: createdAt,
       ...initialState,
     }
+    const values = [this.createStateFile(state)]
 
-    await this.createStateFile(state)
+    if (!state.sync && state.text)
+      values.push(this.notify(state.sessionId, state.text))
+
+    await Promise.all(values)
 
     return state
   }


### PR DESCRIPTION
Closes #358

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Notify the parent session when a background Magi run is created, so users can see that review or merge work has started. This also keeps progress notification prompts short while preserving an immediate relay instruction.

## Current behavior (updates)

Background run start text is written to state, but the initial state creation does not notify the parent session. Magi progress notifications are wrapped in a longer synthetic message.

## New behavior

Initial background run text is sent as a Magi notification when the run is not synchronous. Progress notification payloads use the raw update text with a concise system instruction to report it immediately.

Docs were not updated because this is a notification delivery fix and does not change command options, configuration, or documented output formats.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validated with `pnpm typecheck`. This PR is intended to make the notification behavior easier to test in a real OpenCode session.