### PR TITLE
fix(merge): combine editor completion events

### DIFF
--- a/.changeset/combine-editor-event.md
+++ b/.changeset/combine-editor-event.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Combine the editor completion and result into one event update.

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -89,11 +89,11 @@ export async function edit(this: Merge): Promise<boolean> {
   await this.updateState({
     editor: { outputs: [...(this.state.editor!.outputs ?? []), output] },
   })
-  await this.updateEvent(`Finished editing.`)
 
   await this.updateEvent(
     filterEmpty([
-      `Editor ${output.mode.toLocaleLowerCase()}.`,
+      `Finished editing.`,
+      `Result: ${output.mode.toLocaleLowerCase()}.`,
       output.commitSha
         ? `Commit: ${output.commitSha}${output.commitMessage ? ` ${output.commitMessage}` : ""}`
         : undefined,


### PR DESCRIPTION
Closes #371

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Combine the editor completion message and result details into a single event update.

## Current behavior (updates)

The merge editor emits separate `Finished editing.` and editor result event updates.

## New behavior

The merge editor emits one event update containing `Finished editing.`, the editor result, and any commit, file, or response details.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Added a patch changeset.
- Documentation was not updated because no existing documentation describes the exact event text.
- `pnpm test` passes with no test files found.
- Pre-commit lint, type checking, and formatting checks pass.
