### PR TITLE
test(github): cover primitive retry errors

### DIFF
--- a/src/utils/github.test.ts
+++ b/src/utils/github.test.ts
@@ -65,6 +65,7 @@ describe("createExecWithGitHubApiRetry", () => {
       new Error("rate limit exceeded"),
     ],
     ["a non-rate-limit error", "gh api repos/example", new Error("not found")],
+    ["a primitive error", "gh api repos/example", "not found"],
   ])("propagates %s without retrying", async (_label, command, error) => {
     const exec = vi.fn<Exec>().mockRejectedValue(error)
     const retryingExec = createExecWithGitHubApiRetry(exec, 2)


### PR DESCRIPTION
## AI used

- [x] I checked the generated content before submitting.

## Description

Add coverage for primitive values rejected by the GitHub command retry wrapper.

## Current behavior (updates)

The retry tests cover only object errors, leaving the primitive-error guard branch uncovered.

## New behavior

The test suite verifies that a primitive non-rate-limit rejection is propagated without retrying.

## Is this a breaking change (Yes/No):

No

## Additional Information

`src/utils/github.ts` reaches 100% statement, branch, function, and line coverage.