### PR TITLE
fix(review): continue existing merge queue entries

### DIFF
--- a/.changeset/ignore-existing-merge-queue.md
+++ b/.changeset/ignore-existing-merge-queue.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Continue waiting when a pull request is already in the merge queue.

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -11,6 +11,7 @@ import { Prompt } from "@/prompts"
 import {
   command,
   filterEmpty,
+  ignoreError,
   isArray,
   isObject,
   isString,
@@ -403,7 +404,15 @@ export async function automate(this: Review): Promise<PullRequestAutomation> {
     const graphql = this.magi.createGraphql(octokit)
     const enqueuedAt = new Date().toISOString()
 
-    await graphql.enqueuePullRequest({ id: this.state.pr.metadata.node_id })
+    await ignoreError(
+      () =>
+        graphql.enqueuePullRequest({ id: this.state.pr!.metadata!.node_id }),
+      (e) => {
+        const message = e instanceof Error ? e.message : String(e)
+
+        return /pull request is already in the queue/i.test(message)
+      },
+    )
     await this.updateEvent(`Waiting for merge queue.`)
 
     const result = await waitMergeQueue.call(this, enqueuedAt)
@@ -643,9 +652,17 @@ async function waitMergeQueue(
       await this.updateEvent(
         `Attempt ${attempt} failed to merge from the merge queue. Retrying...`,
       )
-      await this.graphql.enqueuePullRequest({
-        id: this.state.pr.metadata.node_id,
-      })
+      await ignoreError(
+        () =>
+          this.graphql.enqueuePullRequest({
+            id: this.state.pr!.metadata!.node_id,
+          }),
+        (e) => {
+          const message = e instanceof Error ? e.message : String(e)
+
+          return /pull request is already in the queue/i.test(message)
+        },
+      )
 
       return await waitMergeQueue.call(this, nextEnqueuedAt, false, attempt)
     }

--- a/src/utils/function.test.ts
+++ b/src/utils/function.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { ignoreError } from "./function"
+
+describe("ignoreError", () => {
+  test("returns undefined when the error matches the callback", async () => {
+    const error = new Error("expected")
+
+    await expect(
+      ignoreError(
+        () => Promise.reject(error),
+        (e) => e === error,
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  test("rethrows errors that do not match the callback", async () => {
+    const error = new Error("unexpected")
+
+    await expect(
+      ignoreError(
+        () => Promise.reject(error),
+        () => false,
+      ),
+    ).rejects.toThrow(error)
+  })
+})

--- a/src/utils/function.test.ts
+++ b/src/utils/function.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, test } from "vitest"
 import { ignoreError } from "./function"
 
 describe("ignoreError", () => {

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -15,6 +15,17 @@ export function wait(ms = 0, signal?: AbortSignal): Promise<void> {
   })
 }
 
+export async function ignoreError<T>(
+  cb: () => Promise<T> | T,
+  shouldIgnore: (e: unknown) => boolean,
+): Promise<T | undefined> {
+  try {
+    return await cb()
+  } catch (e) {
+    if (!shouldIgnore(e)) throw e
+  }
+}
+
 export async function loop<T>(
   cb: () => Promise<T | void> | T | void,
   ms = 0,


### PR DESCRIPTION
Closes #410

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Treat an already-enqueued pull request as an expected merge queue state.

## Current behavior (updates)

Merge automation fails when GitHub rejects a duplicate `enqueuePullRequest` request for a pull request already in the merge queue.

## New behavior

Merge automation ignores only the existing-queue error and continues waiting for the merge queue. Other enqueue errors are still propagated.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Added the reusable `ignoreError` utility with predicate-based error handling.
- Verified with `pnpm vitest run src/utils/function.test.ts`.
