### PR TITLE
test(commands): add pull request E2E scenarios

### DIFF
--- a/.agents/rules/test.md
+++ b/.agents/rules/test.md
@@ -7,7 +7,7 @@ Follow these rules when creating or modifying automated tests.
 - Add unit tests for individual functions, class methods, config resolution, config validation, prompt composition, output parsing, report formatting, and other isolated behavior.
 - Add integration or flow tests for orchestration across modules, command sequencing, retries, safety gates, run state, review flow, merge flow, triage flow, and CI handling.
 - Add scenario tests when a user-visible command crosses multiple decisions or long-running phases.
-- Name command scenario suites `scenario: /magi:<command>` and keep their fixtures explicit in the test file.
+- Name command scenario suites `magi:<command>`, such as `magi:review` or `magi:merge`, and keep their fixtures explicit in the test file.
 - Do not use a broad flow test as a substitute for focused unit tests of the functions it depends on.
 
 ## File Placement

--- a/src/tools/merge/index.e2e.test.ts
+++ b/src/tools/merge/index.e2e.test.ts
@@ -1,0 +1,185 @@
+import type { ToolContext } from "@opencode-ai/plugin"
+import type { Event, State } from "@/magi"
+import { access, readdir, readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { test } from "#/fixtures/magi"
+import {
+  createGitHubFixture,
+  createPullRequestConfig,
+  createPullRequestExec,
+  createPullRequestMetadata,
+  createRepository,
+  PULL_REQUEST,
+  REVIEWERS,
+} from "#/fixtures/pull-request"
+import { marker } from "@/utils"
+import { merge } from "."
+
+async function readEvents(output: string): Promise<Event[]> {
+  return (await readFile(join(output, "events.jsonl"), "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Event)
+}
+
+describe("magi:merge", () => {
+  describe.each(["single", "multi"] as const)("%s mode", (mode) => {
+    test("completes an approved run without an edit cycle", async ({
+      createMagi,
+      temporaryDirectory,
+    }) => {
+      const repository = await createRepository(temporaryDirectory)
+      const config = createPullRequestConfig(temporaryDirectory, mode)
+      const github = createGitHubFixture(
+        createPullRequestMetadata(temporaryDirectory, repository),
+        PULL_REQUEST,
+      )
+      const { client, magi } = createMagi({ directory: temporaryDirectory })
+      const ghCommands: string[] = []
+      const rawReview = JSON.stringify({ verdict: "APPROVED" })
+      const context = {
+        abort: new AbortController().signal,
+        sessionID: "parent-session",
+      } as ToolContext
+
+      magi.exec = createPullRequestExec(repository, PULL_REQUEST, ghCommands)
+      client.session.create
+        .mockResolvedValueOnce({ data: { id: "reviewer-one-session" } })
+        .mockResolvedValueOnce({ data: { id: "reviewer-two-session" } })
+        .mockResolvedValueOnce({ data: { id: "reviewer-three-session" } })
+        .mockResolvedValueOnce({ data: { id: "operator-session" } })
+      client.session.prompt.mockResolvedValue({
+        data: { parts: [{ text: rawReview, type: "text" }] },
+      })
+
+      const getConfig = vi.spyOn(magi, "getConfig").mockResolvedValue(config)
+      const createOctokit = vi
+        .spyOn(magi, "createOctokit")
+        .mockResolvedValue(github.octokit)
+      const createGraphql = vi
+        .spyOn(magi, "createGraphql")
+        .mockReturnValue(github.graphql)
+      const mergeTool = merge(magi).magi_merge
+
+      if (!mergeTool) throw new Error("Merge tool not found.")
+
+      const result = await mergeTool.execute(
+        { prs: PULL_REQUEST.number.toString() },
+        context,
+      )
+
+      if (typeof result !== "string")
+        throw new Error("Merge tool did not return a report.")
+
+      const report = result
+      const numberOutput = join(
+        config.review.output,
+        PULL_REQUEST.number.toString(),
+      )
+      const entries = await readdir(numberOutput, { withFileTypes: true })
+      const runs = entries.filter((entry) => entry.isDirectory())
+
+      expect(runs).toHaveLength(1)
+
+      const output = join(numberOutput, runs[0]!.name)
+      const state = JSON.parse(
+        await readFile(join(output, "state.json"), "utf8"),
+      ) as State
+      const events = await readEvents(output)
+      const persistedReport = await readFile(join(output, "report.md"), "utf8")
+
+      expect(getConfig).toHaveBeenCalledWith({ editor: true, reviewers: true })
+      expect(createOctokit).toHaveBeenCalledTimes(mode === "single" ? 2 : 4)
+      expect(createGraphql).toHaveBeenCalledTimes(mode === "single" ? 2 : 4)
+      expect(client.session.create).toHaveBeenCalledTimes(4)
+      expect(client.session.prompt).toHaveBeenCalledTimes(3)
+      expect(client.session.prompt.mock.calls[0]![0].parts[0]!.text).toContain(
+        "<output_contract>",
+      )
+      expect(github.createReview).toHaveBeenCalledTimes(
+        mode === "single" ? 1 : 3,
+      )
+      expect(github.createReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "APPROVE",
+          owner: PULL_REQUEST.owner,
+          pull_number: PULL_REQUEST.number,
+          repo: PULL_REQUEST.repo,
+        }),
+      )
+
+      const reviewBodies = github.createReview.mock.calls
+        .map(([input]) => input.body)
+        .join("\n")
+
+      for (const reviewer of REVIEWERS)
+        expect(reviewBodies).toContain(
+          marker.stringify({
+            command: "review",
+            reviewer,
+            verdict: "APPROVED",
+          }),
+        )
+
+      expect(ghCommands).toStrictEqual([
+        "gh pr checks 123 --repo 'magi-ai/opencode-magi' --json name,state,bucket,link,workflow --required",
+        "gh pr checkout 123 --detach",
+      ])
+      expect(state.command).toBe("merge")
+      expect(state.status).toBe("completed")
+      expect(state.pr?.verdict).toBe("APPROVED")
+      expect(state.pr?.automation).toBe("SKIPPED")
+      expect(state.pr?.files).toStrictEqual(["reviewed.txt"])
+      expect(state.editor?.account).toBe(
+        mode === "single" ? "review-bot" : "editor-account",
+      )
+      expect(state.editor?.outputs).toBeUndefined()
+
+      for (const reviewer of REVIEWERS) {
+        expect(state.reviewers?.[reviewer]?.outputs).toStrictEqual([
+          { verdict: "APPROVED" },
+        ])
+        expect(state.reviewers?.[reviewer]?.posted).toBe(
+          "https://github.com/magi-ai/opencode-magi/pull/123#review",
+        )
+        await expect(
+          readFile(join(output, `${reviewer}-review-1-1.md`), "utf8"),
+        ).resolves.toBe(rawReview)
+      }
+
+      expect(events.map(({ message }) => message)).toStrictEqual(
+        expect.arrayContaining([
+          "Started merging.",
+          "Checking PR.",
+          "Finished checking PR.",
+          "Fetching existing reviews.",
+          "Finished fetching existing reviews.",
+          "Checking CI.",
+          "Finished checking CI.",
+          "Creating worktree.",
+          "Finished creating worktree.",
+          "Fetching review context.",
+          "Finished fetching review context.",
+          "Reviewing.",
+          "Running review with reviewer reviewer-one.",
+          "Running review with reviewer reviewer-two.",
+          "Running review with reviewer reviewer-three.",
+          "Finished reviewing.",
+          "Final verdict is APPROVED.",
+          "Posting reviews.",
+          "Finished posting reviews.",
+          "Skipped merge automation.",
+        ]),
+      )
+      expect(persistedReport).toBe(`${report}\n`)
+      expect(report).toContain("- **Status**: Completed")
+      expect(report).toContain("- **Verdict**: Approved")
+      expect(report).toContain("- **Automation**: Skipped")
+      expect(report).not.toContain("- **Editor**:")
+      expect(state.worktree?.path).toBeTypeOf("string")
+      await expect(access(state.worktree!.path)).rejects.toMatchObject({
+        code: "ENOENT",
+      })
+    })
+  })
+})

--- a/src/tools/merge/index.e2e.test.ts
+++ b/src/tools/merge/index.e2e.test.ts
@@ -22,7 +22,7 @@ async function readEvents(output: string): Promise<Event[]> {
     .map((line) => JSON.parse(line) as Event)
 }
 
-describe("magi:merge", () => {
+describe("scenario: /magi:merge", () => {
   describe.each(["single", "multi"] as const)("%s mode", (mode) => {
     test("completes an approved run without an edit cycle", async ({
       createMagi,

--- a/src/tools/merge/index.e2e.test.ts
+++ b/src/tools/merge/index.e2e.test.ts
@@ -22,7 +22,7 @@ async function readEvents(output: string): Promise<Event[]> {
     .map((line) => JSON.parse(line) as Event)
 }
 
-describe("scenario: /magi:merge", () => {
+describe("magi:merge", () => {
   describe.each(["single", "multi"] as const)("%s mode", (mode) => {
     test("completes an approved run without an edit cycle", async ({
       createMagi,

--- a/src/tools/review/index.e2e.test.ts
+++ b/src/tools/review/index.e2e.test.ts
@@ -1,0 +1,183 @@
+import type { ToolContext } from "@opencode-ai/plugin"
+import type { Event, State } from "@/magi"
+import { access, readdir, readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { test } from "#/fixtures/magi"
+import {
+  createGitHubFixture,
+  createPullRequestConfig,
+  createPullRequestExec,
+  createPullRequestMetadata,
+  createRepository,
+  PULL_REQUEST,
+  REVIEWERS,
+} from "#/fixtures/pull-request"
+import { marker } from "@/utils"
+import { review } from "."
+
+async function readEvents(output: string): Promise<Event[]> {
+  return (await readFile(join(output, "events.jsonl"), "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Event)
+}
+
+describe("magi:review", () => {
+  describe.each(["single", "multi"] as const)("%s mode", (mode) => {
+    test("completes an approved review and persists its artifacts", async ({
+      createMagi,
+      temporaryDirectory,
+    }) => {
+      const repository = await createRepository(temporaryDirectory)
+      const config = createPullRequestConfig(temporaryDirectory, mode)
+      const github = createGitHubFixture(
+        createPullRequestMetadata(temporaryDirectory, repository),
+        PULL_REQUEST,
+      )
+      const { client, magi } = createMagi({ directory: temporaryDirectory })
+      const ghCommands: string[] = []
+      const rawReview = JSON.stringify({ verdict: "APPROVED" })
+      const context = {
+        abort: new AbortController().signal,
+        sessionID: "parent-session",
+      } as ToolContext
+
+      magi.exec = createPullRequestExec(repository, PULL_REQUEST, ghCommands)
+      client.session.create
+        .mockResolvedValueOnce({ data: { id: "reviewer-one-session" } })
+        .mockResolvedValueOnce({ data: { id: "reviewer-two-session" } })
+        .mockResolvedValueOnce({ data: { id: "reviewer-three-session" } })
+        .mockResolvedValueOnce({ data: { id: "operator-session" } })
+      client.session.prompt.mockResolvedValue({
+        data: { parts: [{ text: rawReview, type: "text" }] },
+      })
+
+      const getConfig = vi.spyOn(magi, "getConfig").mockResolvedValue(config)
+      const createOctokit = vi
+        .spyOn(magi, "createOctokit")
+        .mockResolvedValue(github.octokit)
+      const createGraphql = vi
+        .spyOn(magi, "createGraphql")
+        .mockReturnValue(github.graphql)
+      const reviewTool = review(magi).magi_review
+
+      if (!reviewTool) throw new Error("Review tool not found.")
+
+      const result = await reviewTool.execute(
+        { prs: PULL_REQUEST.number.toString() },
+        context,
+      )
+
+      if (typeof result !== "string")
+        throw new Error("Review tool did not return a report.")
+
+      const report = result
+      const numberOutput = join(
+        config.review.output,
+        PULL_REQUEST.number.toString(),
+      )
+      const entries = await readdir(numberOutput, { withFileTypes: true })
+      const runs = entries.filter((entry) => entry.isDirectory())
+
+      expect(runs).toHaveLength(1)
+
+      const output = join(numberOutput, runs[0]!.name)
+      const state = JSON.parse(
+        await readFile(join(output, "state.json"), "utf8"),
+      ) as State
+      const events = await readEvents(output)
+      const persistedReport = await readFile(join(output, "report.md"), "utf8")
+
+      expect(getConfig).toHaveBeenCalledWith({ reviewers: true })
+      expect(createOctokit).toHaveBeenCalledTimes(mode === "single" ? 2 : 4)
+      expect(createGraphql).toHaveBeenCalledTimes(mode === "single" ? 2 : 4)
+      expect(client.session.create).toHaveBeenCalledTimes(4)
+      expect(client.session.prompt).toHaveBeenCalledTimes(3)
+      expect(client.session.prompt.mock.calls[0]![0].parts[0]!.text).toContain(
+        "<output_contract>",
+      )
+      expect(github.createReview).toHaveBeenCalledTimes(
+        mode === "single" ? 1 : 3,
+      )
+      expect(github.createReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "APPROVE",
+          owner: "magi-ai",
+          pull_number: PULL_REQUEST.number,
+          repo: PULL_REQUEST.repo,
+        }),
+      )
+
+      const reviewBodies = github.createReview.mock.calls
+        .map(([input]) => input.body)
+        .join("\n")
+
+      for (const reviewer of REVIEWERS)
+        expect(reviewBodies).toContain(
+          marker.stringify({
+            command: "review",
+            reviewer,
+            verdict: "APPROVED",
+          }),
+        )
+
+      expect(ghCommands).toStrictEqual([
+        "gh pr checks 123 --repo 'magi-ai/opencode-magi' --json name,state,bucket,link,workflow --required",
+        "gh pr checkout 123 --detach",
+      ])
+      expect(state.status).toBe("completed")
+      expect(state.pr?.verdict).toBe("APPROVED")
+      expect(state.pr?.automation).toBe("SKIPPED")
+      expect(state.pr?.files).toStrictEqual(["reviewed.txt"])
+
+      for (const reviewer of REVIEWERS) {
+        expect(state.reviewers?.[reviewer]?.outputs).toStrictEqual([
+          { verdict: "APPROVED" },
+        ])
+        expect(state.reviewers?.[reviewer]?.posted).toBe(
+          "https://github.com/magi-ai/opencode-magi/pull/123#review",
+        )
+        await expect(
+          readFile(join(output, `${reviewer}-review-1-1.md`), "utf8"),
+        ).resolves.toBe(rawReview)
+      }
+
+      expect(events.map(({ message }) => message)).toStrictEqual(
+        expect.arrayContaining([
+          "Started reviewing.",
+          "Checking PR.",
+          "Finished checking PR.",
+          "Fetching existing reviews.",
+          "Finished fetching existing reviews.",
+          "Checking CI.",
+          "Finished checking CI.",
+          "Creating worktree.",
+          "Finished creating worktree.",
+          "Fetching review context.",
+          "Finished fetching review context.",
+          "Reviewing.",
+          "Running review with reviewer reviewer-one.",
+          "Running review with reviewer reviewer-two.",
+          "Running review with reviewer reviewer-three.",
+          "Finished review with reviewer reviewer-one.\n\nVerdict: Approved.",
+          "Finished review with reviewer reviewer-two.\n\nVerdict: Approved.",
+          "Finished review with reviewer reviewer-three.\n\nVerdict: Approved.",
+          "Finished reviewing.",
+          "Final verdict is APPROVED.",
+          "Posting reviews.",
+          "Finished posting reviews.",
+          "Skipped merge automation.",
+        ]),
+      )
+      expect(persistedReport).toBe(`${report}\n`)
+      expect(report).toContain("- **Status**: Completed")
+      expect(report).toContain("- **Verdict**: Approved")
+      expect(report).toContain("- **Automation**: Skipped")
+      expect(report).toContain("- **Reviewer**:")
+      expect(state.worktree?.path).toBeTypeOf("string")
+      await expect(access(state.worktree!.path)).rejects.toMatchObject({
+        code: "ENOENT",
+      })
+    })
+  })
+})

--- a/src/tools/review/index.e2e.test.ts
+++ b/src/tools/review/index.e2e.test.ts
@@ -22,7 +22,7 @@ async function readEvents(output: string): Promise<Event[]> {
     .map((line) => JSON.parse(line) as Event)
 }
 
-describe("scenario: /magi:review", () => {
+describe("magi:review", () => {
   describe.each(["single", "multi"] as const)("%s mode", (mode) => {
     test("completes an approved review and persists its artifacts", async ({
       createMagi,

--- a/src/tools/review/index.e2e.test.ts
+++ b/src/tools/review/index.e2e.test.ts
@@ -22,7 +22,7 @@ async function readEvents(output: string): Promise<Event[]> {
     .map((line) => JSON.parse(line) as Event)
 }
 
-describe("magi:review", () => {
+describe("scenario: /magi:review", () => {
   describe.each(["single", "multi"] as const)("%s mode", (mode) => {
     test("completes an approved review and persists its artifacts", async ({
       createMagi,

--- a/test/fixtures/pull-request.ts
+++ b/test/fixtures/pull-request.ts
@@ -1,0 +1,238 @@
+import type { Octokit } from "octokit"
+import type { Config } from "@/config"
+import type { Graphql } from "@/graphql"
+import type { PullRequestMetadata } from "@/tools/review"
+import type { Exec } from "@/utils"
+import { writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { DEFAULT_CONFIG } from "@/constant"
+import { createExec } from "@/utils"
+
+export const PULL_REQUEST = {
+  number: 123,
+  owner: "magi-ai",
+  repo: "opencode-magi",
+} as const
+export const REVIEWERS = [
+  "reviewer-one",
+  "reviewer-two",
+  "reviewer-three",
+] as const
+
+export interface RepositoryFixture {
+  baseSha: string
+  exec: Exec
+  headSha: string
+}
+
+export interface GitHubFixture {
+  createReplyForReviewComment: ReturnType<typeof vi.fn>
+  createReview: ReturnType<typeof vi.fn>
+  get: ReturnType<typeof vi.fn>
+  graphql: Graphql
+  graphqlPaginate: ReturnType<typeof vi.fn>
+  octokit: Octokit
+  octokitPaginate: ReturnType<typeof vi.fn>
+  resolveReviewThread: ReturnType<typeof vi.fn>
+}
+
+export interface PullRequestTarget {
+  number: number
+  owner: string
+  repo: string
+}
+
+export function createPullRequestConfig(
+  directory: string,
+  mode: Config.Mode,
+): Config.Root {
+  const config = structuredClone(DEFAULT_CONFIG)
+
+  config.account = "review-bot"
+  config.github.owner = PULL_REQUEST.owner
+  config.github.repo = PULL_REQUEST.repo
+  config.github.url = `https://github.com/${PULL_REQUEST.owner}/${PULL_REQUEST.repo}`
+  config.merge.automation.close = false
+  config.merge.automation.conflict = false
+  config.merge.automation.merge = false
+  config.merge.editor = {
+    account: mode === "single" ? "review-bot" : "editor-account",
+    author: { email: "editor@example.com", name: "Editor" },
+    model: { id: "test/editor" },
+    permissions: "allow",
+  }
+  config.mode = mode
+  config.output.repairAttempts = 1
+  config.review.automation.close = false
+  config.review.automation.merge = false
+  config.review.checks.wait = false
+  config.review.concurrency.runs = 1
+  config.review.operator = "reviewer-one"
+  config.review.output = join(directory, "runs")
+  config.review.reviewers = REVIEWERS.map((id) => ({
+    account: mode === "single" ? "review-bot" : `${id}-account`,
+    id,
+    model: { id: "test/reviewer" },
+    permissions: "allow",
+  }))
+  config.review.worktree = join(directory, "worktrees")
+
+  return config
+}
+
+export async function createRepository(
+  directory: string,
+): Promise<RepositoryFixture> {
+  const exec = createExec(directory)
+  const file = join(directory, "reviewed.txt")
+
+  await exec("git init --initial-branch=main")
+  await exec("git config user.name 'Magi Test'")
+  await exec("git config user.email 'magi-test@example.com'")
+  await writeFile(file, "base\n")
+  await exec("git add reviewed.txt")
+  await exec("git commit -m 'base'")
+
+  const baseSha = await exec("git rev-parse HEAD")
+
+  await exec("git switch -c feature")
+  await writeFile(file, "base\nfeature\n")
+  await exec("git add reviewed.txt")
+  await exec("git commit -m 'feature'")
+
+  const headSha = await exec("git rev-parse HEAD")
+
+  await exec("git switch main")
+
+  return { baseSha, exec, headSha }
+}
+
+export function createPullRequestMetadata(
+  directory: string,
+  { baseSha, headSha }: RepositoryFixture,
+): PullRequestMetadata {
+  return {
+    base: {
+      ref: "main",
+      repo: { clone_url: directory },
+      sha: baseSha,
+    },
+    changed_files: 1,
+    draft: false,
+    head: {
+      ref: "feature",
+      repo: {
+        clone_url: directory,
+        name: "opencode-magi",
+        owner: { login: "author" },
+      },
+      sha: headSha,
+    },
+    labels: [],
+    node_id: "pull-request-node",
+    state: "open",
+    user: { login: "author" },
+  } as unknown as PullRequestMetadata
+}
+
+export function createGitHubFixture(
+  metadata: PullRequestMetadata,
+  { number, owner, repo }: PullRequestTarget,
+): GitHubFixture {
+  const get = vi.fn().mockResolvedValue({ data: metadata })
+  const listComments = vi.fn()
+  const listCommits = vi.fn()
+  const listFiles = vi.fn()
+  const listReviews = vi.fn()
+  const createReplyForReviewComment = vi.fn()
+  const createReview = vi.fn().mockResolvedValue({
+    data: {
+      html_url: `https://github.com/${owner}/${repo}/pull/${number}#review`,
+    },
+  })
+  const paginate = vi.fn().mockImplementation((request) => {
+    if (request === listFiles)
+      return Promise.resolve([{ filename: "reviewed.txt" }])
+    if (
+      request === listComments ||
+      request === listCommits ||
+      request === listReviews
+    )
+      return Promise.resolve([])
+
+    return Promise.reject(new Error("Unexpected Octokit pagination request."))
+  })
+  const octokit = {
+    paginate,
+    rest: {
+      issues: { listComments },
+      pulls: {
+        createReplyForReviewComment,
+        createReview,
+        get,
+        listCommits,
+        listFiles,
+        listReviews,
+      },
+    },
+  } as unknown as Octokit
+  const closingIssues = vi.fn()
+  const reviewThreads = vi.fn()
+  const resolveReviewThread = vi.fn()
+  const graphqlPaginate = vi.fn().mockImplementation((request) => {
+    if (request === closingIssues)
+      return Promise.resolve({
+        repository: {
+          pullRequest: { closingIssuesReferences: { nodes: [] } },
+        },
+      })
+    if (request === reviewThreads)
+      return Promise.resolve({
+        repository: { pullRequest: { reviewThreads: { nodes: [] } } },
+      })
+
+    return Promise.reject(new Error("Unexpected GraphQL pagination request."))
+  })
+  const graphql = {
+    closingIssues,
+    paginate: graphqlPaginate,
+    resolveReviewThread,
+    reviewThreads,
+  } as unknown as Graphql
+
+  return {
+    createReplyForReviewComment,
+    createReview,
+    get,
+    graphql,
+    graphqlPaginate,
+    octokit,
+    octokitPaginate: paginate,
+    resolveReviewThread,
+  }
+}
+
+export function createPullRequestExec(
+  repository: RepositoryFixture,
+  { number, owner, repo }: PullRequestTarget,
+  ghCommands: string[],
+): Exec {
+  return async function (command, options): Promise<string> {
+    if (!command.startsWith("gh ")) return repository.exec(command, options)
+
+    ghCommands.push(command)
+
+    if (command === `gh pr checkout ${number} --detach`)
+      return repository.exec(
+        `git checkout --detach '${repository.headSha}'`,
+        options,
+      )
+    if (
+      command ===
+      `gh pr checks ${number} --repo '${owner}/${repo}' --json name,state,bucket,link,workflow --required`
+    )
+      return "[]"
+
+    throw new Error(`Unexpected GitHub CLI command: ${command}`)
+  }
+}


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds hermetic end-to-end scenarios for the review and merge commands.

## Current behavior (updates)

Review and merge orchestration is covered by method-level unit tests, but no test executes either command from its tool entry point through persisted state, report generation, and worktree cleanup.

## New behavior

Adds approved baseline scenarios for both `magi:review` and `magi:merge` in single and multi modes with three reviewers and PR #123. The scenarios use a real temporary Git repository and worktree while replacing GitHub and OpenCode boundaries with deterministic fakes. Shared pull-request fixtures are available for future command scenarios.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validated with `pnpm quality` (233 tests) and `pnpm build`. No changeset is required for test-only changes.