### PR TITLE
fix(magi): cancel interrupted runs

### DIFF
--- a/.changeset/cancel-interrupted-merge.md
+++ b/.changeset/cancel-interrupted-merge.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Mark interrupted review and merge runs as cancelled and abort their OpenCode session requests.

--- a/src/magi.ts
+++ b/src/magi.ts
@@ -172,7 +172,7 @@ export class Magi {
     signal?: AbortSignal,
     account?: string,
   ): Promise<Octokit> {
-    const auth = await this.getGhToken(account)
+    const auth = await this.getGhToken(account, signal)
     const retries = config.github.retryApiAttempts
 
     return new Octokit({
@@ -400,21 +400,25 @@ export class Magi {
       model: Config.Model | undefined
       permissions?: Config.Permissions
     },
+    signal?: AbortSignal,
   ): Promise<string> {
     if (isArray(model) || !isObject(model)) throw new Error()
 
     const { id, variant } = model
     const [providerId, modelId] = id.split("/")
-    const result = await this.input.client.session.create({
-      model: {
-        id: modelId!,
-        providerID: providerId!,
-        variant,
+    const result = await this.input.client.session.create(
+      {
+        model: {
+          id: modelId!,
+          providerID: providerId!,
+          variant,
+        },
+        parentID,
+        permission: resolvePermissions(permissions),
+        title,
       },
-      parentID,
-      permission: resolvePermissions(permissions),
-      title,
-    })
+      { signal },
+    )
 
     if (result.error) {
       throw new Error(result.response.statusText)
@@ -425,11 +429,18 @@ export class Magi {
     }
   }
 
-  public async promptSession(sessionID: string, text: string): Promise<string> {
-    const result = await this.input.client.session.prompt({
-      parts: [{ text, type: "text" }],
-      sessionID,
-    })
+  public async promptSession(
+    sessionID: string,
+    text: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const result = await this.input.client.session.prompt(
+      {
+        parts: [{ text, type: "text" }],
+        sessionID,
+      },
+      { signal },
+    )
 
     if (result.error) {
       throw new Error(result.response.statusText)

--- a/src/tools/merge/action.ts
+++ b/src/tools/merge/action.ts
@@ -27,6 +27,7 @@ export async function editCycles(
         )
       },
       retries: this.config.merge.maxThreadResolutionCycles,
+      signal: this.context.abort,
     },
   )
 

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -82,6 +82,7 @@ export async function edit(this: Merge): Promise<boolean> {
       error: (_, count) =>
         this.updateEvent(`Attempt ${count} failed to edit. Retrying...`),
       retries: this.config.output.repairAttempts,
+      signal: this.context.abort,
     },
   )
 
@@ -236,6 +237,7 @@ export async function resolveConflict(this: Merge): Promise<void> {
           `Attempt ${count} failed to resolve conflicts. Retrying...`,
         ),
       retries: this.config.output.repairAttempts,
+      signal: this.context.abort,
     },
   )
 

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -49,6 +49,7 @@ export async function edit(this: Merge): Promise<boolean> {
       const raw = await this.magi.promptSession(
         this.state.editor!.sessionId!,
         count === 1 ? taskMessage : repairMessage,
+        this.context.abort,
       )
 
       await this.createAgentFile("edit", "editor", raw, count, cycle)
@@ -183,6 +184,7 @@ export async function resolveConflict(this: Merge): Promise<void> {
       const raw = await this.magi.promptSession(
         this.state.editor!.sessionId!,
         count === 1 ? taskMessage : repairMessage,
+        this.context.abort,
       )
 
       await this.createAgentFile("conflict", "editor", raw, count, cycle)
@@ -303,7 +305,10 @@ async function push(
   if (!this.state.worktree)
     throw new MagiError("blocked", "PR worktree not found.")
 
-  const token = await this.magi.getGhToken(this.state.editor.account)
+  const token = await this.magi.getGhToken(
+    this.state.editor.account,
+    this.context.abort,
+  )
   const url = `https://${this.config.github.host}/${this.state.pr.metadata.head.repo.owner.login}/${this.state.pr.metadata.head.repo.name}.git`
   const ref = `HEAD:refs/heads/${this.state.pr.metadata.head.ref}`
 

--- a/src/tools/merge/merge.ts
+++ b/src/tools/merge/merge.ts
@@ -4,7 +4,6 @@ import type { Magi } from "@/magi"
 import { join } from "node:path"
 import { MagiError } from "@/magi"
 import { Review } from "@/tools/review/review"
-import { createExecWithGitHubApiRetry, quote } from "@/utils"
 import { editCycles, postReplies } from "./action"
 import { fetchMergeContext, markRepliedReviewers } from "./context"
 import { edit, resolveConflict } from "./editor"
@@ -22,22 +21,12 @@ export class Merge extends Review {
     context: ToolContext,
     options: MergeOptions,
   ): Promise<Merge> {
-    const url = `${config.github.url}/pull/${number}`
-    const octokit = await magi.createOctokit(config, context.abort)
-    const graphql = magi.createGraphql(octokit)
-    const reviewers = Object.fromEntries(
-      config.review.reviewers!.map(
-        ({ account, id, model, permissions }) =>
-          [id, { account, model, permissions }] as const,
-      ),
+    const { exec, graphql, octokit, ...rest } = await this.setup(
+      number,
+      magi,
+      config,
+      context,
     )
-    const operator = config.review.operator
-      ? config.review.reviewers!.find(
-          ({ id }) => id === config.review.operator,
-        )!
-      : config.review.reviewers![
-          Math.abs(number) % config.review.reviewers!.length
-        ]!
     const editor = {
       account: config.merge.editor.account,
       author: config.merge.editor.author,
@@ -46,24 +35,10 @@ export class Merge extends Review {
     }
     const state = await magi.createState(
       join(config.review.output, number.toString()),
-      {
-        ...options,
-        command: "merge",
-        editor,
-        operator,
-        pr: { number, url },
-        repo: quote(`${config.github.owner}/${config.github.repo}`),
-        reviewers,
-        sessionId: context.sessionID,
-      },
+      { ...options, ...rest, command: "merge", editor },
     )
 
     await magi.updateEvent(state.output, `Started merging.`)
-
-    const exec = createExecWithGitHubApiRetry(
-      magi.exec,
-      config.github.retryApiAttempts,
-    )
 
     return new Merge(
       number,
@@ -100,6 +75,7 @@ export class Merge extends Review {
           model: this.state.editor.model,
           permissions: this.state.editor.permissions,
         },
+        this.context.abort,
       ),
     }
 

--- a/src/tools/merge/report.ts
+++ b/src/tools/merge/report.ts
@@ -10,6 +10,8 @@ import {
 import { filterEmpty, toTitleCase } from "@/utils"
 
 export async function createReport(this: Review, e?: unknown): Promise<string> {
+  this.context.abort.throwIfAborted()
+
   if (!e) {
     const status = "completed"
     const text = await createContent.call(this, { status })

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -150,6 +150,7 @@ export async function postReviews(this: Review): Promise<void> {
           const raw = await this.magi.promptSession(
             this.state.operator!.sessionId!,
             count === 1 ? taskMessage : repairMessage,
+            this.context.abort,
           )
 
           await this.createAgentFile("comment", "operator", raw, count)
@@ -350,7 +351,7 @@ export async function automate(this: Review): Promise<PullRequestAutomation> {
     return "SKIPPED"
   }
 
-  const token = await this.magi.getGhToken(account)
+  const token = await this.magi.getGhToken(account, this.context.abort)
 
   if (action === "merge" && !this.config.review.merge.queue) {
     const rules = JSON.parse(
@@ -618,7 +619,7 @@ async function waitMergeQueue(
     throw new MagiError("blocked", `PR left the merge queue before merging.`)
   }
 
-  await wait(30_000)
+  await wait(30_000, this.context.abort)
 
   return await waitMergeQueue.call(this, nextLeftMergeQueue)
 }

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -168,6 +168,7 @@ export async function postReviews(this: Review): Promise<void> {
               `Attempt ${count} failed to post comment by operator. Retrying...`,
             ),
           retries: this.config.output.repairAttempts,
+          signal: this.context.abort,
         },
       )
 

--- a/src/tools/review/check.ts
+++ b/src/tools/review/check.ts
@@ -201,6 +201,7 @@ export async function classifyChecks(this: Review): Promise<void> {
                 `Attempt ${count} failed to classify CI checks with reviewer ${id}. Retrying...`,
               ),
             retries: this.config.output.repairAttempts,
+            signal: this.context.abort,
           },
         )
 
@@ -328,6 +329,7 @@ export async function rerunChecks(this: Review): Promise<void> {
             `Attempt ${count} failed to rerun checks ${label}. Retrying...`,
           ),
         retries: this.config.review.checks.retryFailedJobs,
+        signal: this.context.abort,
       },
     )
   }

--- a/src/tools/review/check.ts
+++ b/src/tools/review/check.ts
@@ -183,6 +183,7 @@ export async function classifyChecks(this: Review): Promise<void> {
             const raw = await this.magi.promptSession(
               sessionId,
               count === 1 ? taskMessage : repairMessage,
+              this.context.abort,
             )
 
             await this.createAgentFile("ci-classification", id, raw, count)

--- a/src/tools/review/report.ts
+++ b/src/tools/review/report.ts
@@ -5,6 +5,8 @@ import { MagiError } from "@/magi"
 import { filterEmpty, toTitleCase } from "@/utils"
 
 export async function createReport(this: Review, e?: unknown): Promise<string> {
+  this.context.abort.throwIfAborted()
+
   if (!e) {
     const status = "completed"
     const text = await createContent.call(this, { status })

--- a/src/tools/review/review.ts
+++ b/src/tools/review/review.ts
@@ -3,7 +3,7 @@ import type { Octokit } from "octokit"
 import type { PullRequestVerdict } from "."
 import type { Config } from "@/config"
 import type { Graphql } from "@/graphql"
-import type { Event, Magi, State } from "@/magi"
+import type { AgentState, Event, Magi, ReviewerState, State } from "@/magi"
 import type { DeepPartial, Exec } from "@/utils"
 import { join } from "node:path"
 import { MagiError } from "@/magi"
@@ -45,6 +45,46 @@ export class Review {
     context: ToolContext,
     options: ReviewOptions,
   ): Promise<Review> {
+    const { exec, graphql, octokit, ...rest } = await this.setup(
+      number,
+      magi,
+      config,
+      context,
+    )
+    const state = await magi.createState(
+      join(config.review.output, number.toString()),
+      { ...options, ...rest, command: "review" },
+    )
+
+    await magi.updateEvent(state.output, `Started reviewing.`)
+
+    return new Review(
+      number,
+      magi,
+      config,
+      context,
+      octokit,
+      graphql,
+      exec,
+      state,
+    )
+  }
+
+  protected static async setup(
+    number: number,
+    magi: Magi,
+    config: Config.Root,
+    context: ToolContext,
+  ): Promise<{
+    exec: Exec
+    graphql: Graphql
+    octokit: Octokit
+    operator: AgentState
+    pr: { number: number; url: string }
+    repo: string
+    reviewers: { [key: string]: ReviewerState }
+    sessionId: string
+  }> {
     const url = `${config.github.url}/pull/${number}`
     const octokit = await magi.createOctokit(config, context.abort)
     const graphql = magi.createGraphql(octokit)
@@ -61,36 +101,21 @@ export class Review {
       : config.review.reviewers![
           Math.abs(number) % config.review.reviewers!.length
         ]!
-    const state = await magi.createState(
-      join(config.review.output, number.toString()),
-      {
-        ...options,
-        command: "review",
-        operator,
-        pr: { number, url },
-        repo: quote(`${config.github.owner}/${config.github.repo}`),
-        reviewers,
-        sessionId: context.sessionID,
-      },
-    )
-
-    await magi.updateEvent(state.output, `Started reviewing.`)
-
     const exec = createExecWithGitHubApiRetry(
       magi.exec,
       config.github.retryApiAttempts,
     )
 
-    return new Review(
-      number,
-      magi,
-      config,
-      context,
-      octokit,
-      graphql,
+    return {
       exec,
-      state,
-    )
+      graphql,
+      octokit,
+      operator,
+      pr: { number, url },
+      repo: quote(`${config.github.owner}/${config.github.repo}`),
+      reviewers,
+      sessionId: context.sessionID,
+    }
   }
 
   public checkPr = checkPr
@@ -107,6 +132,15 @@ export class Review {
   public createReport = createReport
 
   public async cleanup(): Promise<void> {
+    if (
+      this.context.abort.aborted &&
+      ["preparing", "running"].includes(this.state.status)
+    )
+      await this.updateState({
+        completedAt: new Date().toISOString(),
+        status: "cancelled",
+      })
+
     if (this.state.worktree?.path)
       await this.magi.deleteWorktree(this.state.worktree.path)
   }
@@ -159,6 +193,7 @@ export class Review {
                   this.state.sessionId,
                   `magi review #${this.number} ${id}`,
                   { model, permissions },
+                  this.context.abort,
                 ),
               },
             ] as const,
@@ -173,6 +208,7 @@ export class Review {
           model: this.state.operator.model,
           permissions: this.state.operator.permissions,
         },
+        this.context.abort,
       ),
     }
 

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -178,6 +178,7 @@ export async function review(this: Review): Promise<void> {
                 const raw = await this.magi.promptSession(
                   sessionId,
                   count === 1 ? taskMessage : repairMessage,
+                  this.context.abort,
                 )
 
                 await this.createAgentFile(
@@ -381,6 +382,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
               const raw = await this.magi.promptSession(
                 sessionId,
                 count === 1 ? taskMessage : repairMessage,
+                this.context.abort,
               )
 
               await this.createAgentFile(
@@ -532,6 +534,7 @@ async function collectAcceptedFindings(
               const raw = await this.magi.promptSession(
                 sessionId,
                 count === 1 ? taskMessage : repairMessage,
+                this.context.abort,
               )
 
               await this.createAgentFile("finding-validation", id, raw, count)

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -242,6 +242,7 @@ export async function review(this: Review): Promise<void> {
                     `Attempt ${count} failed to ${label} with reviewer ${id}. Retrying...`,
                   ),
                 retries: this.config.output.repairAttempts,
+                signal: this.context.abort,
               },
             )
 
@@ -414,6 +415,7 @@ export async function reconsiderClose(this: Review): Promise<void> {
                   `Attempt ${count} failed to reconsider close verdict with reviewer ${id}. Retrying...`,
                 ),
               retries: this.config.output.repairAttempts,
+              signal: this.context.abort,
             },
           )
 
@@ -574,6 +576,7 @@ async function collectAcceptedFindings(
                   `Attempt ${count} failed to validate review findings with reviewer ${id}. Retrying...`,
                 ),
               retries: this.config.output.repairAttempts,
+              signal: this.context.abort,
             },
           )
 

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -31,18 +31,23 @@ export async function loop<T>(
 export interface RetryOptions {
   error?: (e: unknown, count: number) => Promise<void> | void
   retries?: number
+  signal?: AbortSignal
 }
 
 export async function retry<T = void>(
   callback: (count: number) => Promise<T | void> | T | void,
-  { error, retries = 1 }: RetryOptions,
+  { error, retries = 1, signal }: RetryOptions,
 ): Promise<T | void> {
   let count = 1
 
   while (count <= retries)
     try {
+      signal?.throwIfAborted()
+
       return await callback(count)
     } catch (e) {
+      signal?.throwIfAborted()
+
       await error?.(e, count)
 
       count += 1

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -1,7 +1,19 @@
-export const wait = async (ms = 0): Promise<void> =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms)
+export function wait(ms = 0, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted()
+
+  return new Promise<void>((resolve, reject) => {
+    const abort = (): void => {
+      clearTimeout(timeout)
+      reject(signal?.reason)
+    }
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", abort)
+      resolve()
+    }, ms)
+
+    signal?.addEventListener("abort", abort, { once: true })
   })
+}
 
 export async function loop<T>(
   callback: () => Promise<T | void> | T | void,


### PR DESCRIPTION
Closes #380

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Ensure interrupted review and merge runs stop promptly and persist a cancelled status.

## Current behavior (updates)

Interrupting `/magi:review` or `/magi:merge` can leave `state.json` in the `running` state while non-abortable work continues.

## New behavior

Abort signals are propagated to OpenCode sessions, GitHub authentication, and merge queue waits. Active runs are marked `cancelled` during cleanup, and shared review/merge initialization is consolidated.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- `pnpm test` completed successfully with no test files found.
- Pre-commit lint, type checking, and formatting completed successfully.
- Documentation is unchanged because no command syntax or configuration changed.
