### PR TITLE
docs(readme): fix documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ Run commands from OpenCode.
 
 ## Docs
 
-- [Commands](docs/commands/index.en.md)
-- [Config](docs/config.en.md)
+- [Commands](docs/commands/index.md)
+- [Config](docs/config.md)
 
 ## Contributing
 


### PR DESCRIPTION
Closes #375

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix the broken Commands and Config links in the README Docs section.

## Current behavior (updates)

The links point to `docs/commands/index.en.md` and `docs/config.en.md`, which do not exist.

## New behavior

The links point to the existing `docs/commands/index.md` and `docs/config.md` files.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validation: `pnpm format:check`
