### PR TITLE
test(utils): cover utility functions

### DIFF
--- a/src/utils/array.test.ts
+++ b/src/utils/array.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest"
+import { filterDuplicates, filterEmpty } from "./array"
+
+describe("filterDuplicates", () => {
+  test("removes duplicate values while preserving their first occurrence order", () => {
+    expect(
+      filterDuplicates(["beta", "alpha", "beta", "gamma", "alpha"]),
+    ).toStrictEqual(["beta", "alpha", "gamma"])
+  })
+
+  test("returns an empty array for an empty input", () => {
+    expect(filterDuplicates([])).toStrictEqual([])
+  })
+})
+
+describe("filterEmpty", () => {
+  test("removes null and undefined values", () => {
+    expect(filterEmpty([null, "value", undefined])).toStrictEqual(["value"])
+  })
+
+  test("preserves non-nullish falsy values", () => {
+    expect(filterEmpty([0, "", false])).toStrictEqual([0, "", false])
+  })
+})

--- a/src/utils/assertion.test.ts
+++ b/src/utils/assertion.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "vitest"
+import {
+  isArray,
+  isBoolean,
+  isDate,
+  isEmpty,
+  isEmptyObject,
+  isFunction,
+  isNull,
+  isNumber,
+  isObject,
+  isRegExp,
+  isString,
+  isUndefined,
+} from "./assertion"
+
+describe("isNumber", () => {
+  test("returns true for numbers", () => {
+    expect(isNumber(42)).toBeTruthy()
+  })
+
+  test("returns false for non-numbers", () => {
+    expect(isNumber("42")).toBeFalsy()
+  })
+})
+
+describe("isString", () => {
+  test("returns true for primitive and boxed strings", () => {
+    expect(isString("value")).toBeTruthy()
+    expect(isString(Object("value"))).toBeTruthy()
+  })
+
+  test("returns false for non-strings", () => {
+    expect(isString(42)).toBeFalsy()
+  })
+})
+
+describe("isBoolean", () => {
+  test("returns true for booleans", () => {
+    expect(isBoolean(false)).toBeTruthy()
+  })
+
+  test("returns false for non-booleans", () => {
+    expect(isBoolean(0)).toBeFalsy()
+  })
+})
+
+describe("isUndefined", () => {
+  test("returns true for undefined", () => {
+    expect(isUndefined(undefined)).toBeTruthy()
+  })
+
+  test("returns false for defined values", () => {
+    expect(isUndefined(null)).toBeFalsy()
+  })
+})
+
+describe("isNull", () => {
+  test("returns true for null", () => {
+    expect(isNull(null)).toBeTruthy()
+  })
+
+  test("returns false for non-null values", () => {
+    expect(isNull(undefined)).toBeFalsy()
+  })
+})
+
+describe("isRegExp", () => {
+  test("returns true for regular expressions", () => {
+    expect(isRegExp(/value/)).toBeTruthy()
+  })
+
+  test("returns false for non-regular expressions", () => {
+    expect(isRegExp("value")).toBeFalsy()
+  })
+})
+
+describe("isObject", () => {
+  test("returns true for objects and functions", () => {
+    expect(isObject({})).toBeTruthy()
+    expect(isObject(() => undefined)).toBeTruthy()
+  })
+
+  test("returns false for arrays", () => {
+    expect(isObject([])).toBeFalsy()
+  })
+
+  test("returns false for null and primitive values", () => {
+    expect(isObject(null)).toBeFalsy()
+    expect(isObject("value")).toBeFalsy()
+  })
+})
+
+describe("isDate", () => {
+  test("returns true for dates", () => {
+    expect(isDate(new Date("2026-01-01T00:00:00Z"))).toBeTruthy()
+  })
+
+  test("returns false for date strings", () => {
+    expect(isDate("2026-01-01T00:00:00Z")).toBeFalsy()
+  })
+})
+
+describe("isArray", () => {
+  test("returns true for arrays", () => {
+    expect(isArray([])).toBeTruthy()
+  })
+
+  test("returns false for non-arrays", () => {
+    expect(isArray({ length: 0 })).toBeFalsy()
+  })
+})
+
+describe("isEmpty", () => {
+  test("returns true for an empty array", () => {
+    expect(isEmpty([])).toBeTruthy()
+  })
+
+  test("returns true when every array value is nullish", () => {
+    expect(isEmpty([null, undefined])).toBeTruthy()
+  })
+
+  test("returns false when an array contains a non-nullish value", () => {
+    expect(isEmpty([null, 0])).toBeFalsy()
+  })
+})
+
+describe("isEmptyObject", () => {
+  test("returns true for an object without enumerable properties", () => {
+    expect(isEmptyObject({})).toBeTruthy()
+  })
+
+  test("returns false for an object with enumerable properties", () => {
+    expect(isEmptyObject({ value: undefined })).toBeFalsy()
+  })
+})
+
+describe("isFunction", () => {
+  test("returns true for functions", () => {
+    expect(isFunction(() => undefined)).toBeTruthy()
+  })
+
+  test("returns false for non-functions", () => {
+    expect(isFunction({})).toBeFalsy()
+  })
+})

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { createExec, execAsync } from "./exec"
+
+const { execAsyncMock } = vi.hoisted(() => ({ execAsyncMock: vi.fn() }))
+
+vi.mock("node:util", () => ({
+  promisify: (): typeof execAsyncMock => execAsyncMock,
+}))
+
+describe("execAsync", () => {
+  beforeEach(() => {
+    execAsyncMock.mockReset()
+  })
+
+  test("returns the promisified exec result", async () => {
+    const result = { stderr: "warning", stdout: "output" }
+
+    execAsyncMock.mockResolvedValue(result)
+
+    await expect(execAsync("command")).resolves.toBe(result)
+    expect(execAsyncMock).toHaveBeenCalledExactlyOnceWith("command")
+  })
+
+  test("propagates execution errors", async () => {
+    const error = new Error("execution failed")
+
+    execAsyncMock.mockRejectedValue(error)
+
+    await expect(execAsync("command")).rejects.toBe(error)
+  })
+})
+
+describe("createExec", () => {
+  beforeEach(() => {
+    execAsyncMock.mockReset()
+  })
+
+  test("uses the default directory and trims stdout", async () => {
+    execAsyncMock.mockResolvedValue({ stderr: "", stdout: "  output\n" })
+
+    const exec = createExec("/default")
+
+    await expect(exec("command")).resolves.toBe("output")
+    expect(execAsyncMock).toHaveBeenCalledExactlyOnceWith("command", {
+      cwd: "/default",
+      env: process.env,
+      maxBuffer: 1024 * 1024 * 20,
+      signal: undefined,
+    })
+  })
+
+  test("forwards directory, environment, and abort signal overrides", async () => {
+    execAsyncMock.mockResolvedValue({ stderr: "", stdout: "output" })
+
+    const controller = new AbortController()
+    const exec = createExec("/default")
+
+    await exec("command", {
+      cwd: "/override",
+      env: { TEST_EXEC_VALUE: "value" },
+      signal: controller.signal,
+    })
+
+    expect(execAsyncMock).toHaveBeenCalledExactlyOnceWith("command", {
+      cwd: "/override",
+      env: { ...process.env, TEST_EXEC_VALUE: "value" },
+      maxBuffer: 1024 * 1024 * 20,
+      signal: controller.signal,
+    })
+  })
+
+  test("propagates execution errors", async () => {
+    const error = new Error("execution failed")
+
+    execAsyncMock.mockRejectedValue(error)
+
+    await expect(createExec("/default")("command")).rejects.toBe(error)
+  })
+})

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -1,0 +1,97 @@
+import { resolve } from "node:path"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { rm } from "./fs"
+
+const fs = vi.hoisted(() => ({
+  originalRm: vi.fn(),
+  readdir: vi.fn(),
+  rmdir: vi.fn(),
+}))
+
+vi.mock("node:fs/promises", () => ({
+  readdir: fs.readdir,
+  rm: fs.originalRm,
+  rmdir: fs.rmdir,
+}))
+
+describe("rm", () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test("removes the target with the supplied options without pruning by default", async () => {
+    fs.originalRm.mockResolvedValue(undefined)
+
+    await rm("target", { force: true, recursive: true })
+
+    expect(fs.originalRm).toHaveBeenCalledWith("target", {
+      force: true,
+      recursive: true,
+    })
+    expect(fs.readdir).not.toHaveBeenCalled()
+    expect(fs.rmdir).not.toHaveBeenCalled()
+  })
+
+  test("prunes empty ancestors in order and stops at a non-empty directory", async () => {
+    fs.originalRm.mockResolvedValue(undefined)
+    fs.readdir.mockResolvedValueOnce([]).mockResolvedValueOnce(["remaining"])
+    fs.rmdir.mockResolvedValue(undefined)
+
+    const parent = resolve(process.cwd(), "root", "parent")
+    const root = resolve(process.cwd(), "root")
+
+    await rm(resolve(parent, "target"), { prune: true })
+
+    expect(fs.readdir).toHaveBeenNthCalledWith(1, parent)
+    expect(fs.rmdir).toHaveBeenCalledExactlyOnceWith(parent)
+    expect(fs.readdir).toHaveBeenNthCalledWith(2, root)
+  })
+
+  test("uses a string prune root and never removes that root", async () => {
+    fs.originalRm.mockResolvedValue(undefined)
+    fs.readdir.mockResolvedValue([])
+    fs.rmdir.mockResolvedValue(undefined)
+
+    const root = resolve(process.cwd(), "root")
+    const parent = resolve(root, "parent")
+
+    await rm(resolve(parent, "target"), { prune: root })
+
+    expect(fs.readdir).toHaveBeenCalledExactlyOnceWith(parent)
+    expect(fs.rmdir).toHaveBeenCalledExactlyOnceWith(parent)
+  })
+
+  test("does not inspect ancestors outside the prune root", async () => {
+    fs.originalRm.mockResolvedValue(undefined)
+
+    const root = resolve(process.cwd(), "root")
+    const target = resolve(process.cwd(), "outside", "target")
+
+    await rm(target, { prune: root })
+
+    expect(fs.readdir).not.toHaveBeenCalled()
+    expect(fs.rmdir).not.toHaveBeenCalled()
+  })
+
+  test("stops pruning when inspecting an ancestor fails", async () => {
+    fs.originalRm.mockResolvedValue(undefined)
+    fs.readdir.mockRejectedValue(new Error("unavailable"))
+
+    const root = resolve(process.cwd(), "root")
+
+    await expect(
+      rm(resolve(root, "parent", "target"), { prune: root }),
+    ).resolves.toBeUndefined()
+    expect(fs.rmdir).not.toHaveBeenCalled()
+  })
+
+  test("propagates target removal errors without attempting to prune", async () => {
+    const error = new Error("removal failed")
+
+    fs.originalRm.mockRejectedValue(error)
+
+    await expect(rm("target", { prune: true })).rejects.toBe(error)
+    expect(fs.readdir).not.toHaveBeenCalled()
+    expect(fs.rmdir).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/function.test.ts
+++ b/src/utils/function.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { loop, retry, wait } from "./function"
+
+describe("wait", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test("resolves after the requested delay and removes the abort listener", async () => {
+    vi.useFakeTimers()
+
+    const controller = new AbortController()
+    const removeEventListener = vi.spyOn(
+      controller.signal,
+      "removeEventListener",
+    )
+    const result = wait(100, controller.signal)
+
+    await vi.advanceTimersByTimeAsync(99)
+    expect(removeEventListener).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(result).resolves.toBeUndefined()
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    )
+  })
+
+  test("rejects with the reason when aborted while waiting", async () => {
+    vi.useFakeTimers()
+
+    const controller = new AbortController()
+    const reason = new Error("cancelled")
+    const result = wait(100, controller.signal)
+
+    controller.abort(reason)
+
+    await expect(result).rejects.toBe(reason)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  test("throws the reason when the signal is already aborted", () => {
+    const controller = new AbortController()
+    const reason = new Error("already cancelled")
+
+    controller.abort(reason)
+
+    expect(() => wait(100, controller.signal)).toThrow(reason)
+  })
+})
+
+describe("loop", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("repeats synchronous and asynchronous nullish results until a value is returned", async () => {
+    vi.useFakeTimers()
+
+    const callback = vi
+      .fn()
+      .mockReturnValueOnce(undefined)
+      .mockResolvedValueOnce(null)
+      .mockReturnValueOnce("complete")
+    const result = loop(callback, 100)
+
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toBe("complete")
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  test("propagates callback errors", async () => {
+    const error = new Error("failed")
+
+    await expect(
+      loop(() => {
+        throw error
+      }),
+    ).rejects.toBe(error)
+  })
+})
+
+describe("retry", () => {
+  test("returns the first successful result with the attempt context", async () => {
+    const callback = vi.fn().mockReturnValue("complete")
+
+    await expect(retry(callback, { retries: 3 })).resolves.toBe("complete")
+    expect(callback).toHaveBeenCalledExactlyOnceWith(1, undefined)
+  })
+
+  test("reports failures and passes the previous error to the next attempt", async () => {
+    const firstError = new Error("first")
+    const secondError = new Error("second")
+    const callback = vi
+      .fn()
+      .mockRejectedValueOnce(firstError)
+      .mockImplementationOnce(() => {
+        throw secondError
+      })
+      .mockResolvedValueOnce("complete")
+    const onError = vi.fn().mockResolvedValue(undefined)
+
+    await expect(retry(callback, { error: onError, retries: 3 })).resolves.toBe(
+      "complete",
+    )
+    expect(callback).toHaveBeenNthCalledWith(1, 1, undefined)
+    expect(callback).toHaveBeenNthCalledWith(2, 2, firstError)
+    expect(callback).toHaveBeenNthCalledWith(3, 3, secondError)
+    expect(onError).toHaveBeenNthCalledWith(1, firstError, 1)
+    expect(onError).toHaveBeenNthCalledWith(2, secondError, 2)
+  })
+
+  test("resolves undefined after all attempts fail", async () => {
+    const error = new Error("failed")
+    const callback = vi.fn().mockRejectedValue(error)
+
+    await expect(retry(callback, { retries: 2 })).resolves.toBeUndefined()
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  test("propagates error callback failures", async () => {
+    const callbackError = new Error("callback failed")
+    const errorCallbackError = new Error("error callback failed")
+
+    await expect(
+      retry(
+        () => {
+          throw callbackError
+        },
+        {
+          error: () => {
+            throw errorCallbackError
+          },
+          retries: 2,
+        },
+      ),
+    ).rejects.toBe(errorCallbackError)
+  })
+
+  test("propagates an existing abort without running the callback", async () => {
+    const controller = new AbortController()
+    const reason = new Error("cancelled")
+    const callback = vi.fn()
+
+    controller.abort(reason)
+
+    await expect(
+      retry(callback, { retries: 2, signal: controller.signal }),
+    ).rejects.toBe(reason)
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  test("prefers an abort reason over a callback error", async () => {
+    const controller = new AbortController()
+    const reason = new Error("cancelled")
+    const onError = vi.fn()
+
+    await expect(
+      retry(
+        () => {
+          controller.abort(reason)
+
+          throw new Error("failed")
+        },
+        { error: onError, retries: 2, signal: controller.signal },
+      ),
+    ).rejects.toBe(reason)
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/github.test.ts
+++ b/src/utils/github.test.ts
@@ -1,0 +1,159 @@
+import type { Exec } from "./exec"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { createExecWithGitHubApiRetry, parseIssues, parsePrs } from "./github"
+
+describe("parseIssues", () => {
+  test("parses issue numbers, references, and URLs", () => {
+    expect(
+      parseIssues("12, #34 https://github.com/magi-ai/opencode-magi/issues/56"),
+    ).toStrictEqual([12, 34, 56])
+  })
+
+  test("ignores values that do not end in an issue number", () => {
+    expect(parseIssues("issue-twelve invalid #34-extra 56")).toStrictEqual([56])
+  })
+
+  test("throws when no issue numbers are present", () => {
+    expect(() => parseIssues("invalid input")).toThrow(
+      "Specify one or more issue numbers or issue URLs.",
+    )
+  })
+})
+
+describe("parsePrs", () => {
+  test("parses PR numbers, references, and URLs", () => {
+    expect(
+      parsePrs("12, #34 https://github.com/magi-ai/opencode-magi/pull/56"),
+    ).toStrictEqual([12, 34, 56])
+  })
+
+  test("stops parsing when command options begin", () => {
+    expect(parsePrs("12 34 --merge 56 #78")).toStrictEqual([12, 34])
+  })
+
+  test("throws when no PR numbers are present", () => {
+    expect(() => parsePrs("--merge 12")).toThrow(
+      "Specify one or more PR numbers or PR URLs.",
+    )
+  })
+})
+
+describe("createExecWithGitHubApiRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("returns successful command output without retrying", async () => {
+    const exec = vi.fn<Exec>().mockResolvedValue("output")
+    const retryingExec = createExecWithGitHubApiRetry(exec, 2)
+
+    await expect(retryingExec("gh api repos/example")).resolves.toBe("output")
+    expect(exec).toHaveBeenCalledExactlyOnceWith(
+      "gh api repos/example",
+      undefined,
+    )
+  })
+
+  test.each([
+    ["a non-GitHub command", "git status", new Error("rate limit exceeded")],
+    [
+      "an unsupported GitHub command",
+      "gh issue list",
+      new Error("rate limit exceeded"),
+    ],
+    ["a non-rate-limit error", "gh api repos/example", new Error("not found")],
+  ])("propagates %s without retrying", async (_label, command, error) => {
+    const exec = vi.fn<Exec>().mockRejectedValue(error)
+    const retryingExec = createExecWithGitHubApiRetry(exec, 2)
+
+    await expect(retryingExec(command)).rejects.toBe(error)
+    expect(exec).toHaveBeenCalledExactlyOnceWith(command, undefined)
+  })
+
+  test("retries eligible commands with exponential backoff", async () => {
+    const exec = vi
+      .fn<Exec>()
+      .mockRejectedValueOnce({ stderr: "API rate limit exceeded" })
+      .mockRejectedValueOnce({ stdout: "RATE LIMIT" })
+      .mockResolvedValue("output")
+    const retryingExec = createExecWithGitHubApiRetry(exec, 2, 100)
+    const result = retryingExec("prefix gh pr view 12")
+
+    await vi.advanceTimersByTimeAsync(99)
+    expect(exec).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(exec).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(199)
+    expect(exec).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(result).resolves.toBe("output")
+    expect(exec).toHaveBeenCalledTimes(3)
+  })
+
+  test("propagates the final error after retry attempts are exhausted", async () => {
+    const firstError = new Error("rate limit first")
+    const finalError = new Error("rate limit final")
+    const exec = vi
+      .fn<Exec>()
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(finalError)
+    const retryingExec = createExecWithGitHubApiRetry(exec, 1, 50)
+    const result = retryingExec("gh auth status")
+
+    void result.catch(() => undefined)
+
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(result).rejects.toBe(finalError)
+    expect(exec).toHaveBeenCalledTimes(2)
+  })
+
+  test("retries immediately when the delay is zero", async () => {
+    const exec = vi
+      .fn<Exec>()
+      .mockRejectedValueOnce(new Error("rate limit exceeded"))
+      .mockResolvedValue("output")
+    const retryingExec = createExecWithGitHubApiRetry(exec, 1, 0)
+
+    await expect(retryingExec("gh run view 12")).resolves.toBe("output")
+    expect(exec).toHaveBeenCalledTimes(2)
+  })
+
+  test("aborts before waiting when the signal is already aborted", async () => {
+    const exec = vi
+      .fn<Exec>()
+      .mockRejectedValue(new Error("rate limit exceeded"))
+    const controller = new AbortController()
+
+    controller.abort()
+
+    const retryingExec = createExecWithGitHubApiRetry(exec, 1, 100)
+
+    await expect(
+      retryingExec("gh api repos/example", { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+    expect(exec).toHaveBeenCalledTimes(1)
+  })
+
+  test("aborts while waiting for the next retry", async () => {
+    const exec = vi
+      .fn<Exec>()
+      .mockRejectedValue(new Error("rate limit exceeded"))
+    const controller = new AbortController()
+    const retryingExec = createExecWithGitHubApiRetry(exec, 1, 100)
+    const result = retryingExec("gh api repos/example", {
+      signal: controller.signal,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    controller.abort()
+
+    await expect(result).rejects.toMatchObject({ name: "AbortError" })
+    expect(exec).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/utils/object.test.ts
+++ b/src/utils/object.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest"
+import { filterObject, merge, omitNullish } from "./object"
+
+describe("merge", () => {
+  test("recursively merges nested objects", () => {
+    expect(
+      merge(
+        { enabled: true, nested: { left: 1, shared: "base" } },
+        { nested: { right: 2, shared: "override" } },
+      ),
+    ).toStrictEqual({
+      enabled: true,
+      nested: { left: 1, right: 2, shared: "override" },
+    })
+  })
+
+  test("replaces values that are not objects on both sides", () => {
+    expect(
+      merge(
+        { mode: { name: "base" }, values: [1] },
+        { mode: "override", values: [2] },
+      ),
+    ).toStrictEqual({ mode: "override", values: [2] })
+  })
+
+  test("does not mutate either input", () => {
+    const base = { nested: { left: 1 } }
+    const override = { nested: { right: 2 } }
+
+    merge(base, override)
+
+    expect(base).toStrictEqual({ nested: { left: 1 } })
+    expect(override).toStrictEqual({ nested: { right: 2 } })
+  })
+})
+
+describe("filterObject", () => {
+  test("keeps entries accepted by the predicate", () => {
+    expect(
+      filterObject({ first: 1, second: 2 }, (_, value) => value > 1),
+    ).toStrictEqual({
+      second: 2,
+    })
+  })
+
+  test("passes each key, value, and the source object to the predicate", () => {
+    const source = { first: 1 }
+    const calls: unknown[][] = []
+
+    filterObject(source, (...args) => {
+      calls.push(args)
+
+      return true
+    })
+
+    expect(calls).toStrictEqual([["first", 1, source]])
+  })
+})
+
+describe("omitNullish", () => {
+  test("removes nullish entries while preserving other falsy values", () => {
+    expect(
+      omitNullish({ empty: "", false: false, null: null, undefined, zero: 0 }),
+    ).toStrictEqual({ empty: "", false: false, zero: 0 })
+  })
+})

--- a/src/utils/opencode.test.ts
+++ b/src/utils/opencode.test.ts
@@ -1,0 +1,141 @@
+import type { Provider } from "@opencode-ai/sdk/v2"
+import type { PluginInput } from "./opencode"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { getModels } from "./opencode"
+
+const { createExecMock, execMock } = vi.hoisted(() => {
+  const execMock = vi.fn()
+
+  return { createExecMock: vi.fn(() => execMock), execMock }
+})
+
+vi.mock("./exec", () => ({ createExec: createExecMock }))
+
+function createInput(): PluginInput {
+  return {
+    $: vi.fn() as unknown as PluginInput["$"],
+    client: createOpencodeClient({ baseUrl: "http://localhost" }),
+    directory: "/repo",
+    experimental_workspace: { register: vi.fn() },
+    project: { id: "project", time: { created: 0 }, worktree: "/repo" },
+    serverUrl: new URL("http://localhost"),
+    worktree: "/repo",
+  }
+}
+
+function createProvider(id: string, modelIds: string[]): Provider {
+  return {
+    env: [],
+    id,
+    models: Object.fromEntries(
+      modelIds.map((modelId) => [modelId, {} as Provider["models"][string]]),
+    ),
+    name: id,
+    options: {},
+    source: "config",
+  }
+}
+
+function createRequest(): Request {
+  return new Request("http://localhost")
+}
+
+describe("getModels", () => {
+  beforeEach(() => {
+    createExecMock.mockClear()
+    execMock.mockReset()
+  })
+
+  test("returns configured provider models", async () => {
+    const input = createInput()
+    const providers = vi
+      .spyOn(input.client.config, "providers")
+      .mockResolvedValue({
+        data: {
+          default: {},
+          providers: [
+            createProvider("anthropic", ["opus", "sonnet"]),
+            createProvider("", ["local"]),
+          ],
+        },
+        error: undefined,
+        request: createRequest(),
+        response: new Response(),
+      })
+    const list = vi
+      .spyOn(input.client.provider, "list")
+      .mockRejectedValue(new Error("unexpected provider list call"))
+
+    await expect(getModels(input)).resolves.toStrictEqual([
+      "anthropic/opus",
+      "anthropic/sonnet",
+      "local",
+    ])
+    expect(providers).toHaveBeenCalledExactlyOnceWith({ directory: "/repo" })
+    expect(list).not.toHaveBeenCalled()
+    expect(createExecMock).not.toHaveBeenCalled()
+  })
+
+  test("falls back to the provider list endpoint", async () => {
+    const input = createInput()
+
+    vi.spyOn(input.client.config, "providers").mockRejectedValue(
+      new Error("unsupported"),
+    )
+
+    const list = vi.spyOn(input.client.provider, "list").mockResolvedValue({
+      data: {
+        all: [createProvider("openai", ["gpt"])],
+        connected: [],
+        default: {},
+      },
+      error: undefined,
+      request: createRequest(),
+      response: new Response(),
+    })
+
+    await expect(getModels(input)).resolves.toStrictEqual(["openai/gpt"])
+    expect(list).toHaveBeenCalledExactlyOnceWith({ directory: "/repo" })
+    expect(createExecMock).not.toHaveBeenCalled()
+  })
+
+  test("falls back to the CLI and filters non-model output", async () => {
+    const input = createInput()
+
+    vi.spyOn(input.client.config, "providers").mockResolvedValue({
+      data: { default: {}, providers: [] },
+      error: undefined,
+      request: createRequest(),
+      response: new Response(),
+    })
+    vi.spyOn(input.client.provider, "list").mockRejectedValue(
+      new Error("unexpected provider list call"),
+    )
+    execMock.mockResolvedValue("anthropic/sonnet\nheading\nopenai/gpt")
+
+    await expect(getModels(input)).resolves.toStrictEqual([
+      "anthropic/sonnet",
+      "openai/gpt",
+    ])
+    expect(createExecMock).toHaveBeenCalledExactlyOnceWith("/repo")
+    expect(execMock).toHaveBeenCalledExactlyOnceWith("opencode models")
+  })
+
+  test("returns an empty array when provider data is unavailable and the CLI fails", async () => {
+    const input = createInput()
+
+    vi.spyOn(input.client.config, "providers").mockResolvedValue({
+      data: undefined,
+      error: { data: { message: "unavailable" }, name: "BadRequest" },
+      request: createRequest(),
+      response: new Response(),
+    })
+    vi.spyOn(input.client.provider, "list").mockRejectedValue(
+      new Error("unexpected provider list call"),
+    )
+    execMock.mockRejectedValue(new Error("CLI unavailable"))
+
+    await expect(getModels(input)).resolves.toStrictEqual([])
+  })
+})

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest"
+import { command, marker, quote, split, toTitleCase } from "./string"
+
+describe("quote", () => {
+  test("wraps a value in single quotes", () => {
+    expect(quote("hello world")).toBe("'hello world'")
+  })
+
+  test("escapes embedded single quotes for a shell command", () => {
+    expect(quote("it's ready")).toBe("'it'\\''s ready'")
+  })
+})
+
+describe("split", () => {
+  test("splits on comma and whitespace sequences", () => {
+    expect(split("alpha, beta\ngamma\tdelta")).toStrictEqual([
+      "alpha",
+      "beta",
+      "gamma",
+      "delta",
+    ])
+  })
+
+  test("returns a single value unchanged", () => {
+    expect(split("alpha")).toStrictEqual(["alpha"])
+  })
+})
+
+describe("toTitleCase", () => {
+  test("separates camel case words", () => {
+    expect(toTitleCase("pullRequestReview")).toBe("Pull Request Review")
+  })
+
+  test("converts snake and kebab case separators", () => {
+    expect(toTitleCase("pull_request-review")).toBe("Pull Request Review")
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(toTitleCase("  Ready  ")).toBe("Ready")
+  })
+})
+
+describe("command", () => {
+  test("joins command parts with spaces", () => {
+    expect(command("gh", "pr", "view", 42)).toBe("gh pr view 42")
+  })
+
+  test("omits nullish parts while preserving other falsy values", () => {
+    expect(command("run", null, 0, false, undefined)).toBe("run 0 false")
+  })
+})
+
+describe("marker.parse", () => {
+  test("parses all markers and preserves equals signs in values", () => {
+    expect(
+      marker.parse(
+        "before <!-- opencode-magi command=review token=left=right --> after\n<!-- opencode-magi status=ready -->",
+      ),
+    ).toStrictEqual([
+      { command: "review", token: "left=right" },
+      { status: "ready" },
+    ])
+  })
+
+  test("ignores malformed marker attributes", () => {
+    expect(
+      marker.parse("<!-- opencode-magi valid=yes invalid =missing -->"),
+    ).toStrictEqual([{ valid: "yes" }])
+  })
+
+  test("returns an empty array when no marker is present", () => {
+    expect(marker.parse("plain text")).toStrictEqual([])
+  })
+})
+
+describe("marker.stringify", () => {
+  test("serializes marker attributes in insertion order", () => {
+    expect(marker.stringify({ command: "review", reviewer: "alpha" })).toBe(
+      "<!-- opencode-magi command=review reviewer=alpha -->",
+    )
+  })
+
+  test("joins multiple markers with newlines", () => {
+    expect(marker.stringify({ first: 1 }, { second: 2 })).toBe(
+      "<!-- opencode-magi first=1 -->\n<!-- opencode-magi second=2 -->",
+    )
+  })
+})

--- a/src/utils/worker.test.ts
+++ b/src/utils/worker.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test, vi } from "vitest"
+import { Worker } from "./worker"
+
+interface Deferred<T> {
+  promise: Promise<T>
+  reject: (error: unknown) => void
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let reject!: (error: unknown) => void
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    reject = promiseReject
+    resolve = promiseResolve
+  })
+
+  return { promise, reject, resolve }
+}
+
+describe("Worker.run", () => {
+  test("runs up to the concurrency limit and starts queued tasks in FIFO order", async () => {
+    const worker = new Worker<string>(2)
+    const first = deferred<string>()
+    const second = deferred<string>()
+    const third = deferred<string>()
+    const fourth = deferred<string>()
+    const started: string[] = []
+    const firstResult = worker.run(() => {
+      started.push("first")
+
+      return first.promise
+    })
+    const secondResult = worker.run(() => {
+      started.push("second")
+
+      return second.promise
+    })
+    const thirdResult = worker.run(() => {
+      started.push("third")
+
+      return third.promise
+    })
+    const fourthResult = worker.run(() => {
+      started.push("fourth")
+
+      return fourth.promise
+    })
+
+    expect(started).toStrictEqual(["first", "second"])
+
+    second.resolve("second result")
+    await expect(secondResult).resolves.toBe("second result")
+    await Promise.resolve()
+    expect(started).toStrictEqual(["first", "second", "third"])
+
+    first.resolve("first result")
+    await expect(firstResult).resolves.toBe("first result")
+    await Promise.resolve()
+    expect(started).toStrictEqual(["first", "second", "third", "fourth"])
+
+    third.resolve("third result")
+    fourth.resolve("fourth result")
+    await expect(thirdResult).resolves.toBe("third result")
+    await expect(fourthResult).resolves.toBe("fourth result")
+  })
+
+  test("normalizes fractional and non-positive limits to one active task", async () => {
+    const worker = new Worker<void>(0.5)
+    const first = deferred<void>()
+    const second = vi.fn().mockResolvedValue(undefined)
+    const firstResult = worker.run(() => first.promise)
+    const secondResult = worker.run(second)
+
+    expect(second).not.toHaveBeenCalled()
+
+    first.resolve(undefined)
+    await firstResult
+    await Promise.resolve()
+    await expect(secondResult).resolves.toBeUndefined()
+    expect(second).toHaveBeenCalledOnce()
+  })
+
+  test("continues with the next queued task after a rejection", async () => {
+    const worker = new Worker<string>(1)
+    const first = deferred<string>()
+    const error = new Error("failed")
+    const second = vi.fn().mockResolvedValue("complete")
+    const firstResult = worker.run(() => first.promise)
+    const secondResult = worker.run(second)
+
+    void firstResult.catch(() => undefined)
+
+    expect(second).not.toHaveBeenCalled()
+
+    first.reject(error)
+    await expect(firstResult).rejects.toBe(error)
+    await Promise.resolve()
+    await expect(secondResult).resolves.toBe("complete")
+    expect(second).toHaveBeenCalledOnce()
+  })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,8 @@
 import { vi } from "vitest"
 
 vi.mock("@opencode-ai/sdk/v2", () => ({
-  createOpencodeClient: vi.fn(),
+  createOpencodeClient: vi.fn(() => ({
+    config: { providers: vi.fn() },
+    provider: { list: vi.fn() },
+  })),
 }))


### PR DESCRIPTION
Closes: N/A (test-only change; no issue created)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add focused unit tests for every runtime export in `src/utils`, excluding the barrel and type-only index files.

## Current behavior (updates)

The utility modules do not have colocated unit tests.

## New behavior

Each utility module has a matching `.test.ts` file, with function-specific `describe` blocks covering pure helpers, async control flow, filesystem behavior, command execution, GitHub retries, OpenCode model resolution, and worker concurrency. External commands and API behavior are mocked.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- `pnpm test` (94 tests)
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm type:check`