### PR TITLE
refactor(config): remove redundant agent checks

### DIFF
--- a/.changeset/tidy-agent-checks.md
+++ b/.changeset/tidy-agent-checks.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Simplify reviewer and voter config validation conditions.

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -44,18 +44,14 @@ function requiredErrors(
     required(github, config.github.repo, "github.repo"),
     required(reviewers, config.review.reviewers, "review.reviewers"),
     ...(config.review.reviewers ?? []).map((reviewer, index) =>
-      required(
-        reviewers || !!reviewer,
-        reviewer.model,
-        `review.reviewers[${index}].model`,
-      ),
+      required(reviewers, reviewer.model, `review.reviewers[${index}].model`),
     ),
     required(editor, config.merge.editor, "merge.editor"),
     required(editor, config.merge.editor?.model, "merge.editor.model"),
     required(editor, config.merge.editor?.author, "merge.editor.author"),
     required(voters, config.triage.voters, "triage.voters"),
     ...(config.triage.voters ?? []).map((voter, index) =>
-      required(voters || !!voter, voter.model, `triage.voters[${index}].model`),
+      required(voters, voter.model, `triage.voters[${index}].model`),
     ),
     required(creator, config.triage.creator, "triage.creator"),
     required(creator, config.triage.creator?.model, "triage.creator.model"),


### PR DESCRIPTION
Closes #429

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Simplify required-model validation for configured reviewers and voters.

## Current behavior (updates)

Validation checks each mapped reviewer and voter for truthiness even though map callbacks only receive existing entries.

## New behavior

Validation conditions now rely only on the corresponding configured-agent requirement flag. No user-facing behavior changes.

## Is this a breaking change (Yes/No):

No

## Additional Information

No documentation update is needed because this is an internal, behavior-preserving refactor.
