### PR TITLE
fix(review): batch magi notifications

### DIFF
--- a/src/magi.ts
+++ b/src/magi.ts
@@ -125,6 +125,10 @@ export interface State {
 
 const active: Set<Status> = new Set(["preparing", "running"])
 const backgrounds = new Map<number, AbortController>()
+const notifications = new Map<
+  string,
+  { callback?: NodeJS.Timeout; texts: string[] }
+>()
 
 export class MagiError extends Error {
   constructor(
@@ -237,12 +241,27 @@ export class Magi {
     }
   }
 
-  public async notify(sessionID: string, text: string): Promise<void> {
-    await this.input.client.session.promptAsync({
-      parts: [{ synthetic: true, text, type: "text" }],
-      sessionID,
-      system: "Report the update to the user immediately.",
-    })
+  public notify(sessionID: string, text: string): void {
+    const notification = notifications.get(sessionID) ?? { texts: [] }
+
+    notification.texts.push(text)
+    notifications.set(sessionID, notification)
+
+    notification.callback ??= setTimeout(async () => {
+      const { texts } = notifications.get(sessionID)!
+
+      if (!texts.length) return
+
+      notifications.delete(sessionID)
+
+      try {
+        await this.input.client.session.promptAsync({
+          parts: texts.map((text) => ({ synthetic: true, text, type: "text" })),
+          sessionID,
+          system: "Report the update to the user immediately.",
+        })
+      } catch {}
+    }, 3000)
   }
 
   public async clear(config: Config.Root): Promise<{
@@ -362,12 +381,10 @@ export class Magi {
       updatedAt: createdAt,
       ...initialState,
     }
-    const values = [this.createStateFile(state)]
 
-    if (!state.sync && state.text)
-      values.push(this.notify(state.sessionId, state.text))
+    await this.createStateFile(state)
 
-    await Promise.all(values)
+    if (!state.sync && state.text) this.notify(state.sessionId, state.text)
 
     return state
   }
@@ -407,12 +424,10 @@ export class Magi {
 
     const prev = await this.getState(dir)
     const state = merge<State>(prev, next)
-    const values = [this.createStateFile(state)]
 
-    if (!state.sync && next.text)
-      values.push(this.notify(prev.sessionId, next.text))
+    await this.createStateFile(state)
 
-    await Promise.all(values)
+    if (!state.sync && next.text) this.notify(prev.sessionId, next.text)
 
     return state
   }

--- a/src/tools/merge/action.ts
+++ b/src/tools/merge/action.ts
@@ -19,10 +19,10 @@ export async function editCycles(
       return verdict
     },
     {
-      error: async (e, count) => {
+      error: (e, count) => {
         if (e !== error) throw e
 
-        await this.notify(
+        this.notify(
           `Attempt ${count} failed to edit cycles for ${this.getLink()}. Retrying...`,
         )
       },

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -95,7 +95,7 @@ export async function edit(this: Merge): Promise<boolean> {
     text: `Finished editing ${this.getLink()}.`,
   })
 
-  await this.notify(
+  this.notify(
     filterEmpty([
       `Editor ${output.mode === "EDITED" ? "edited" : "replied to"} ${this.getLink()}.`,
       output.commitSha

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -96,7 +96,7 @@ export async function postReviews(this: Review): Promise<void> {
       })
 
       if (!findings.length) {
-        await this.notify(`Finished posting reviews for ${this.getLink()}.`)
+        this.notify(`Finished posting reviews for ${this.getLink()}.`)
 
         return
       }
@@ -118,7 +118,7 @@ export async function postReviews(this: Review): Promise<void> {
       if (!this.state.operator?.sessionId)
         throw new MagiError("blocked", "Reporter session ID not found.")
 
-      await this.notify(`Generating comment for ${this.getLink()} by operator.`)
+      this.notify(`Generating comment for ${this.getLink()} by operator.`)
 
       const contents = JSON.stringify(
         reviewers.flatMap<PullRequestFinding | string>(([, { outputs }]) => {
@@ -175,7 +175,7 @@ export async function postReviews(this: Review): Promise<void> {
       if (!output)
         throw new MagiError("blocked", "Invalid output for operator.")
 
-      await this.notify(`Generated comment for ${this.getLink()} by operator.`)
+      this.notify(`Generated comment for ${this.getLink()} by operator.`)
 
       params.body = output
     }

--- a/src/tools/review/check.ts
+++ b/src/tools/review/check.ts
@@ -186,7 +186,7 @@ export async function classifyChecks(this: Review): Promise<void> {
         if (!sessionId)
           throw new Error(`No session ID found for reviewer ${id}.`)
 
-        await this.notify(
+        this.notify(
           `Classifying CI checks for ${this.getLink()} with reviewer ${id}.`,
         )
 
@@ -238,32 +238,30 @@ export async function classifyChecks(this: Review): Promise<void> {
     return { ...check, classifieds, scope }
   })
 
-  await Promise.all(
-    failed.map(async ({ classifieds, name, scope }) => {
-      const reasons = {
-        in: Object.entries(classifieds)
-          .filter(([, { scope }]) => scope)
-          .map(([id, { comment }]) => `- ${id}: ${comment}`),
-        out: Object.entries(classifieds)
-          .filter(([, { scope }]) => !scope)
-          .map(([id, { comment }]) => `- ${id}: ${comment}`),
-      }
+  failed.forEach(({ classifieds, name, scope }) => {
+    const reasons = {
+      in: Object.entries(classifieds)
+        .filter(([, { scope }]) => scope)
+        .map(([id, { comment }]) => `- ${id}: ${comment}`),
+      out: Object.entries(classifieds)
+        .filter(([, { scope }]) => !scope)
+        .map(([id, { comment }]) => `- ${id}: ${comment}`),
+    }
 
-      await this.notify(
-        filterEmpty([
-          scope
-            ? `Check ${name} for ${this.getLink()} was classified as in scope by majority vote.`
-            : `Check ${name} for ${this.getLink()} was classified as out of scope by majority vote. Rerunning it.`,
-          reasons.in.length
-            ? `In scope reasons:\n${reasons.in.join("\n")}`
-            : undefined,
-          reasons.out.length
-            ? `Out of scope reasons:\n${reasons.out.join("\n")}`
-            : undefined,
-        ]).join("\n\n"),
-      )
-    }),
-  )
+    this.notify(
+      filterEmpty([
+        scope
+          ? `Check ${name} for ${this.getLink()} was classified as in scope by majority vote.`
+          : `Check ${name} for ${this.getLink()} was classified as out of scope by majority vote. Rerunning it.`,
+        reasons.in.length
+          ? `In scope reasons:\n${reasons.in.join("\n")}`
+          : undefined,
+        reasons.out.length
+          ? `Out of scope reasons:\n${reasons.out.join("\n")}`
+          : undefined,
+      ]).join("\n\n"),
+    )
+  })
 
   this.state = await this.magi.updateState(this.state.output, {
     pr: { checks: { failed } },
@@ -300,7 +298,7 @@ export async function rerunChecks(this: Review): Promise<void> {
   } else {
     await retry(
       async () => {
-        await this.notify(`Rerunning checks ${label} for ${this.getLink()}.`)
+        this.notify(`Rerunning checks ${label} for ${this.getLink()}.`)
         await Promise.all(
           checks.failed
             .filter(({ scope }) => !scope)
@@ -360,7 +358,7 @@ export async function rerunChecks(this: Review): Promise<void> {
       : undefined,
   ]).join("\n")
 
-  if (message) await this.notify(message)
+  if (message) this.notify(message)
 
   this.state = await this.magi.updateState(this.state.output, {
     pr: { checks },

--- a/src/tools/review/review.ts
+++ b/src/tools/review/review.ts
@@ -113,8 +113,8 @@ export class Review {
   public automate = automate
   public createReport = createReport
 
-  public async notify(text: string): Promise<void> {
-    if (!this.state.sync) await this.magi.notify(this.state.sessionId, text)
+  public notify(text: string): void {
+    if (!this.state.sync) this.magi.notify(this.state.sessionId, text)
   }
 
   public async cleanup(): Promise<void> {

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -49,7 +49,7 @@ export async function review(this: Review): Promise<void> {
             this.state.reviewers[id]!
 
           if (status === "skip") {
-            await this.notify(
+            this.notify(
               `Skipping review for ${this.getLink()} with reviewer ${id}.`,
             )
 
@@ -70,7 +70,7 @@ export async function review(this: Review): Promise<void> {
             const label = rereview ? "rereview" : "review"
             const cycle = (outputs?.length ?? 0) + 1
 
-            await this.notify(
+            this.notify(
               `Running ${label} for ${this.getLink()} with reviewer ${id}.`,
             )
 
@@ -267,7 +267,7 @@ export async function validateFindings(this: Review): Promise<void> {
     ]),
   )
 
-  await notifyVerdictChanges.call(
+  notifyVerdictChanges.call(
     this,
     this.state.reviewers ?? {},
     reviewers,
@@ -345,7 +345,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
           )
           const repairMessage = await prompt.repair()
 
-          await this.notify(
+          this.notify(
             `Reconsidering close verdict for ${this.getLink()} with reviewer ${id}.`,
           )
 
@@ -418,7 +418,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
     },
   )
 
-  await notifyVerdictChanges.call(
+  notifyVerdictChanges.call(
     this,
     this.state.reviewers ?? {},
     reviewers,
@@ -433,7 +433,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
     ]),
   )
 
-  await notifyVerdictChanges.call(
+  notifyVerdictChanges.call(
     this,
     reviewers,
     validatedReviewers,
@@ -479,7 +479,7 @@ async function collectAcceptedFindings(
               `No session ID found for reviewer ${id}.`,
             )
 
-          await this.notify(
+          this.notify(
             `Validating review findings for ${this.getLink()} with reviewer ${id}.`,
           )
 
@@ -562,45 +562,42 @@ async function collectAcceptedFindings(
   )
   const threshold = Math.floor(this.config.review.reviewers.length / 2) + 1
 
-  await Promise.all(
-    findings.map(async ({ finding, index, reviewer }) => {
-      const votes = Object.entries(validations).flatMap(
-        ([validator, validation]) => {
-          if (validator === reviewer) return []
+  findings.forEach(({ finding, index, reviewer }) => {
+    const votes = Object.entries(validations).flatMap(
+      ([validator, validation]) => {
+        if (validator === reviewer) return []
 
-          const vote = validation.votes.find(
-            (vote) => vote.reviewer === reviewer && vote.index === index,
-          )
+        const vote = validation.votes.find(
+          (vote) => vote.reviewer === reviewer && vote.index === index,
+        )
 
-          return vote ? [{ validator, vote }] : []
-        },
-      )
-      const agrees =
-        1 + votes.filter(({ vote }) => vote.vote === "AGREE").length
-      const key = `${reviewer}:${index}`
-      const acceptedComments = votes
-        .filter(({ vote }) => vote.vote === "AGREE")
-        .map(({ validator, vote }) => `- ${validator}: ${vote.comment}`)
-      const rejectedComments = votes
-        .filter(({ vote }) => vote.vote === "DISAGREE")
-        .map(({ validator, vote }) => `- ${validator}: ${vote.comment}`)
+        return vote ? [{ validator, vote }] : []
+      },
+    )
+    const agrees = 1 + votes.filter(({ vote }) => vote.vote === "AGREE").length
+    const key = `${reviewer}:${index}`
+    const acceptedComments = votes
+      .filter(({ vote }) => vote.vote === "AGREE")
+      .map(({ validator, vote }) => `- ${validator}: ${vote.comment}`)
+    const rejectedComments = votes
+      .filter(({ vote }) => vote.vote === "DISAGREE")
+      .map(({ validator, vote }) => `- ${validator}: ${vote.comment}`)
 
-      if (agrees >= threshold) accepted.add(key)
+    if (agrees >= threshold) accepted.add(key)
 
-      await this.notify(
-        filterEmpty([
-          `Finding ${reviewer} #${index + 1} for ${this.getLink()} was ${agrees >= threshold ? "accepted" : "rejected"} by majority vote.`,
-          `Finding: ${finding.path}:${finding.line}\n${finding.body}`,
-          acceptedComments.length
-            ? `Accepted by:\n${acceptedComments.join("\n")}`
-            : undefined,
-          rejectedComments.length
-            ? `Rejected by:\n${rejectedComments.join("\n")}`
-            : undefined,
-        ]).join("\n\n"),
-      )
-    }),
-  )
+    this.notify(
+      filterEmpty([
+        `Finding ${reviewer} #${index + 1} for ${this.getLink()} was ${agrees >= threshold ? "accepted" : "rejected"} by majority vote.`,
+        `Finding: ${finding.path}:${finding.line}\n${finding.body}`,
+        acceptedComments.length
+          ? `Accepted by:\n${acceptedComments.join("\n")}`
+          : undefined,
+        rejectedComments.length
+          ? `Rejected by:\n${rejectedComments.join("\n")}`
+          : undefined,
+      ]).join("\n\n"),
+    )
+  })
 
   return accepted
 }
@@ -636,24 +633,22 @@ function transformState(
   return { ...reviewer, outputs }
 }
 
-async function notifyVerdictChanges(
+function notifyVerdictChanges(
   this: Review,
   prev: { [key: string]: ReviewerState },
   next: { [key: string]: ReviewerState },
   reason: string,
-): Promise<void> {
-  await Promise.all(
-    Object.entries(next).map(async ([id, reviewer]) => {
-      const prevVerdict = prev[id]?.outputs?.at(-1)?.verdict
-      const nextVerdict = reviewer.outputs?.at(-1)?.verdict
+): void {
+  Object.entries(next).forEach(([id, reviewer]) => {
+    const prevVerdict = prev[id]?.outputs?.at(-1)?.verdict
+    const nextVerdict = reviewer.outputs?.at(-1)?.verdict
 
-      if (!prevVerdict || !nextVerdict || prevVerdict === nextVerdict) return
+    if (!prevVerdict || !nextVerdict || prevVerdict === nextVerdict) return
 
-      await this.notify(
-        `Reviewer ${id} verdict changed from ${prevVerdict} to ${nextVerdict} for ${this.getLink()} ${reason}.`,
-      )
-    }),
-  )
+    this.notify(
+      `Reviewer ${id} verdict changed from ${prevVerdict} to ${nextVerdict} for ${this.getLink()} ${reason}.`,
+    )
+  })
 }
 
 function validateInlineCommentTargets(


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Batch Magi progress notifications per parent session before relaying them to the user. This reduces notification bursts while preserving each notification as a separate synthetic text part.

No changeset is included by request because this PR is intended for behavior verification.

## Current behavior (updates)

Each progress notification is sent to the parent session immediately. Large bursts of notifications can cause the orchestrating agent to skip, delay, or summarize updates.

## New behavior

Notifications are collected per session and sent together after a short delay. Notification dispatch is fire-and-forget, and send failures are ignored so background runs are not failed by notification delivery.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validated with `pnpm typecheck` and `pnpm format:check`. `.opencode/magi.json` has local unstaged changes and is intentionally not included.