### PR TITLE
fix(merge): preserve editor push identity

### DIFF
--- a/.changeset/clear-editor-push-headers.md
+++ b/.changeset/clear-editor-push-headers.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Use the configured editor credentials when pushing changes from GitHub Actions.

--- a/src/tools/merge/editor.ts
+++ b/src/tools/merge/editor.ts
@@ -314,12 +314,14 @@ async function push(
   await this.exec(command("git", "push", quote(url), quote(ref)), {
     cwd: this.state.worktree!.path,
     env: {
-      GIT_CONFIG_COUNT: "2",
+      GIT_CONFIG_COUNT: "3",
       GIT_CONFIG_KEY_0: "credential.helper",
       GIT_CONFIG_KEY_1: "credential.helper",
+      GIT_CONFIG_KEY_2: `http.https://${this.config.github.host}/.extraheader`,
       GIT_CONFIG_VALUE_0: "",
       GIT_CONFIG_VALUE_1:
         "!f() { echo username=git; echo password=$GIT_PASSWORD; }; f",
+      GIT_CONFIG_VALUE_2: "",
       GIT_PASSWORD: token,
       GIT_TERMINAL_PROMPT: "0",
     },

--- a/src/tools/merge/index.e2e.test.ts
+++ b/src/tools/merge/index.e2e.test.ts
@@ -796,7 +796,7 @@ describe("magi:merge", () => {
     )
     const { client, magi } = createMagi({ directory: temporaryDirectory })
     const ghCommands: string[] = []
-    const pushed: string[] = []
+    const pushed: { command: string; env?: { [key: string]: string } }[] = []
     const editorOutput = JSON.stringify({
       commitMessage: "fix review findings",
       commitSha: "edited-sha",
@@ -830,7 +830,7 @@ describe("magi:merge", () => {
           return "edited-sha"
 
         if (command.startsWith("git push ")) {
-          pushed.push(command)
+          pushed.push({ command, env: options?.env })
 
           return ""
         }
@@ -863,7 +863,15 @@ describe("magi:merge", () => {
     expect(state.reviewers?.["reviewer-two"]?.outputs).toHaveLength(2)
     expect(state.reviewers?.["reviewer-three"]?.outputs).toHaveLength(2)
     expect(pushed).toStrictEqual([
-      "git push 'https://github.com/author/opencode-magi.git' 'HEAD:refs/heads/feature'",
+      {
+        command:
+          "git push 'https://github.com/author/opencode-magi.git' 'HEAD:refs/heads/feature'",
+        env: expect.objectContaining({
+          GIT_CONFIG_COUNT: "3",
+          GIT_CONFIG_KEY_2: "http.https://github.com/.extraheader",
+          GIT_CONFIG_VALUE_2: "",
+        }),
+      },
     ])
     expect(
       events.filter(({ message }) => message === "Checking CI."),


### PR DESCRIPTION
Closes #442

## AI used

- [x] I checked the generated content before submitting.

## Description

Ensures editor pushes from the Merge workflow use the configured editor credentials.

## Current behavior (updates)

`actions/checkout` persists a GitHub Actions authorization header in nested worktrees, causing editor pushes to be attributed to `github-actions[bot]` and requiring workflow approval.

## New behavior

The editor push clears the persisted HTTP extra header before supplying its configured credential helper.

## Is this a breaking change (Yes/No):

No

## Additional Information

- No documentation update: this is an internal credential-selection fix with no user-facing configuration or command changes.
- `pnpm quality` passes.