### PR TITLE
docs(pr): make issue references optional

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -3,6 +3,6 @@
 Read the [template](/.github/pull_request_template.md) and use its structure for the PR body. Replace the HTML comments with actual content.
 
 - Use the same format as the commit message for the title.
-- Always include `Closes #<issue-number>`.
+- Include `Closes #<issue-number>` when the PR resolves an issue.
 - Clearly state whether this is a breaking change.
 - The template includes an "AI used" section. If AI generated the PR, uncheck "I did not use AI" and check "I checked the generated content before submitting."


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Makes issue references optional for pull requests that do not resolve an issue.

## Current behavior (updates)

Every pull request is required to include a `Closes #<issue-number>` reference.

## New behavior

A closing issue reference is required only when the pull request resolves an issue.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validated with `pnpm format:check`.