### PR TITLE
feat(config): add conditional automation policies

### DIFF
--- a/.changeset/conditional-automation.md
+++ b/.changeset/conditional-automation.md
@@ -1,5 +1,5 @@
 ---
-"opencode-magi": major
+"opencode-magi": minor
 ---
 
 Add conditional review and merge automation and replace review safety filters.

--- a/.changeset/conditional-automation.md
+++ b/.changeset/conditional-automation.md
@@ -1,5 +1,5 @@
 ---
-"opencode-magi": minor
+"opencode-magi": major
 ---
 
 Add conditional review and merge automation and replace review safety filters.

--- a/.changeset/conditional-automation.md
+++ b/.changeset/conditional-automation.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Add conditional review and merge automation and replace review safety filters.

--- a/schema.json
+++ b/schema.json
@@ -174,21 +174,125 @@
         "variant": { "type": "string" }
       }
     },
+    "safetyFilter": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "exclude": { "type": "array", "items": { "type": "string" } },
+        "include": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "safetyBranchFilter": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "base": { "$ref": "#/$defs/safetyFilter" },
+        "head": { "$ref": "#/$defs/safetyFilter" }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "authors": { "$ref": "#/$defs/safetyFilter" },
+        "branches": { "$ref": "#/$defs/safetyBranchFilter" },
+        "labels": { "$ref": "#/$defs/safetyFilter" },
+        "maxChangedFiles": { "type": "integer", "minimum": 0 },
+        "paths": { "$ref": "#/$defs/safetyFilter" }
+      }
+    },
+    "conditions": {
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "prefixItems": [{ "type": "boolean" }, { "$ref": "#/$defs/safety" }]
+          }
+        }
+      ]
+    },
+    "automationSafety": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "authors": { "$ref": "#/$defs/safetyFilter" },
+        "branches": { "$ref": "#/$defs/safetyBranchFilter" },
+        "labels": { "$ref": "#/$defs/safetyFilter" },
+        "paths": { "$ref": "#/$defs/safetyFilter" }
+      }
+    },
+    "automationConditions": {
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "prefixItems": [
+              { "type": "boolean" },
+              { "$ref": "#/$defs/automationSafety" }
+            ]
+          }
+        }
+      ]
+    },
+    "mergeAutomationConditions": {
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "prefixItems": [
+              { "type": "boolean" },
+              { "$ref": "#/$defs/mergeAutomationSafety" }
+            ]
+          }
+        }
+      ]
+    },
+    "mergeAutomationSafety": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "authors": { "$ref": "#/$defs/safetyFilter" },
+        "branches": { "$ref": "#/$defs/safetyBranchFilter" },
+        "edited": { "type": "boolean" },
+        "labels": { "$ref": "#/$defs/safetyFilter" },
+        "paths": { "$ref": "#/$defs/safetyFilter" }
+      }
+    },
     "automation": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "merge": { "type": "boolean", "default": true },
-        "close": { "type": "boolean" }
+        "merge": { "$ref": "#/$defs/automationConditions", "default": true },
+        "close": { "$ref": "#/$defs/automationConditions", "default": false }
       }
     },
     "mergeAutomation": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "merge": { "type": "boolean", "default": true },
-        "close": { "type": "boolean", "default": false },
-        "conflict": { "type": "boolean", "default": false }
+        "merge": {
+          "$ref": "#/$defs/mergeAutomationConditions",
+          "default": true
+        },
+        "close": {
+          "$ref": "#/$defs/mergeAutomationConditions",
+          "default": false
+        },
+        "conflict": { "$ref": "#/$defs/automationConditions", "default": false }
       }
     },
     "reviewChecks": {
@@ -220,16 +324,6 @@
       "additionalProperties": false,
       "properties": {
         "runs": { "type": "integer", "minimum": 1, "default": 3 }
-      }
-    },
-    "safety": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "allowAuthors": { "type": "array", "items": { "type": "string" } },
-        "blockedPaths": { "type": "array", "items": { "type": "string" } },
-        "maxChangedFiles": { "type": "integer", "minimum": 0 },
-        "requiredLabels": { "type": "array", "items": { "type": "string" } }
       }
     },
     "reviewPrompts": {
@@ -376,7 +470,7 @@
         },
         "prompts": { "$ref": "#/$defs/reviewPrompts" },
         "checks": { "$ref": "#/$defs/reviewChecks" },
-        "safety": { "$ref": "#/$defs/safety" },
+        "safety": { "$ref": "#/$defs/conditions" },
         "automation": { "$ref": "#/$defs/automation" },
         "concurrency": { "$ref": "#/$defs/concurrency" },
         "merge": { "$ref": "#/$defs/reviewMerge" },

--- a/src/config/index.type.ts
+++ b/src/config/index.type.ts
@@ -74,10 +74,39 @@ export interface Reviewer extends Omit<AgentRef, "author" | "id"> {
   ref?: string
 }
 
+export type ReviewConditionFilter =
+  | { exclude: string[]; include: string[] }
+  | { exclude: string[] }
+  | { include: string[] }
+
+export type ReviewConditionBranchFilter =
+  | { base: ReviewConditionFilter; head: ReviewConditionFilter }
+  | { base: ReviewConditionFilter }
+  | { head: ReviewConditionFilter }
+
+export interface ReviewCondition {
+  authors?: ReviewConditionFilter
+  branches?: ReviewConditionBranchFilter
+  labels?: ReviewConditionFilter
+  maxChangedFiles?: number
+  paths?: ReviewConditionFilter
+}
+
+export type ReviewConditions = [boolean, ReviewCondition][] | boolean
+
+export interface ReviewAutomationCondition extends Omit<
+  ReviewCondition,
+  "maxChangedFiles"
+> {}
+
+export type ReviewAutomationConditions =
+  | [boolean, ReviewAutomationCondition][]
+  | boolean
+
 export interface Review {
   automation: {
-    close: boolean
-    merge: boolean
+    close: ReviewAutomationConditions
+    merge: ReviewAutomationConditions
   }
   checks: {
     exclude: string[]
@@ -106,12 +135,7 @@ export interface Review {
     reviewGuidelines?: string
   }
   reviewers?: Reviewer[]
-  safety: {
-    allowAuthors: string[]
-    blockedPaths: string[]
-    maxChangedFiles?: number
-    requiredLabels: string[]
-  }
+  safety: ReviewConditions
   worktree: string
 }
 
@@ -119,11 +143,22 @@ export interface Editor extends Omit<Reviewer, "id"> {
   author?: Author
 }
 
+export interface MergeAutomationCondition extends Omit<
+  ReviewCondition,
+  "maxChangedFiles"
+> {
+  edited?: boolean
+}
+
+export type MergeAutomationConditions =
+  | [boolean, MergeAutomationCondition][]
+  | boolean
+
 export interface Merge {
   automation: {
-    close: boolean
-    conflict: boolean
-    merge: boolean
+    close: MergeAutomationConditions
+    conflict: ReviewAutomationConditions
+    merge: MergeAutomationConditions
   }
   checks: {
     wait: boolean

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -52,6 +52,47 @@ describe("validate", () => {
       expect(exec).not.toHaveBeenCalled()
     })
 
+    test("accepts conditional automation and safety configuration", async () => {
+      const config = createConfig()
+
+      config.review.automation.merge = [
+        [
+          true,
+          {
+            authors: { include: ["dependabot[bot]"] },
+            branches: { base: { include: ["main"] } },
+            labels: { exclude: ["do-not-merge"] },
+            paths: { exclude: [".github/**"] },
+          },
+        ],
+      ]
+      config.merge.automation.close = [[false, { edited: true }]]
+      config.review.safety = [
+        [
+          true,
+          {
+            authors: { exclude: ["untrusted"] },
+            branches: { head: { exclude: ["wip/**"] } },
+            labels: { include: ["ready"] },
+            maxChangedFiles: 10,
+            paths: { include: ["src/**"] },
+          },
+        ],
+      ]
+
+      await expect(validateConfig(config)).resolves.toStrictEqual([])
+    })
+
+    test("accepts merge automation conditions without edited", async () => {
+      const config = createConfig()
+
+      config.merge.automation.merge = [
+        [true, { authors: { include: ["dependabot[bot]"] } }],
+      ]
+
+      await expect(validateConfig(config)).resolves.toStrictEqual([])
+    })
+
     test("allows GitHub fields to be optional", async () => {
       const config = createConfig()
 

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -62,11 +62,7 @@ export const DEFAULT_CONFIG: Config.Root = {
       queue: false,
     },
     output: ".magi/runs/pr",
-    safety: {
-      allowAuthors: [],
-      blockedPaths: [],
-      requiredLabels: [],
-    },
+    safety: [],
     worktree: ".magi/worktrees/pr",
   },
   triage: {

--- a/src/tools/merge/index.e2e.test.ts
+++ b/src/tools/merge/index.e2e.test.ts
@@ -1024,7 +1024,7 @@ describe("magi:merge", () => {
     const { client, magi } = createMagi({ directory: temporaryDirectory })
     const ghCommands: string[] = []
 
-    config.merge.automation.merge = true
+    config.merge.automation.merge = [[true, { edited: false }]]
     config.review.concurrency.reviewers = 1
     magi.exec = createScenarioExec(repository, ghCommands, (command) => {
       if (command.startsWith("gh auth token")) return "token"
@@ -1133,7 +1133,9 @@ describe("magi:merge", () => {
     let diffChecks = 0
     let mergeAttempts = 0
 
-    config.merge.automation.conflict = true
+    config.merge.automation.conflict = [
+      [true, { paths: { exclude: [".github/**"] } }],
+    ]
     config.merge.automation.merge = true
     config.merge.maxThreadResolutionCycles = 1
     config.review.concurrency.reviewers = 1

--- a/src/tools/merge/index.ts
+++ b/src/tools/merge/index.ts
@@ -180,7 +180,7 @@ export const merge: Tool = function (magi) {
 
                 if (
                   automation === "CONFLICT" &&
-                  run.config.merge.automation.conflict
+                  run.isAutomationEnabled(run.config.merge.automation.conflict)
                 ) {
                   await run.editCycles(async (cycle) =>
                     editCycle(run, { conflict: true, cycle }),

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -4,6 +4,7 @@ import type {
   PullRequestReviewParams,
 } from "./index.type"
 import type { Review } from "./review"
+import type { Config } from "@/config"
 import type { ReviewerState } from "@/magi"
 import type { Dict } from "@/utils"
 import { MagiError } from "@/magi"
@@ -13,6 +14,7 @@ import {
   filterEmpty,
   ignoreError,
   isArray,
+  isBoolean,
   isObject,
   isString,
   loop,
@@ -23,6 +25,7 @@ import {
   wait,
   Worker,
 } from "@/utils"
+import { getConditionErrors } from "./check"
 
 const events = {
   APPROVED: "APPROVE",
@@ -312,10 +315,14 @@ export async function automate(this: Review): Promise<PullRequestAutomation> {
 
   if (!["APPROVED", "CLOSED"].includes(this.state.pr.verdict)) return "SKIPPED"
 
-  const automation = this.config[this.state.command].automation
   const action = this.state.pr.verdict === "APPROVED" ? "merge" : "close"
 
-  if (!automation[action]) {
+  if (
+    !isAutomationEnabled.call(
+      this,
+      this.config[this.state.command].automation[action],
+    )
+  ) {
     await this.updateState({ pr: { automation: "SKIPPED" } })
     await this.updateEvent(`Skipped ${action} automation.`)
 
@@ -568,6 +575,32 @@ export async function automate(this: Review): Promise<PullRequestAutomation> {
   await this.updateEvent(`Finished ${action} automation.`)
 
   return action === "merge" ? "MERGED" : "CLOSED"
+}
+
+export function isAutomationEnabled(
+  this: Review,
+  conditions:
+    | Config.MergeAutomationConditions
+    | Config.ReviewAutomationConditions,
+): boolean {
+  if (isBoolean(conditions)) return conditions
+
+  const edited =
+    !this.state.dryRun &&
+    this.state.editor?.outputs?.some(({ commitSha }) => !!commitSha)
+
+  return conditions.every(([expected, condition]) => {
+    const errors = getConditionErrors(
+      condition,
+      this.state.pr!.metadata!,
+      this.state.pr!.files ?? [],
+    )
+    const matches =
+      !errors.length &&
+      (!("edited" in condition) || condition.edited === !!edited)
+
+    return matches === expected
+  })
 }
 
 function hasFailedChecks(checks: unknown): boolean {

--- a/src/tools/review/check.ts
+++ b/src/tools/review/check.ts
@@ -6,12 +6,14 @@ import type {
   PullRequestMetadata,
 } from "./index.type"
 import type { Review } from "./review"
+import type { Config } from "@/config"
 import picomatch from "picomatch"
 import { MagiError } from "@/magi"
 import { Prompt } from "@/prompts"
 import {
   command,
   filterEmpty,
+  isBoolean,
   isNumber,
   omitNullish,
   quote,
@@ -43,6 +45,106 @@ const ci = {
   },
 }
 
+function matchesValues(
+  filter: Config.ReviewConditionFilter | undefined,
+  values: string[],
+): boolean {
+  if (!filter) return true
+  if (
+    "include" in filter &&
+    !values.some((value) => filter.include.includes(value))
+  )
+    return false
+
+  return !(
+    "exclude" in filter &&
+    values.some((value) => filter.exclude.includes(value))
+  )
+}
+
+function matchesPatterns(
+  filter: Config.ReviewConditionFilter | undefined,
+  values: string[],
+): boolean {
+  if (!filter) return true
+
+  if ("include" in filter) {
+    const isIncluded = picomatch(filter.include, { dot: true })
+
+    if (!values.some((value) => isIncluded(value))) return false
+  }
+
+  if ("exclude" in filter) {
+    const isExcluded = picomatch(filter.exclude, { dot: true })
+
+    if (values.some((value) => isExcluded(value))) return false
+  }
+
+  return true
+}
+
+export function getConditionErrors(
+  condition: Config.ReviewCondition,
+  metadata: PullRequestMetadata,
+  files: string[],
+): string[] {
+  const errors: string[] = []
+  const branches = condition.branches
+    ? {
+        base:
+          "base" in condition.branches ? condition.branches.base : undefined,
+        head:
+          "head" in condition.branches ? condition.branches.head : undefined,
+      }
+    : {}
+
+  if (!matchesValues(condition.authors, [metadata.user.login]))
+    errors.push(`Author does not match safety filter: ${metadata.user.login}.`)
+  if (!matchesPatterns(branches.base, [metadata.base.ref]))
+    errors.push(
+      `Base branch does not match safety filter: ${metadata.base.ref}.`,
+    )
+  if (!matchesPatterns(branches.head, [metadata.head.ref]))
+    errors.push(
+      `Head branch does not match safety filter: ${metadata.head.ref}.`,
+    )
+  if (
+    !matchesValues(
+      condition.labels,
+      metadata.labels.map(({ name }) => name),
+    )
+  )
+    errors.push(`Labels do not match safety filter.`)
+  if (!matchesPatterns(condition.paths, files))
+    errors.push(`Paths do not match safety filter.`)
+  if (
+    isNumber(condition.maxChangedFiles) &&
+    metadata.changed_files > condition.maxChangedFiles
+  )
+    errors.push(
+      `Changed files exceed limit: ${metadata.changed_files} > ${condition.maxChangedFiles}.`,
+    )
+
+  return errors
+}
+
+function getSafetyErrors(
+  conditions: Config.ReviewConditions,
+  metadata: PullRequestMetadata,
+  files: string[],
+): string[] {
+  if (isBoolean(conditions)) return conditions ? [] : ["Safety is disabled."]
+
+  return conditions.flatMap(([expected, condition], index) => {
+    const errors = getConditionErrors(condition, metadata, files)
+
+    if (!errors.length === expected) return []
+    if (expected) return errors
+
+    return [`Safety condition ${index + 1} unexpectedly matched.`]
+  })
+}
+
 export async function checkPr(this: Review): Promise<void> {
   this.context.abort.throwIfAborted()
 
@@ -55,39 +157,7 @@ export async function checkPr(this: Review): Promise<void> {
     throw new MagiError("blocked", `PR is not open.`)
   if (metadata.draft) throw new MagiError("blocked", `PR is a draft.`)
 
-  const errors: string[] = []
-
-  if (this.config.review.safety.allowAuthors.length)
-    if (!this.config.review.safety.allowAuthors.includes(metadata.user.login))
-      errors.push(`Author is not allowed: ${metadata.user.login}.`)
-
-  if (this.config.review.safety.requiredLabels.length) {
-    const missingLabels = this.config.review.safety.requiredLabels.filter(
-      (label) =>
-        !metadata.labels.some(({ name }: { name: string }) => name === label),
-    )
-
-    if (missingLabels.length)
-      errors.push(`Required labels missing: ${missingLabels.join(", ")}.`)
-  }
-
-  if (
-    isNumber(this.config.review.safety.maxChangedFiles) &&
-    metadata.changed_files > this.config.review.safety.maxChangedFiles
-  )
-    errors.push(
-      `Changed files exceed limit: ${metadata.changed_files} > ${this.config.review.safety.maxChangedFiles}.`,
-    )
-
-  if (this.config.review.safety.blockedPaths.length) {
-    const isBlocked = picomatch(this.config.review.safety.blockedPaths, {
-      dot: true,
-    })
-    const blocked = files.filter((file) => isBlocked(file))
-
-    if (blocked.length)
-      errors.push(`Blocked paths changed: ${blocked.join(", ")}.`)
-  }
+  const errors = getSafetyErrors(this.config.review.safety, metadata, files)
 
   if (errors.length)
     throw new MagiError("blocked", `PR is safety blocked. ${errors.join(" ")}`)

--- a/src/tools/review/index.e2e.test.ts
+++ b/src/tools/review/index.e2e.test.ts
@@ -328,10 +328,17 @@ describe("magi:review", () => {
     const { client, magi } = createMagi({ directory: temporaryDirectory })
     const ghCommands: string[] = []
 
-    config.review.safety.allowAuthors = ["trusted-author"]
-    config.review.safety.blockedPaths = ["reviewed.txt"]
-    config.review.safety.maxChangedFiles = 0
-    config.review.safety.requiredLabels = ["ready"]
+    config.review.safety = [
+      [
+        true,
+        {
+          authors: { include: ["trusted-author"] },
+          labels: { include: ["ready"] },
+          maxChangedFiles: 0,
+          paths: { exclude: ["reviewed.txt"] },
+        },
+      ],
+    ]
     magi.exec = createReviewExec(repository, ghCommands)
     vi.spyOn(magi, "getConfig").mockResolvedValue(config)
     mockGitHub(magi, github)
@@ -343,10 +350,10 @@ describe("magi:review", () => {
     const { report, state } = await readRun(config)
 
     expect(state.status).toBe("blocked")
-    expect(report).toContain("Author is not allowed: author.")
-    expect(report).toContain("Required labels missing: ready.")
+    expect(report).toContain("Author does not match safety filter: author.")
+    expect(report).toContain("Labels do not match safety filter.")
     expect(report).toContain("Changed files exceed limit: 1 > 0.")
-    expect(report).toContain("Blocked paths changed: reviewed.txt.")
+    expect(report).toContain("Paths do not match safety filter.")
     expect(client.session.create).not.toHaveBeenCalled()
     expect(github.createReview).not.toHaveBeenCalled()
     expect(ghCommands).toStrictEqual([])

--- a/src/tools/review/review.test.ts
+++ b/src/tools/review/review.test.ts
@@ -488,17 +488,24 @@ describe("Review", () => {
       metadata.changed_files = 2
       metadata.labels = []
       metadata.user.login = "untrusted"
-      config.review.safety.allowAuthors = ["trusted"]
-      config.review.safety.blockedPaths = ["secrets/**"]
-      config.review.safety.maxChangedFiles = 1
-      config.review.safety.requiredLabels = ["reviewable"]
+      config.review.safety = [
+        [
+          true,
+          {
+            authors: { include: ["trusted"] },
+            labels: { include: ["reviewable"] },
+            maxChangedFiles: 1,
+            paths: { exclude: ["secrets/**"] },
+          },
+        ],
+      ]
       octokitMocks.get.mockResolvedValue({ data: metadata })
       octokitMocks.paginate.mockResolvedValue([
         { filename: "secrets/token.txt" },
       ])
 
       await expect(review.checkPr()).rejects.toThrow(
-        "PR is safety blocked. Author is not allowed: untrusted. Required labels missing: reviewable. Changed files exceed limit: 2 > 1. Blocked paths changed: secrets/token.txt.",
+        "PR is safety blocked. Author does not match safety filter: untrusted. Labels do not match safety filter. Paths do not match safety filter. Changed files exceed limit: 2 > 1.",
       )
     })
 
@@ -508,13 +515,43 @@ describe("Review", () => {
       const { config, octokitMocks, review } = createReviewFixture(magi)
       const metadata = createMetadata()
 
-      config.review.safety.requiredLabels = ["reviewable"]
+      config.review.safety = [[true, { labels: { include: ["reviewable"] } }]]
       metadata.labels = [{ name: "unrelated" }] as typeof metadata.labels
       octokitMocks.get.mockResolvedValue({ data: metadata })
 
       await expect(review.checkPr()).rejects.toThrow(
-        "Required labels missing: reviewable.",
+        "Labels do not match safety filter.",
       )
+    })
+
+    test("accepts pull requests that match every safety filter", async ({
+      magiFixture: { magi },
+    }) => {
+      const { config, octokitMocks, review } = createReviewFixture(magi)
+      const metadata = createMetadata()
+
+      metadata.base.ref = "main"
+      metadata.head.ref = "feature/automation"
+      metadata.labels = [{ name: "ready" }] as typeof metadata.labels
+      metadata.user.login = "trusted"
+      config.review.safety = [
+        [
+          true,
+          {
+            authors: { exclude: ["untrusted"], include: ["trusted"] },
+            branches: {
+              base: { exclude: ["legacy/**"], include: ["main"] },
+              head: { exclude: ["wip/**"], include: ["feature/**"] },
+            },
+            labels: { exclude: ["do-not-review"], include: ["ready"] },
+            paths: { exclude: ["src/generated/**"], include: ["src/**"] },
+          },
+        ],
+      ]
+      octokitMocks.get.mockResolvedValue({ data: metadata })
+      octokitMocks.paginate.mockResolvedValue([{ filename: "src/index.ts" }])
+
+      await expect(review.checkPr()).resolves.toBeUndefined()
     })
 
     test("blocks a multi-mode reviewer that authored the pull request", async ({
@@ -2476,6 +2513,84 @@ describe("Review", () => {
 
       await expect(review.automate()).resolves.toBe("SKIPPED")
       expect(review.state.pr.automation).toBe("SKIPPED")
+      expect(exec).not.toHaveBeenCalled()
+    })
+
+    test("skips automation when a condition fails", async ({
+      magiFixture: { magi },
+    }) => {
+      const { config, exec, review } = createReviewFixture(magi)
+      const metadata = createMetadata()
+
+      metadata.labels = [{ name: "do-not-merge" }] as typeof metadata.labels
+      config.review.automation.merge = [
+        [true, { authors: { include: [metadata.user.login] } }],
+        [false, { labels: { include: ["do-not-merge"] } }],
+      ]
+      review.state.operator = { account: "review-bot" }
+      review.state.pr = {
+        ...review.state.pr!,
+        checks: createChecks(),
+        metadata,
+        verdict: "APPROVED",
+      }
+
+      await expect(review.automate()).resolves.toBe("SKIPPED")
+      expect(exec).not.toHaveBeenCalled()
+    })
+
+    test("enables automation when a condition does not match", async ({
+      magiFixture: { magi },
+    }) => {
+      const { config, exec, review } = createReviewFixture(magi)
+      const metadata = createMetadata()
+
+      config.review.automation.merge = [
+        [true, { authors: { include: [metadata.user.login] } }],
+        [false, { authors: { include: ["blocked-author"] } }],
+      ]
+      config.review.merge.auto = false
+      review.state.operator = { account: "review-bot" }
+      review.state.pr = {
+        ...review.state.pr!,
+        checks: createChecks(),
+        metadata,
+        verdict: "APPROVED",
+      }
+      vi.spyOn(magi, "getGhToken").mockResolvedValue("token")
+      exec.mockImplementation((command) =>
+        Promise.resolve(command.includes("gh api") ? "[]" : ""),
+      )
+
+      await expect(review.automate()).resolves.toBe("MERGED")
+    })
+
+    test("skips merge automation after an editor commit when configured", async ({
+      magiFixture: { magi },
+    }) => {
+      const { config, exec, review } = createReviewFixture(magi)
+
+      config.merge.automation.merge = [[true, { edited: false }]]
+      review.state.command = "merge"
+      review.state.editor = {
+        outputs: [
+          {
+            commitSha: "editor-commit",
+            filesTouched: ["src/index.ts"],
+            mode: "EDITED",
+            responses: [],
+          },
+        ],
+      }
+      review.state.operator = { account: "review-bot" }
+      review.state.pr = {
+        ...review.state.pr!,
+        checks: createChecks(),
+        metadata: createMetadata(),
+        verdict: "APPROVED",
+      }
+
+      await expect(review.automate()).resolves.toBe("SKIPPED")
       expect(exec).not.toHaveBeenCalled()
     })
 

--- a/src/tools/review/review.ts
+++ b/src/tools/review/review.ts
@@ -8,7 +8,7 @@ import type { DeepPartial, Exec } from "@/utils"
 import { join } from "node:path"
 import { MagiError } from "@/magi"
 import { createExecWithGitHubApiRetry, quote } from "@/utils"
-import { automate, postReviews } from "./action"
+import { automate, isAutomationEnabled, postReviews } from "./action"
 import { checkCi, checkPr, classifyChecks, rerunChecks } from "./check"
 import { checkExistingReviews, fetchReviewContext } from "./context"
 import { createReport } from "./report"
@@ -128,6 +128,7 @@ export class Review {
   public validateFindings = validateFindings
   public reconsiderClose = reconsiderClose
   public postReviews = postReviews
+  public isAutomationEnabled = isAutomationEnabled
   public automate = automate
   public createReport = createReport
 


### PR DESCRIPTION
Closes #438

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add conditional policies for review safety and review/merge automation.

## Current behavior (updates)

Review safety accepts a single object with fixed allow/block lists, and automation accepts only booleans.

## New behavior

`review.safety` and automation actions accept either a boolean or an AND-combined list of `[expected, condition]` pairs. Conditions support authors, branches, labels, paths, and editor commit status where applicable.

## Is this a breaking change (Yes/No):

Yes. Replace the previous `review.safety.allowAuthors`, `blockedPaths`, and `requiredLabels` fields with a boolean or a list of `[expected, condition]` pairs.

## Additional Information

Configuration documentation changes are intentionally deferred.
