### PR TITLE
feat(config): add author association role filters

### DIFF
--- a/.changeset/fresh-roles-filter.md
+++ b/.changeset/fresh-roles-filter.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": minor
+---
+
+Add pull request author association filters to review conditions.

--- a/schema.json
+++ b/schema.json
@@ -192,6 +192,45 @@
         "head": { "$ref": "#/$defs/safetyFilter" }
       }
     },
+    "roleFilter": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "COLLABORATOR",
+              "CONTRIBUTOR",
+              "FIRST_TIME_CONTRIBUTOR",
+              "FIRST_TIMER",
+              "MANNEQUIN",
+              "MEMBER",
+              "NONE",
+              "OWNER"
+            ]
+          }
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "COLLABORATOR",
+              "CONTRIBUTOR",
+              "FIRST_TIME_CONTRIBUTOR",
+              "FIRST_TIMER",
+              "MANNEQUIN",
+              "MEMBER",
+              "NONE",
+              "OWNER"
+            ]
+          }
+        }
+      }
+    },
     "safety": {
       "type": "object",
       "additionalProperties": false,
@@ -200,7 +239,8 @@
         "branches": { "$ref": "#/$defs/safetyBranchFilter" },
         "labels": { "$ref": "#/$defs/safetyFilter" },
         "maxChangedFiles": { "type": "integer", "minimum": 0 },
-        "paths": { "$ref": "#/$defs/safetyFilter" }
+        "paths": { "$ref": "#/$defs/safetyFilter" },
+        "roles": { "$ref": "#/$defs/roleFilter" }
       }
     },
     "conditions": {
@@ -224,7 +264,8 @@
         "authors": { "$ref": "#/$defs/safetyFilter" },
         "branches": { "$ref": "#/$defs/safetyBranchFilter" },
         "labels": { "$ref": "#/$defs/safetyFilter" },
-        "paths": { "$ref": "#/$defs/safetyFilter" }
+        "paths": { "$ref": "#/$defs/safetyFilter" },
+        "roles": { "$ref": "#/$defs/roleFilter" }
       }
     },
     "automationConditions": {
@@ -269,7 +310,8 @@
         "branches": { "$ref": "#/$defs/safetyBranchFilter" },
         "edited": { "type": "boolean" },
         "labels": { "$ref": "#/$defs/safetyFilter" },
-        "paths": { "$ref": "#/$defs/safetyFilter" }
+        "paths": { "$ref": "#/$defs/safetyFilter" },
+        "roles": { "$ref": "#/$defs/roleFilter" }
       }
     },
     "automation": {

--- a/src/config/index.type.ts
+++ b/src/config/index.type.ts
@@ -79,6 +79,21 @@ export type ReviewConditionFilter =
   | { exclude: string[] }
   | { include: string[] }
 
+export type ReviewConditionRole =
+  | "COLLABORATOR"
+  | "CONTRIBUTOR"
+  | "FIRST_TIME_CONTRIBUTOR"
+  | "FIRST_TIMER"
+  | "MANNEQUIN"
+  | "MEMBER"
+  | "NONE"
+  | "OWNER"
+
+export type ReviewConditionRoleFilter =
+  | { exclude: ReviewConditionRole[]; include: ReviewConditionRole[] }
+  | { exclude: ReviewConditionRole[] }
+  | { include: ReviewConditionRole[] }
+
 export type ReviewConditionBranchFilter =
   | { base: ReviewConditionFilter; head: ReviewConditionFilter }
   | { base: ReviewConditionFilter }
@@ -90,6 +105,7 @@ export interface ReviewCondition {
   labels?: ReviewConditionFilter
   maxChangedFiles?: number
   paths?: ReviewConditionFilter
+  roles?: ReviewConditionRoleFilter
 }
 
 export type ReviewConditions = [boolean, ReviewCondition][] | boolean

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -63,10 +63,13 @@ describe("validate", () => {
             branches: { base: { include: ["main"] } },
             labels: { exclude: ["do-not-merge"] },
             paths: { exclude: [".github/**"] },
+            roles: { include: ["MEMBER"] },
           },
         ],
       ]
-      config.merge.automation.close = [[false, { edited: true }]]
+      config.merge.automation.close = [
+        [false, { edited: true, roles: { include: ["COLLABORATOR"] } }],
+      ]
       config.review.safety = [
         [
           true,
@@ -76,6 +79,7 @@ describe("validate", () => {
             labels: { include: ["ready"] },
             maxChangedFiles: 10,
             paths: { include: ["src/**"] },
+            roles: { exclude: ["NONE"] },
           },
         ],
       ]

--- a/src/tools/review/check.ts
+++ b/src/tools/review/check.ts
@@ -100,6 +100,10 @@ export function getConditionErrors(
 
   if (!matchesValues(condition.authors, [metadata.user.login]))
     errors.push(`Author does not match safety filter: ${metadata.user.login}.`)
+  if (!matchesValues(condition.roles, [metadata.author_association]))
+    errors.push(
+      `Role does not match safety filter: ${metadata.author_association}.`,
+    )
   if (!matchesPatterns(branches.base, [metadata.base.ref]))
     errors.push(
       `Base branch does not match safety filter: ${metadata.base.ref}.`,

--- a/src/tools/review/review.test.ts
+++ b/src/tools/review/review.test.ts
@@ -524,6 +524,20 @@ describe("Review", () => {
       )
     })
 
+    test("blocks pull requests with unmatched author roles", async ({
+      magiFixture: { magi },
+    }) => {
+      const { config, octokitMocks, review } = createReviewFixture(magi)
+      const metadata = createMetadata()
+
+      config.review.safety = [[true, { roles: { include: ["MEMBER"] } }]]
+      octokitMocks.get.mockResolvedValue({ data: metadata })
+
+      await expect(review.checkPr()).rejects.toThrow(
+        "PR is safety blocked. Role does not match safety filter: NONE.",
+      )
+    })
+
     test("accepts pull requests that match every safety filter", async ({
       magiFixture: { magi },
     }) => {
@@ -534,6 +548,7 @@ describe("Review", () => {
       metadata.head.ref = "feature/automation"
       metadata.labels = [{ name: "ready" }] as typeof metadata.labels
       metadata.user.login = "trusted"
+      metadata.author_association = "MEMBER"
       config.review.safety = [
         [
           true,
@@ -545,6 +560,7 @@ describe("Review", () => {
             },
             labels: { exclude: ["do-not-review"], include: ["ready"] },
             paths: { exclude: ["src/generated/**"], include: ["src/**"] },
+            roles: { exclude: ["NONE"], include: ["MEMBER"] },
           },
         ],
       ]

--- a/test/fixtures/review.ts
+++ b/test/fixtures/review.ts
@@ -52,6 +52,7 @@ export interface ReviewFixture<T extends Review> {
 
 export function createMetadata(): PullRequestMetadata {
   return {
+    author_association: "NONE",
     base: {
       ref: "main",
       repo: { clone_url: "https://github.com/magi-ai/opencode-magi.git" },


### PR DESCRIPTION
Closes #444

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add pull request author association filters to review conditions.

## Current behavior (updates)

Safety and automation conditions can filter by author login but cannot match the pull request author's GitHub author association.

## New behavior

`roles` accepts include and exclude filters for GitHub `author_association` values in review safety, review automation, and merge automation conditions. The existing pull request metadata is used, so no additional GitHub API request is made.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- The schema restricts role values to GitHub's supported `author_association` values.
- Documentation was intentionally not changed at the request of the user.
- Verified with `pnpm quality` and `pnpm build`.
