### PR TITLE
fix(review): handle merged queue pull requests

### DIFF
--- a/.changeset/handle-merged-queue-pr.md
+++ b/.changeset/handle-merged-queue-pr.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Treat a pull request merged by a concurrent review run as a successful merge queue outcome.

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -404,15 +404,30 @@ export async function automate(this: Review): Promise<PullRequestAutomation> {
     const graphql = this.magi.createGraphql(octokit)
     const enqueuedAt = new Date().toISOString()
 
-    await ignoreError(
-      () =>
-        graphql.enqueuePullRequest({ id: this.state.pr!.metadata!.node_id }),
-      (e) => {
-        const message = e instanceof Error ? e.message : String(e)
+    try {
+      await ignoreError(
+        () =>
+          graphql.enqueuePullRequest({ id: this.state.pr!.metadata!.node_id }),
+        (e) => {
+          const message = e instanceof Error ? e.message : String(e)
 
-        return /pull request is already in the queue/i.test(message)
-      },
-    )
+          return /pull request is already in the queue/i.test(message)
+        },
+      )
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+
+      if (!/pull request is closed/i.test(message)) throw e
+
+      const { repository } = await graphql.mergeQueueStatus({
+        owner: this.config.github.owner,
+        pr: this.number,
+        repo: this.config.github.repo,
+      })
+
+      if (repository?.pullRequest?.state !== "MERGED") throw e
+    }
+
     await this.updateEvent(`Waiting for merge queue.`)
 
     const result = await waitMergeQueue.call(this, enqueuedAt)

--- a/src/tools/review/review.test.ts
+++ b/src/tools/review/review.test.ts
@@ -677,6 +677,47 @@ describe("Review", () => {
       expect(exec).not.toHaveBeenCalled()
       expect(updateState).not.toHaveBeenCalled()
     })
+
+    test("completes when the pull request was merged before queueing", async ({
+      magiFixture: { magi },
+    }) => {
+      const { config, graphqlMocks, octokit, review } =
+        createReviewFixture(magi)
+
+      config.review.automation.merge = true
+      config.review.merge.queue = true
+      review.state.operator = { account: "reviewer-one" }
+      review.state.pr!.checks = createChecks()
+      review.state.pr!.metadata = createMetadata()
+      review.state.pr!.verdict = "APPROVED"
+      graphqlMocks.enqueuePullRequest.mockRejectedValue(
+        new Error("Pull request is closed"),
+      )
+      graphqlMocks.mergeQueueStatus.mockResolvedValue({
+        repository: {
+          pullRequest: {
+            isInMergeQueue: false,
+            mergeQueueEntry: null,
+            state: "MERGED",
+            timelineItems: { nodes: [] },
+          },
+        },
+      })
+      vi.spyOn(magi, "createOctokit").mockResolvedValue(octokit)
+      vi.spyOn(magi, "createGraphql").mockReturnValue(
+        graphqlMocks as unknown as Graphql,
+      )
+
+      await expect(review.automate()).resolves.toBe("MERGED")
+      expect(graphqlMocks.enqueuePullRequest).toHaveBeenCalledWith({
+        id: "pr-node",
+      })
+      expect(graphqlMocks.mergeQueueStatus).toHaveBeenCalledWith({
+        owner: "magi-ai",
+        pr: 42,
+        repo: "opencode-magi",
+      })
+    })
   })
 
   describe("createReport", () => {

--- a/test/fixtures/review.ts
+++ b/test/fixtures/review.ts
@@ -22,6 +22,8 @@ export interface OctokitMocks {
 
 export interface GraphqlMocks {
   closingIssues: ReturnType<typeof vi.fn>
+  enqueuePullRequest: ReturnType<typeof vi.fn>
+  mergeQueueStatus: ReturnType<typeof vi.fn>
   paginate: ReturnType<typeof vi.fn>
   resolveReviewThread: ReturnType<typeof vi.fn>
   reviewThreads: ReturnType<typeof vi.fn>
@@ -158,6 +160,8 @@ export function createReviewFixture<T extends Review>(
   } as unknown as Octokit
   const graphqlMocks: GraphqlMocks = {
     closingIssues: vi.fn(),
+    enqueuePullRequest: vi.fn(),
+    mergeQueueStatus: vi.fn(),
     paginate: vi.fn(),
     resolveReviewThread: vi.fn(),
     reviewThreads: vi.fn(),


### PR DESCRIPTION
Closes #427

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Treat a pull request merged by an overlapping review run as a successful merge queue outcome.

## Current behavior (updates)

A later review run fails when GitHub rejects its merge queue request because another run has already merged the pull request.

## New behavior

When queueing reports a closed pull request, the review verifies its state and completes when it is already merged. Other failures remain errors.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Added a regression test for this race condition.
- Verified with `pnpm quality` and `pnpm build`.
- No documentation update is needed because this changes no user configuration or command interface.