### PR TITLE
fix(merge): skip bot-created pull requests

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -69,8 +69,10 @@ jobs:
             const usernames = new Set([context.actor]);
 
             if (context.eventName === "pull_request") {
+              if (context.payload.pull_request.user.type === "Bot") return false;
               usernames.add(context.payload.pull_request.user.login);
             } else if (context.eventName === "issue_comment") {
+              if (context.payload.issue.user.type === "Bot") return false;
               usernames.add(context.payload.issue.user.login);
               usernames.add(context.payload.comment.user.login);
             } else {


### PR DESCRIPTION
Closes #417

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Prevent the Merge workflow from processing pull requests created by bots.

## Current behavior (updates)

The actor check accepts bot-created pull requests when the bot account is older than 30 days, allowing the Merge job to run.

## New behavior

The actor check rejects pull requests whose author type is `Bot`, both for pull request events and `/merge` comments.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Reproduced by #406.
- `pnpm quality` passes with 182 tests.
- `pnpm build` passes.
- The workflow YAML parses successfully.
