### PR TITLE
fix(config): reject duplicate group accounts

### DIFF
--- a/.changeset/reject-duplicate-group-accounts.md
+++ b/.changeset/reject-duplicate-group-accounts.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Reject duplicate GitHub accounts within reviewer and voter groups.

--- a/docs/config.ja.md
+++ b/docs/config.ja.md
@@ -216,6 +216,8 @@ Magiの設定ファイルは、OpenCodeではなくOpenCode Magiによってマ�
 
 デフォルトでは、シングルモード（`mode: "single"`）です。複数のGitHubアカウントを使用するマルチモードにする場合は、`mode: "multi"`を設定し、各エージェントごとにアカウントを設定します。
 
+`review.reviewers`内と`triage.voters`内では、アカウントを一意にする必要があります。ロール間では同じアカウントを再利用できます。
+
 ```json
 {
   "mode": "multi",

--- a/docs/config.md
+++ b/docs/config.md
@@ -216,6 +216,8 @@ You can set `allow`, `ask`, or `deny`. A string applies to the entire target per
 
 By default, Magi runs in single mode (`mode: "single"`). To use multiple GitHub accounts, set `mode: "multi"` and configure an account for each agent.
 
+Accounts must be unique within `review.reviewers` and `triage.voters`, but may be reused between roles.
+
 ```json
 {
   "mode": "multi",

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -276,6 +276,40 @@ describe("validate", () => {
       ])
     })
 
+    test("reports duplicate reviewer accounts", async () => {
+      const config = createConfig()
+      const exec = vi.fn<Exec>().mockResolvedValue("token")
+
+      config.mode = "multi"
+      config.review.reviewers = [
+        createReviewer("reviewer-1", "shared-account"),
+        createReviewer("reviewer-2", "shared-account"),
+        createReviewer("reviewer-3", "review-account-3"),
+      ]
+
+      await expect(validateConfig(config, { exec })).resolves.toStrictEqual([
+        "review.reviewers has duplicate account: shared-account",
+      ])
+      expect(exec).toHaveBeenCalledTimes(2)
+    })
+
+    test("reports duplicate voter accounts", async () => {
+      const config = createConfig()
+      const exec = vi.fn<Exec>().mockResolvedValue("token")
+
+      config.mode = "multi"
+      config.triage.voters = [
+        createVoter("voter-1", "shared-account"),
+        createVoter("voter-2", "shared-account"),
+        createVoter("voter-3", "voter-account-3"),
+      ]
+
+      await expect(validateConfig(config, { exec })).resolves.toStrictEqual([
+        "triage.voters has duplicate account: shared-account",
+      ])
+      expect(exec).toHaveBeenCalledTimes(2)
+    })
+
     test("reuses accounts across agent roles", async () => {
       const config = createConfig()
       const exec = vi.fn<Exec>().mockResolvedValue("token")

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -161,35 +161,30 @@ async function authErrors(config: Config.Root, exec: Exec): Promise<string[]> {
   if (config.mode === "single") {
     return filterEmpty([await authError(config, exec, config.account!)])
   } else {
-    const accounts = {
-      ...Object.fromEntries(
-        config.review.reviewers?.map(({ account }, index) => [
-          account!,
-          `review.reviewers[${index}]`,
-        ]) ?? [],
-      ),
-      ...Object.fromEntries(
-        config.triage.voters?.map(({ account }, index) => [
-          account!,
-          `triage.voters[${index}]`,
-        ]) ?? [],
-      ),
-    }
-
-    if (config.merge.editor)
-      accounts[config.merge.editor.account!] = "merge.editor"
-    if (config.triage.creator)
-      accounts[config.triage.creator.account!] = "triage.creator"
+    const reviewerAccounts =
+      config.review.reviewers?.map(({ account }) => account!) ?? []
+    const voterAccounts =
+      config.triage.voters?.map(({ account }) => account!) ?? []
+    const accounts = new Set(
+      filterEmpty([
+        ...reviewerAccounts,
+        ...voterAccounts,
+        config.merge.editor?.account,
+        config.triage.creator?.account,
+      ]),
+    )
 
     return filterEmpty([
       ...duplicateErrors(
-        Object.keys(accounts),
-        (value) => `${accounts[value]} has duplicate account: ${value}`,
+        reviewerAccounts,
+        (value) => `review.reviewers has duplicate account: ${value}`,
+      ),
+      ...duplicateErrors(
+        voterAccounts,
+        (value) => `triage.voters has duplicate account: ${value}`,
       ),
       ...(await Promise.all(
-        Object.keys(accounts).map((account) =>
-          authError(config, exec, account),
-        ),
+        [...accounts].map((account) => authError(config, exec, account)),
       )),
     ])
   }


### PR DESCRIPTION
## AI used

- [x] I checked the generated content before submitting.

## Description

Reject duplicate GitHub accounts within reviewer and voter groups while preserving account reuse across roles.

## Current behavior (updates)

Duplicate accounts in a reviewer or voter group are silently collapsed before validation, so the duplicate-account error is unreachable.

## New behavior

Validation reports duplicate accounts within `review.reviewers` and `triage.voters`. Accounts shared by different roles remain valid and are authenticated once.

## Is this a breaking change (Yes/No):

No. Invalid duplicate group configuration is now rejected.

## Additional Information

- `pnpm quality` passed (383 tests).
- `src/config/validate.ts` has 100% targeted coverage.