### PR TITLE
refactor(review): remove unreachable state guards

### DIFF
--- a/.changeset/remove-unreachable-review-guards.md
+++ b/.changeset/remove-unreachable-review-guards.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Remove unreachable review state guards.

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -697,8 +697,6 @@ async function waitMergeQueue(
 
 async function isConflict(this: Review): Promise<boolean> {
   if (!this.state.worktree) return false
-  if (!this.state.pr?.metadata)
-    throw new MagiError("blocked", "PR metadata not found.")
 
   const options = { cwd: this.state.worktree.path, signal: this.context.abort }
   const status = await this.exec(
@@ -714,8 +712,8 @@ async function isConflict(this: Review): Promise<boolean> {
       "git",
       "fetch",
       "--no-tags",
-      quote(this.state.pr.metadata.base.repo.clone_url),
-      quote(`refs/heads/${this.state.pr.metadata.base.ref}`),
+      quote(this.state.pr!.metadata!.base.repo.clone_url),
+      quote(`refs/heads/${this.state.pr!.metadata!.base.ref}`),
     ),
     options,
   )

--- a/src/tools/review/context.ts
+++ b/src/tools/review/context.ts
@@ -96,9 +96,6 @@ export async function checkExistingReviews(this: Review): Promise<boolean> {
   for (const [id, reviewer] of Object.entries(reviewers)) {
     if (reviewer.status !== "skip") continue
 
-    if (!reviewer.review)
-      throw new MagiError("blocked", `No review found for reviewer ${id}.`)
-
     const single = this.config.mode === "single"
     const author = single ? this.config.account : reviewer.account
     const hasUserReply = threads.some(({ comments, isResolved }) => {
@@ -119,15 +116,15 @@ export async function checkExistingReviews(this: Review): Promise<boolean> {
       return (
         !!last &&
         last.author?.login !== author &&
-        (!reviewer.review?.submitted_at ||
-          last.createdAt.localeCompare(reviewer.review.submitted_at) > 0)
+        (!reviewer.review!.submitted_at ||
+          last.createdAt.localeCompare(reviewer.review!.submitted_at) > 0)
       )
     })
 
     if (hasUserReply) {
       reviewer.status = "rereview"
     } else {
-      const verdict = reviewer.review.state as PullRequestVerdict
+      const verdict = reviewer.review!.state as PullRequestVerdict
 
       reviewer.outputs = [...(reviewer.outputs ?? []), { verdict }]
     }
@@ -366,14 +363,11 @@ export async function getInlineCommentTargets(
 }
 
 async function hasCommit(this: Review, sha: string): Promise<boolean> {
-  if (!this.state.worktree)
-    throw new MagiError("blocked", "PR worktree not found.")
-
   try {
     await this.exec(
       command("git", "cat-file", "-e", quote(`${sha}^{commit}`)),
       {
-        cwd: this.state.worktree.path,
+        cwd: this.state.worktree!.path,
         signal: this.context.abort,
       },
     )


### PR DESCRIPTION
## AI used

- [x] I checked the generated content before submitting.

## Description

Remove review state guards that cannot be reached through the review orchestration flow.

## Current behavior (updates)

Review operations retain redundant runtime checks after their callers establish the required state.

## New behavior

The redundant guards are removed and TypeScript non-null assertions document the established state invariants.

## Is this a breaking change (Yes/No):

No

## Additional Information

No documentation update is needed because user-facing behavior and configuration are unchanged. A patch changeset is included.

Verification: `pnpm quality`.