### PR TITLE
feat(review): report reviewer results immediately

### DIFF
--- a/.changeset/report-reviewer-verdicts.md
+++ b/.changeset/report-reviewer-verdicts.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Report each reviewer verdict as soon as the review completes.

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -9,7 +9,14 @@ import type { ReviewerState } from "@/magi"
 import type { PromptTag } from "@/prompts"
 import { MagiError } from "@/magi"
 import { Prompt } from "@/prompts"
-import { filterEmpty, marker, omitNullish, retry, Worker } from "@/utils"
+import {
+  filterEmpty,
+  marker,
+  omitNullish,
+  retry,
+  toTitleCase,
+  Worker,
+} from "@/utils"
 
 interface Finding {
   finding: PullRequestFinding
@@ -190,6 +197,40 @@ export async function review(this: Review): Promise<void> {
                   status,
                   parsed,
                   inlineCommentTargets,
+                )
+
+                const findings = parsed.findings ?? parsed.newFindings ?? []
+
+                await this.updateEvent(
+                  filterEmpty([
+                    `Finished ${label} with reviewer ${id}.`,
+                    `Verdict: ${toTitleCase(parsed.verdict.toLocaleLowerCase())}.`,
+                    parsed.comment ? `Comment:\n${parsed.comment}` : undefined,
+                    findings.length
+                      ? `Findings:\n${findings
+                          .map(
+                            ({ body, line, path, startLine }) =>
+                              `- ${path}:${startLine != null ? `${startLine}-` : ""}${line}: ${body}`,
+                          )
+                          .join("\n")}`
+                      : undefined,
+                    parsed.followUps?.length
+                      ? `Follow-ups:\n${parsed.followUps
+                          .map(
+                            ({ body, commentId }) =>
+                              `- Comment ${commentId}: ${body}`,
+                          )
+                          .join("\n")}`
+                      : undefined,
+                    parsed.resolves?.length
+                      ? `Resolved threads:\n${parsed.resolves
+                          .map(
+                            ({ commentId, threadId }) =>
+                              `- Comment ${commentId} in thread ${threadId}`,
+                          )
+                          .join("\n")}`
+                      : undefined,
+                  ]).join("\n\n"),
                 )
 
                 return parsed

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -215,7 +215,7 @@ export async function review(this: Review): Promise<void> {
                           .join("\n")}`
                       : undefined,
                     parsed.followUps?.length
-                      ? `Follow-ups:\n${parsed.followUps
+                      ? `FollowUps:\n${parsed.followUps
                           .map(
                             ({ body, commentId }) =>
                               `- Comment ${commentId}: ${body}`,


### PR DESCRIPTION
Closes #373

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Report each reviewer result immediately after its output is validated.

## Current behavior (updates)

Individual reviewer results are not emitted as review events when each concurrent reviewer completes.

## New behavior

Each reviewer emits one event containing its title-cased verdict and any comment, findings, follow-ups, or resolved threads before returning its parsed output. Array details are formatted as Markdown bullet lists.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Added a minor changeset.
- Documentation was not updated because no existing documentation describes individual review event payloads.
- `pnpm test` passes with no test files found.
- Pre-commit lint, type checking, and formatting checks pass.
