### PR TITLE
fix(review): re-review replied threads

### DIFF
--- a/.changeset/fix-rereview-thread-replies.md
+++ b/.changeset/fix-rereview-thread-replies.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Trigger re-reviews when reviewers receive replies on their open threads.

--- a/src/tools/review/context.ts
+++ b/src/tools/review/context.ts
@@ -74,7 +74,7 @@ export async function checkExistingReviews(this: Review): Promise<boolean> {
       )
 
       if (!targetReviews.length) {
-        return [id, { status: "initial" }]
+        return [id, { account, status: "initial" }]
       } else {
         const latestReviews = targetReviews.filter(
           ({ submitted_at }) =>
@@ -86,8 +86,9 @@ export async function checkExistingReviews(this: Review): Promise<boolean> {
         )
         const review = targetReviews.at(-1)
 
-        if (latestReviews.length) return [id, { review, status: "skip" }]
-        else return [id, { review, status: "rereview" }]
+        if (latestReviews.length)
+          return [id, { account, review, status: "skip" }]
+        else return [id, { account, review, status: "rereview" }]
       }
     }),
   )


### PR DESCRIPTION
Closes #402

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Preserve reviewer accounts while determining whether existing review threads require a re-review.

## Current behavior (updates)

In multi mode, the derived reviewer state omits the reviewer account. Replies on an open reviewer thread are therefore not associated with that reviewer, and the prior verdict is reused.

## New behavior

Reviewer accounts remain available during existing-review checks, so a reply on an open reviewer thread schedules that reviewer for re-review.

## Is this a breaking change (Yes/No):

No.

## Additional Information

No documentation update is needed because this fixes the existing review workflow without changing commands or configuration. The pre-commit format, lint, type-check, and commit-message hooks passed. No test was added at the request of the user.
