### PR TITLE
refactor(merge): remove redundant state guards

### DIFF
--- a/.changeset/remove-redundant-merge-guards.md
+++ b/.changeset/remove-redundant-merge-guards.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Remove redundant merge state guards.

--- a/src/tools/merge/context.ts
+++ b/src/tools/merge/context.ts
@@ -136,9 +136,7 @@ function addSyntheticReplies(
   this: Merge,
   threads: PullRequestReviewThread[],
 ): PullRequestReviewThread[] {
-  const output = this.state.editor?.outputs?.at(-1)
-
-  if (!output) throw new MagiError("blocked", "Editor output not found.")
+  const output = this.state.editor!.outputs!.at(-1)!
 
   return threads.map((thread) => ({
     ...thread,

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -304,22 +304,15 @@ async function setAccount(this: Merge): Promise<void> {
 async function push(
   this: Merge,
 ): Promise<{ files: string[]; metadata: PullRequestMetadata }> {
-  if (!this.state.editor?.account)
-    throw new MagiError("blocked", "Editor account not found.")
-  if (!this.state.pr?.metadata)
-    throw new MagiError("blocked", "PR metadata not found.")
-  if (!this.state.worktree)
-    throw new MagiError("blocked", "PR worktree not found.")
-
   const token = await this.magi.getGhToken(
-    this.state.editor.account,
+    this.state.editor!.account,
     this.context.abort,
   )
-  const url = `https://${this.config.github.host}/${this.state.pr.metadata.head.repo.owner.login}/${this.state.pr.metadata.head.repo.name}.git`
-  const ref = `HEAD:refs/heads/${this.state.pr.metadata.head.ref}`
+  const url = `https://${this.config.github.host}/${this.state.pr!.metadata!.head.repo.owner.login}/${this.state.pr!.metadata!.head.repo.name}.git`
+  const ref = `HEAD:refs/heads/${this.state.pr!.metadata!.head.ref}`
 
   await this.exec(command("git", "push", quote(url), quote(ref)), {
-    cwd: this.state.worktree.path,
+    cwd: this.state.worktree!.path,
     env: {
       GIT_CONFIG_COUNT: "2",
       GIT_CONFIG_KEY_0: "credential.helper",
@@ -337,10 +330,7 @@ async function push(
 }
 
 async function getConflictedFiles(this: Merge): Promise<string[]> {
-  if (!this.state.worktree)
-    throw new MagiError("blocked", "PR worktree not found.")
-
-  const options = { cwd: this.state.worktree.path, signal: this.context.abort }
+  const options = { cwd: this.state.worktree!.path, signal: this.context.abort }
 
   try {
     await this.exec(


### PR DESCRIPTION
## AI used

- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Removes merge state guards whose prerequisites are already guaranteed by their callers.

## Current behavior (updates)

Private merge helpers repeat checks after the command flow has validated the same state.

## New behavior

The helpers rely on their existing call-site invariants and retain the same command behavior.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- No documentation update is needed because this does not change user-facing behavior, configuration, commands, or output.
- `pnpm quality` passes.
- Targeted coverage reports 100% statements, lines, and functions for `context.ts` and `editor.ts`.