### PR TITLE
fix(review): format verdict change events in title case

### DIFF
--- a/.changeset/title-case-verdict-events.md
+++ b/.changeset/title-case-verdict-events.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Format reviewer verdict change events in title case.

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -675,7 +675,7 @@ async function notifyVerdictChanges(
       if (!prevVerdict || !nextVerdict || prevVerdict === nextVerdict) return
 
       await this.updateEvent(
-        `Reviewer ${id} verdict changed from ${prevVerdict} to ${nextVerdict} ${reason}.`,
+        `Reviewer ${id} verdict changed from ${toTitleCase(prevVerdict.toLocaleLowerCase())} to ${toTitleCase(nextVerdict.toLocaleLowerCase())} ${reason}.`,
       )
     }),
   )


### PR DESCRIPTION
Closes #376

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Format reviewer verdict change events consistently with review reports.

## Current behavior (updates)

Verdict change events display raw enum values such as `CHANGES_REQUESTED` and `APPROVED`.

## New behavior

Verdict change events display title-cased values such as `Changes Requested` and `Approved` by using the existing `toTitleCase` utility.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Added a patch changeset.
- `pnpm test` passes with no test files found.
