### PR TITLE
fix(review): revert background run start notification

### DIFF
--- a/.changeset/notify-background-run-start.md
+++ b/.changeset/notify-background-run-start.md
@@ -1,5 +1,0 @@
----
-"opencode-magi": patch
----
-
-Notify users when background Magi runs start.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -239,9 +239,19 @@ export class Magi {
 
   public async notify(sessionID: string, text: string): Promise<void> {
     await this.input.client.session.promptAsync({
-      parts: [{ synthetic: true, text, type: "text" }],
+      parts: [
+        {
+          synthetic: true,
+          text: [
+            "Magi notification:",
+            text,
+            "",
+            "Relay this update to the user immediately.",
+          ].join("\n"),
+          type: "text",
+        },
+      ],
       sessionID,
-      system: "Report the update to the user immediately.",
     })
   }
 
@@ -362,12 +372,8 @@ export class Magi {
       updatedAt: createdAt,
       ...initialState,
     }
-    const values = [this.createStateFile(state)]
 
-    if (!state.sync && state.text)
-      values.push(this.notify(state.sessionId, state.text))
-
-    await Promise.all(values)
+    await this.createStateFile(state)
 
     return state
   }


### PR DESCRIPTION
Closes #366

Reverts #366.

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Revert the notification changes that were accidentally merged in #366. This restores the previous Magi notification payload and removes the changeset from that PR.

## Current behavior (updates)

#366 is merged into `main`, adding background run start notifications and shortening the synthetic notification prompt.

## New behavior

The #366 changes are reverted. This PR does not resolve #358; it only restores the pre-#366 behavior so the notification fix can be reconsidered separately.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validated with `pnpm typecheck`.