### PR TITLE
fix(merge): authenticate workflow pushes with PAT

### DIFF
--- a/.changeset/merge-pat-push-auth.md
+++ b/.changeset/merge-pat-push-auth.md
@@ -1,5 +1,0 @@
----
-"opencode-magi": patch
----
-
-Authenticate automated merge pushes with personal access tokens.

--- a/.changeset/merge-pat-push-auth.md
+++ b/.changeset/merge-pat-push-auth.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Use the PAT-compatible credential username for automated merge pushes.

--- a/.changeset/merge-pat-push-auth.md
+++ b/.changeset/merge-pat-push-auth.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Authenticate automated merge pushes with personal access tokens.

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -322,7 +322,7 @@ async function push(
       GIT_CONFIG_KEY_1: "credential.helper",
       GIT_CONFIG_VALUE_0: "",
       GIT_CONFIG_VALUE_1:
-        "!f() { echo username=x-access-token; echo password=$GIT_PASSWORD; }; f",
+        "!f() { echo username=git; echo password=$GIT_PASSWORD; }; f",
       GIT_PASSWORD: token,
       GIT_TERMINAL_PROMPT: "0",
     },


### PR DESCRIPTION
Closes #396

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use the PAT-compatible credential username for automated merge pushes.

## Current behavior (updates)

The merge editor supplies `x-access-token` as the credential username when pushing with the configured token.

## New behavior

The merge editor supplies `git` as the credential username while preserving the existing token and non-interactive push configuration.

## Is this a breaking change (Yes/No):

No.

## Additional Information

No documentation update is needed because this changes only internal Git credential wiring. Validated with `pnpm build`; PAT authentication requires GitHub Actions validation.
