### PR TITLE
chore(config): update Magi agent model IDs

### DIFF
--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -20,8 +20,7 @@
         "account": "balthasar-magi",
         "model": [
           {
-            "id": "opencode-go/mimo-v2.5-pro",
-            "variant": "high"
+            "id": "opencode-go/mimo-v2.5-pro"
           }
         ]
       },

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -10,7 +10,7 @@
         "account": "melchior-magi",
         "model": [
           {
-            "id": "opencode-go/minimax-m2.7",
+            "id": "opencode-go/minimax-m3",
             "variant": "high"
           }
         ]
@@ -20,7 +20,7 @@
         "account": "balthasar-magi",
         "model": [
           {
-            "id": "opencode-go/deepseek-v4-pro",
+            "id": "opencode-go/mimo-v2.5-pro",
             "variant": "high"
           }
         ]
@@ -30,7 +30,7 @@
         "account": "caspar-magi",
         "model": [
           {
-            "id": "opencode-go/qwen3.6-plus",
+            "id": "opencode-go/qwen3.7-plus",
             "variant": "high"
           }
         ]


### PR DESCRIPTION
Closes #389

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update stale configured agent model IDs.

## Current behavior (updates)

The Melchior, Balthasar, and Caspar agent configurations use unavailable model IDs.

## New behavior

Their configurations select currently supported OpenCode model IDs. The merge automation setting and Hirotomo Yamada's existing model remain unchanged.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validated with `jq empty .opencode/magi.json`.
