### PR TITLE
fix(review): restrict rereview thread replies

### DIFF
--- a/.changeset/fix-rereview-thread-ownership.md
+++ b/.changeset/fix-rereview-thread-ownership.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Prevent reviewers from replying to other reviewers' unresolved threads during re-review.

--- a/src/prompts/review/rereview/output-contract.md
+++ b/src/prompts/review/rereview/output-contract.md
@@ -15,6 +15,7 @@ Rules:
 - `"verdict"` must be `"APPROVED"`, `"CHANGES_REQUESTED"`, or `"CLOSED"`.
 - `"resolves"` contains threads that should be resolved because the issue is fixed or the user's explanation is acceptable.
 - Each `"resolves"` item must use the exact `"commentId"` and `"threadId"` from `<unresolved_threads>`.
+- Each `"followUps"` item must use a `"commentId"` from `<unresolved_threads>`.
 - Omit `"resolves"` when no thread should be resolved.
 - `"APPROVED"` may omit `"followUps"` and `"newFindings"`. If present, they must be empty.
 - `"APPROVED"` may omit `"comment"`. If present, it must be an empty string.

--- a/src/prompts/review/rereview/task.md
+++ b/src/prompts/review/rereview/task.md
@@ -3,11 +3,12 @@ The PR worktree is {worktreePath}.
 Validate whether your unresolved comments are fixed in the diff from {previousHeadSha} to {headSha} and in the review thread conversation.
 Use: git -C "{worktreePath}" diff {previousHeadSha}...{headSha}
 Your unresolved threads are provided in `<unresolved_threads>`.
+All review threads are provided in `<review>` for context, but only your unresolved threads may be resolved or receive followUps.
 
 If there is no new commit, still reconsider the thread when a user replied after your latest comment.
 If you agree with the user's explanation or the code is fixed, add the thread to `resolves`.
 If you do not agree, reply in the same thread with a followUp explaining why the issue still needs changes and keep `"CHANGES_REQUESTED"`.
-Do not duplicate an existing unresolved thread as a newFinding. Use newFindings only for separate new issues.
+Do not duplicate an issue already raised in any review thread as a newFinding. Use newFindings only for separate new issues.
 Every newFinding must target a valid right-side line in the PR diff.
 If the problem itself does not have an exact changed line, choose the nearest changed line that represents the cause, responsibility, missing implementation, or affected behavior. This includes but is not limited to missing validation, missing wiring, missing requirements, missing tests, missing documentation, affected configuration, or relevant call sites.
 Do not omit line. Do not create file-level or body-only newFindings.

--- a/src/tools/review/reviewer.ts
+++ b/src/tools/review/reviewer.ts
@@ -2,6 +2,7 @@ import type {
   FindingValidationOutput,
   PullRequestFinding,
   PullRequestReviewMarker,
+  PullRequestReviewThread,
   ReviewOutput,
 } from "./index.type"
 import type { Review } from "./review"
@@ -194,6 +195,7 @@ export async function review(this: Review): Promise<void> {
                 if (!prompt.validate<ReviewOutput>(parsed))
                   throw new Error(`Invalid output for reviewer ${id}.`)
 
+                validateThreadTargets(parsed, unresolvedThreads)
                 validateInlineCommentTargets(
                   status,
                   parsed,
@@ -727,4 +729,31 @@ function validateInlineCommentTargets(
           )
     }
   }
+}
+
+function validateThreadTargets(
+  { followUps, resolves }: ReviewOutput,
+  threads: PullRequestReviewThread[],
+): void {
+  const targets = new Map(
+    threads.flatMap(({ comments, id }) =>
+      comments.flatMap(({ databaseId }) =>
+        databaseId == null ? [] : [[databaseId, id] as const],
+      ),
+    ),
+  )
+
+  if (followUps)
+    for (const [index, { commentId }] of followUps.entries())
+      if (!targets.has(commentId))
+        throw new Error(
+          `followUps[${index}].commentId must target an unresolved thread owned by the reviewer.`,
+        )
+
+  if (resolves)
+    for (const [index, { commentId, threadId }] of resolves.entries())
+      if (targets.get(commentId) !== threadId)
+        throw new Error(
+          `resolves[${index}] must target an unresolved thread owned by the reviewer.`,
+        )
 }


### PR DESCRIPTION
Closes #382

## AI used

- [x] I checked the generated content before submitting.

## Description

Restrict re-review follow-ups and thread resolutions to the reviewer who owns the unresolved thread.

## Current behavior (updates)

After an editor pushes a commit, every reviewer re-reviews the PR. Since all review threads are visible in the context and follow-up targets are not validated, a reviewer can reply to another reviewer's unresolved thread.

## New behavior

All review threads remain available as context. Prompt instructions prevent duplicate findings, and output validation rejects follow-ups or resolutions that do not target the reviewer's own unresolved threads before they are posted.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Verified with `pnpm build`.
- Documentation is unchanged because this is an internal reviewer-output constraint and no public configuration or command interface changes.