### PR TITLE
fix(review): retry timed out merge queue checks

### DIFF
--- a/.changeset/retry-merge-queue-timeouts.md
+++ b/.changeset/retry-merge-queue-timeouts.md
@@ -1,0 +1,5 @@
+---
+"opencode-magi": patch
+---
+
+Retry pull requests removed from the merge queue after checks time out.

--- a/src/tools/review/action.ts
+++ b/src/tools/review/action.ts
@@ -685,7 +685,8 @@ async function waitMergeQueue(
     const removedFromQueue = timelineItems.nodes?.at(-1)
 
     if (
-      removedFromQueue?.reason === "failed_checks" &&
+      (removedFromQueue?.reason === "checks_timed_out" ||
+        removedFromQueue?.reason === "failed_checks") &&
       Date.parse(removedFromQueue.createdAt) >= Date.parse(enqueuedAt)
     ) {
       if (retries >= this.config.review.checks.retryFailedJobs)

--- a/src/tools/review/review.test.ts
+++ b/src/tools/review/review.test.ts
@@ -2,6 +2,7 @@ import type { ToolContext } from "@opencode-ai/plugin"
 import type { Octokit } from "octokit"
 import type { PullRequestReview, PullRequestReviewThread } from "."
 import type { Graphql } from "@/graphql"
+import type { Magi } from "@/magi"
 import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { test } from "#/fixtures/magi"
@@ -2871,7 +2872,10 @@ describe("Review", () => {
       expect(review.state.pr.automation).toBe("CONFLICT")
     })
 
-    test("re-enqueues after failed merge-queue checks", async ({ magi }) => {
+    async function reenqueueAfterMergeQueueRemoval(
+      magi: Magi,
+      reason: "checks_timed_out" | "failed_checks",
+    ): Promise<void> {
       const { config, graphqlMocks, review, updateEvent } =
         createReviewFixture(magi)
       const enqueuePullRequest = vi
@@ -2909,7 +2913,7 @@ describe("Review", () => {
                 nodes: [
                   {
                     createdAt: "2026-07-23T01:00:00.000Z",
-                    reason: "failed_checks",
+                    reason,
                   },
                 ],
               },
@@ -2954,6 +2958,14 @@ describe("Review", () => {
         review.state.output,
         "Attempt 1 failed to merge from the merge queue. Retrying...",
       )
+    }
+
+    test("re-enqueues after failed merge-queue checks", async ({ magi }) => {
+      await reenqueueAfterMergeQueueRemoval(magi, "failed_checks")
+    })
+
+    test("re-enqueues after timed out merge-queue checks", async ({ magi }) => {
+      await reenqueueAfterMergeQueueRemoval(magi, "checks_timed_out")
     })
 
     test("blocks when the merge queue status is unavailable", async ({


### PR DESCRIPTION
Closes #447

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Retry merge-queue entries that GitHub removes after required checks time out.

## Current behavior (updates)

Only entries removed with `failed_checks` are re-enqueued. Entries removed with `checks_timed_out` end the review as blocked.

## New behavior

`checks_timed_out` uses the existing re-enqueue flow and `retryFailedJobs` limit. The regression test covers both retryable removal reasons.

## Is this a breaking change (Yes/No):

No

## Additional Information

- No documentation update is needed because this changes neither configuration nor commands.
- Verified with `pnpm test`, `pnpm build`, targeted coverage, format, lint, and type checks.
