### PR TITLE
test(merge): cover reachable edit paths

### DIFF
--- a/src/tools/merge/index.e2e.test.ts
+++ b/src/tools/merge/index.e2e.test.ts
@@ -518,6 +518,121 @@ describe("magi:merge", () => {
     )
   })
 
+  test("creates edit-cycle resources after reusing changes-requested reviews", async ({
+    createMagi,
+    temporaryDirectory,
+  }) => {
+    const repository = await createRepository(temporaryDirectory)
+    const config = createPullRequestConfig(temporaryDirectory, "single")
+    const github = createGitHubFixture(
+      createPullRequestMetadata(temporaryDirectory, repository),
+      PULL_REQUEST,
+    )
+    const { client, magi } = createMagi({ directory: temporaryDirectory })
+    const ghCommands: string[] = []
+    const reviewBody = marker.stringify(
+      ...REVIEWERS.map((reviewer) => ({
+        command: "review",
+        reviewer,
+        verdict: "CHANGES_REQUESTED",
+      })),
+    )
+    const threads = REVIEWERS.map((reviewer, index) => ({
+      comments: {
+        nodes: [
+          {
+            author: { login: "review-bot" },
+            body: marker.stringify({
+              command: "review",
+              reviewer,
+              verdict: "CHANGES_REQUESTED",
+            }),
+            createdAt: "2026-07-24T01:00:00.000Z",
+            databaseId: index + 7,
+          },
+        ],
+      },
+      id: `thread-${index + 1}`,
+      isResolved: false,
+      line: index + 1,
+      path: "reviewed.txt",
+    }))
+
+    config.merge.maxThreadResolutionCycles = 1
+    config.review.concurrency.reviewers = 1
+    github.octokitPaginate.mockImplementation((request) => {
+      if (request === github.listFiles)
+        return Promise.resolve([{ filename: "reviewed.txt" }])
+      if (request === github.listComments) return Promise.resolve([])
+      if (request === github.listCommits)
+        return Promise.resolve([
+          {
+            commit: { author: { date: "2026-07-24T00:00:00.000Z" } },
+            parents: [{}],
+          },
+        ])
+      if (request === github.listReviews)
+        return Promise.resolve([
+          {
+            body: reviewBody,
+            commit_id: repository.headSha,
+            html_url:
+              "https://github.com/magi-ai/opencode-magi/pull/123#review",
+            state: "COMMENTED",
+            submitted_at: "2026-07-24T01:00:00.000Z",
+            user: { login: "review-bot" },
+          },
+        ])
+
+      return Promise.reject(new Error("Unexpected Octokit pagination request."))
+    })
+    github.graphqlPaginate.mockImplementation((request) => {
+      if (request === github.closingIssues)
+        return Promise.resolve({
+          repository: {
+            pullRequest: { closingIssuesReferences: { nodes: [] } },
+          },
+        })
+      if (request === github.reviewThreads)
+        return Promise.resolve({
+          repository: { pullRequest: { reviewThreads: { nodes: threads } } },
+        })
+
+      return Promise.reject(new Error("Unexpected GraphQL pagination request."))
+    })
+    magi.exec = createScenarioExec(repository, ghCommands)
+    mockSessions(client)
+    mockPromptOutputs(client, [
+      JSON.stringify({
+        mode: "REPLIED",
+        responses: REVIEWERS.map((_, index) => ({
+          action: "DISAGREE",
+          body: "No code change is needed.",
+          commentId: index + 7,
+        })),
+      }),
+      ...REVIEWERS.map(() => approvedOutput()),
+    ])
+    vi.spyOn(magi, "getConfig").mockResolvedValue(config)
+    mockGitHub(magi, github)
+
+    await expect(executeMerge(magi, createContext())).resolves.toContain(
+      "- **Verdict**: Approved",
+    )
+
+    const { events, state } = await readRun(config)
+
+    expect(client.session.create).toHaveBeenCalledTimes(5)
+    expect(state.worktree?.path).toBeTypeOf("string")
+    expect(github.createReplyForReviewComment).toHaveBeenCalledTimes(3)
+    expect(events.map(({ message }) => message)).toStrictEqual(
+      expect.arrayContaining([
+        "Creating editor session.",
+        "Creating worktree.",
+      ]),
+    )
+  })
+
   test("repairs invalid editor output within the full edit cycle", async ({
     createMagi,
     temporaryDirectory,

--- a/src/tools/merge/merge.test.ts
+++ b/src/tools/merge/merge.test.ts
@@ -14,6 +14,7 @@ import {
   createReviewFixture,
   createState,
 } from "#/fixtures/review"
+import { MagiError } from "@/magi"
 import { Prompt } from "@/prompts"
 import { marker } from "@/utils"
 import { Merge } from "./merge"
@@ -384,6 +385,55 @@ describe("Merge", () => {
         "Editor output not found.",
       )
     })
+
+    test("includes synthetic new findings and editor replies during a dry run", async ({
+      magiFixture: { magi },
+    }) => {
+      const { exec, merge } = createMergeFixture(magi)
+
+      merge.state.dryRun = true
+      merge.state.editor = {
+        outputs: [
+          createEditOutput({
+            responses: [{ action: "FIXED", body: "Fixed.", commentId: -1 }],
+          }),
+        ],
+      }
+      merge.state.reviewers = {
+        one: {
+          outputs: [
+            {
+              newFindings: [
+                {
+                  body: "Finding.",
+                  line: 2,
+                  path: "src/index.ts",
+                  state: "accepted",
+                },
+              ],
+              verdict: "CHANGES_REQUESTED",
+            },
+          ],
+        },
+      }
+      merge.state.pr!.metadata = createMetadata()
+      merge.state.worktree = { path: "/tmp/worktree" }
+      exec.mockResolvedValue("")
+
+      await merge.fetchMergeContext()
+
+      expect(merge.state.pr?.threads).toStrictEqual([
+        expect.objectContaining({
+          comments: [
+            expect.objectContaining({
+              body: expect.stringContaining("Finding."),
+            }),
+            expect.objectContaining({ body: "Fixed." }),
+          ],
+          id: "dry-run:one:1",
+        }),
+      ])
+    })
   })
 
   describe("markRepliedReviewers", () => {
@@ -602,6 +652,77 @@ describe("Merge", () => {
       )
     })
 
+    test("ignores null and resolved review threads", async ({
+      magiFixture: { magi },
+    }) => {
+      const { graphqlMocks, merge } = createMergeFixture(magi)
+
+      merge.state.editor = {
+        author: { email: "editor@example.com", name: "Editor" },
+        sessionId: "editor-session",
+      }
+      merge.state.worktree = { path: "/tmp/worktree" }
+      graphqlMocks.paginate.mockResolvedValue({
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [
+                null,
+                { comments: { nodes: [] }, id: "thread-1", isResolved: true },
+              ],
+            },
+          },
+        },
+      })
+
+      await expect(merge.edit()).rejects.toThrow(
+        "No editable review threads found.",
+      )
+    })
+
+    test("stops retrying when the editor session is blocked", async ({
+      magiFixture: { magi },
+    }) => {
+      const { graphqlMocks, merge, updateEvent } = createMergeFixture(magi)
+      const error = new MagiError("blocked", "Editor requested input.")
+
+      merge.config.output.repairAttempts = 2
+      merge.state.editor = {
+        author: { email: "editor@example.com", name: "Editor" },
+        sessionId: "editor-session",
+      }
+      merge.state.worktree = { path: "/tmp/worktree" }
+      graphqlMocks.paginate.mockResolvedValue({
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [
+                {
+                  comments: { nodes: [{ databaseId: 101 }] },
+                  id: "thread-1",
+                  isResolved: false,
+                },
+              ],
+            },
+          },
+        },
+      })
+      vi.spyOn(Prompt, "init").mockResolvedValue({
+        create: vi.fn().mockResolvedValue("edit-task"),
+      } as unknown as Prompt)
+
+      const promptSession = vi
+        .spyOn(magi, "promptSession")
+        .mockRejectedValue(error)
+
+      await expect(merge.edit()).rejects.toThrow(error)
+      expect(promptSession).toHaveBeenCalledOnce()
+      expect(updateEvent).not.toHaveBeenCalledWith(
+        merge.state.output,
+        "Attempt 1 failed to edit. Retrying...",
+      )
+    })
+
     test("rejects an edited output that does not match worktree HEAD", async ({
       magiFixture: { magi },
     }) => {
@@ -793,12 +914,13 @@ describe("Merge", () => {
       const prompt = {
         create: vi.fn().mockResolvedValue("conflict-task"),
         parse: vi.fn().mockReturnValue({}),
-        repair: vi.fn(),
-        validate: vi.fn().mockReturnValue(true),
+        repair: vi.fn().mockResolvedValue("repaired-conflict-task"),
+        validate: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
       }
 
       let conflictChecks = 0
 
+      merge.config.output.repairAttempts = 2
       merge.state.dryRun = true
       merge.state.editor = {
         author: { email: "editor@example.com", name: "Editor" },
@@ -835,11 +957,49 @@ describe("Merge", () => {
 
       await merge.resolveConflict()
 
+      expect(prompt.repair).toHaveBeenCalledOnce()
       expect(merge.state.pr.metadata?.head.sha).toBe("resolved-sha")
       expect(merge.state.pr.files).toStrictEqual(["README.md", "src/index.ts"])
       expect(updateEvent).toHaveBeenCalledWith(
         merge.state.output,
         "Skipped pushing conflict resolution during dry run.",
+      )
+    })
+
+    test("stops retrying when the conflict editor session is blocked", async ({
+      magiFixture: { magi },
+    }) => {
+      const { exec, merge, updateEvent } = createMergeFixture(magi)
+      const error = new MagiError("blocked", "Editor requested input.")
+
+      merge.config.output.repairAttempts = 2
+      merge.state.editor = {
+        author: { email: "editor@example.com", name: "Editor" },
+        sessionId: "editor-session",
+      }
+      merge.state.pr!.metadata = createMetadata()
+      merge.state.worktree = { path: "/tmp/worktree" }
+      exec.mockImplementation((command) => {
+        if (command.includes("git merge --no-commit"))
+          return Promise.reject(new Error("merge conflict"))
+        if (command.includes("git diff --name-only"))
+          return Promise.resolve("src/index.ts")
+
+        return Promise.resolve("")
+      })
+      vi.spyOn(Prompt, "init").mockResolvedValue({
+        create: vi.fn().mockResolvedValue("conflict-task"),
+      } as unknown as Prompt)
+
+      const promptSession = vi
+        .spyOn(magi, "promptSession")
+        .mockRejectedValue(error)
+
+      await expect(merge.resolveConflict()).rejects.toThrow(error)
+      expect(promptSession).toHaveBeenCalledOnce()
+      expect(updateEvent).not.toHaveBeenCalledWith(
+        merge.state.output,
+        "Attempt 1 failed to resolve conflicts. Retrying...",
       )
     })
   })


### PR DESCRIPTION
## AI used

- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds coverage for reachable merge edit and conflict paths.

## Current behavior (updates)

Reachable editor retry, GraphQL thread, synthetic dry-run, and reused changes-requested review paths were not covered.

## New behavior

Adds unit and end-to-end tests for those paths without changing production source.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- `pnpm quality` passes.
- Targeted coverage verifies `index.ts` statements, lines, and functions at 100%.
- Remaining uncovered statements are the previously identified redundant guards and are intentionally unchanged.